### PR TITLE
Custom error handling

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,6 +1,6 @@
 .PHONY = all build format tests dump
 
-all: tests build
+all: format tests build
 
 build:
 	./manage.py collectstatic --clear --no-input --verbosity=0

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -11,3 +11,6 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/v1/", include((router.urls, "hitas"))),
 ]
+
+handler404 = "hitas.error_handlers.handle_404"
+handler500 = "hitas.error_handlers.handle_500"

--- a/backend/hitas/error_handlers.py
+++ b/backend/hitas/error_handlers.py
@@ -1,0 +1,9 @@
+from hitas.exceptions import GenericNotFound, InternalServerError
+
+
+def handle_404(request, exception=None) -> GenericNotFound:
+    return GenericNotFound()
+
+
+def handle_500(request) -> InternalServerError:
+    return InternalServerError()

--- a/backend/hitas/exceptions.py
+++ b/backend/hitas/exceptions.py
@@ -1,4 +1,9 @@
+from typing import Any, Dict, List, Union
+
+from django.http.response import JsonResponse
+from rest_framework import exceptions
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 from rest_framework.views import exception_handler as drf_exc_handler
 from rest_framework.views import set_rollback
 
@@ -6,8 +11,28 @@ from rest_framework.views import set_rollback
 def exception_handler(exc, context):
     if isinstance(exc, HitasException):
         set_rollback()
-        return Response(exc.data, status=exc.status_code)
+        return exc.to_response()
     else:
+        if isinstance(exc, exceptions.ValidationError):
+            fields = []
+
+            for field_name, error in exc.get_full_details().items():
+                fields.extend(_convert_fields(field_name, error))
+
+            return BadRequestException(fields).to_response()
+
+        if isinstance(exc, exceptions.MethodNotAllowed):
+            return MethodNotAllowed().to_response()
+
+        if isinstance(exc, exceptions.UnsupportedMediaType):
+            return UnsupportedMediaType().to_response()
+
+        if isinstance(exc, exceptions.NotAcceptable):
+            return NotAcceptable().to_response()
+
+        if isinstance(exc, exceptions.ParseError):
+            return BadRequestException().to_response()
+
         return drf_exc_handler(exc, context)
 
 
@@ -15,6 +40,90 @@ class HitasException(Exception):
     def __init__(self, status_code, data):
         self.status_code = status_code
         self.data = data
+
+    def to_response(self) -> Response:
+        return Response(self.data, status=self.status_code)
+
+
+class GenericNotFound(JsonResponse):
+    def __init__(self):
+        super().__init__(
+            status=404,
+            data={
+                "status": 404,
+                "reason": "Not Found",
+                "message": "Resource not found",
+                "error": "not_found",
+            },
+        )
+
+
+class InternalServerError(JsonResponse):
+    def __init__(self):
+        super().__init__(
+            status=500,
+            data={
+                "status": 500,
+                "reason": "Internal Server Error",
+                "message": "Internal server error. Please try again.",
+                "error": "internal_server_error",
+            },
+        )
+
+
+class UnsupportedMediaType(HitasException):
+    def __init__(self):
+        super().__init__(
+            status_code=415,
+            data={
+                "status": 415,
+                "reason": "Unsupported Media Type",
+                "message": "Unsupported media type",
+                "error": "unsupported_media_type",
+            },
+        )
+
+
+class NotAcceptable(HitasException):
+    def __init__(self):
+        super().__init__(
+            status_code=406,
+            data={
+                "status": 406,
+                "reason": "Not Acceptable",
+                "message": "Not acceptable",
+                "error": "not_acceptable",
+            },
+        )
+
+
+class MethodNotAllowed(HitasException):
+    def __init__(self):
+        super().__init__(
+            status_code=405,
+            data={
+                "status": 405,
+                "reason": "Method Not Allowed",
+                "message": "Method not allowed",
+                "error": "method_not_allowed",
+            },
+        )
+
+
+class BadRequestException(HitasException):
+    def __init__(self, fields=None):
+        super().__init__(
+            status_code=400,
+            data={
+                "status": 400,
+                "reason": "Bad Request",
+                "message": "Bad request",
+                "error": "bad_request",
+            },
+        )
+
+        if fields is not None:
+            self.data["fields"] = fields
 
 
 class HousingCompanyNotFound(HitasException):
@@ -42,3 +151,32 @@ class InvalidPage(HitasException):
                 "fields": [{"field": "page_number", "message": "Page number must be a positive integer."}],
             },
         )
+
+
+def _convert_fields(field_name: str, error: Union[Dict[str, Any], List[Dict[str, Any]]]):
+    if isinstance(error, list):
+        return _convert_field_errors(field_name, error)
+    elif isinstance(error, dict):
+        retval = []
+
+        for subfield_name, suberror in error.items():
+            if subfield_name == api_settings.NON_FIELD_ERRORS_KEY:
+                retval.extend(_convert_field_errors(field_name, suberror))
+            else:
+                retval.extend(_convert_fields(f"{field_name}.{subfield_name}", suberror))
+
+        return retval
+
+
+def _convert_field_errors(field_name: str, errors: List[Dict[str, Any]]):
+    retval = []
+
+    for error in errors:
+        if error["code"] in ["required", "null", "blank"]:
+            retval.append({"field": field_name, "message": "This field is mandatory and cannot be blank."})
+        elif error["code"] in ["invalid"]:
+            retval.append({"field": field_name, "message": error["message"]})
+        else:
+            raise Exception(f"Unhandled error code '{error['code']}'.")
+
+    return retval

--- a/backend/hitas/models/housing_company.py
+++ b/backend/hitas/models/housing_company.py
@@ -19,7 +19,7 @@ def validate_business_id(value: str) -> None:
 
     if match is None:
         raise ValidationError(
-            _("%(value)s is not an valid business id"),
+            _("'%(value)s' is not a valid business id."),
             params={"value": value},
         )
 

--- a/backend/hitas/tests/apis/test_errors.py
+++ b/backend/hitas/tests/apis/test_errors.py
@@ -1,0 +1,82 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from hitas.tests.apis.helpers import validate_openapi
+
+
+class ExceptionApiCases(APITestCase):
+    maxDiff = None
+
+    def test_400_invalid_json(self):
+        response = self.client.post(reverse("hitas:housing-company-list"), data="foo", content_type="application/json")
+
+        validate_openapi(response)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual(
+            response.json(),
+            {
+                "error": "bad_request",
+                "message": "Bad request",
+                "reason": "Bad Request",
+                "status": 400,
+            },
+        )
+
+    def test_404(self):
+        response = self.client.get("/foo")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertDictEqual(
+            response.json(),
+            {
+                "error": "not_found",
+                "message": "Resource not found",
+                "reason": "Not Found",
+                "status": 404,
+            },
+        )
+
+    def test_405(self):
+        response = self.client.generic("FOO", reverse("hitas:housing-company-list"))
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertDictEqual(
+            response.json(),
+            {
+                "error": "method_not_allowed",
+                "message": "Method not allowed",
+                "reason": "Method Not Allowed",
+                "status": 405,
+            },
+        )
+
+    def test_406(self):
+        response = self.client.get(reverse("hitas:housing-company-list"), HTTP_ACCEPT="text/plain")
+
+        validate_openapi(response)
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+        self.assertDictEqual(
+            response.json(),
+            {
+                "error": "not_acceptable",
+                "message": "Not acceptable",
+                "reason": "Not Acceptable",
+                "status": 406,
+            },
+        )
+
+    def test_415(self):
+        response = self.client.post(reverse("hitas:housing-company-list"), data="foo", content_type="text/plain")
+
+        validate_openapi(response)
+        self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+        self.assertDictEqual(
+            response.json(),
+            {
+                "error": "unsupported_media_type",
+                "message": "Unsupported media type",
+                "reason": "Unsupported Media Type",
+                "status": 415,
+            },
+        )

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -34,6 +34,29 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    post:
+      description: Add a new housing company
+      operationId: create-housing-company
+      responses:
+        '201':
+          description: Successfully added a new housing company
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HousingCompanyDetails'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -58,6 +81,8 @@ paths:
                 $ref: '#/components/schemas/HousingCompanyDetails'
         '404':
           $ref: '#/components/responses/NotFound'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -553,6 +578,64 @@ components:
           x-extensible-enum:
             - housing_company_not_found
 
+    NotAcceptableError:
+      description: Not acceptable error
+      type: object
+      required:
+        - status
+        - reason
+        - message
+        - error
+      properties:
+        status:
+          description: Error code
+          type: integer
+          enum: [406]
+          example: 406
+        reason:
+          description: Error phrase
+          type: string
+          enum: ["Not Acceptable"]
+          example: Not Acceptable
+        message:
+          description: Human-readable details about the error
+          type: string
+          example: Only 'application/json' Content-Type is supported.
+        error:
+          description: Error reason
+          type: string
+          enum: [not_acceptable]
+          example: not_acceptable
+
+    UnsupportedMediaTypeError:
+      description: Unsupported media type error
+      type: object
+      required:
+        - status
+        - reason
+        - message
+        - error
+      properties:
+        status:
+          description: Error code
+          type: integer
+          enum: [415]
+          example: 415
+        reason:
+          description: Error phrase
+          type: string
+          enum: ["Unsupported Media Type"]
+          example: Unsupported Media Type
+        message:
+          description: Human-readable details about the error
+          type: string
+          example: Only 'application/json' Content-Type is supported.
+        error:
+          description: Error reason
+          type: string
+          enum: [unsupported_media_type]
+          example: unsupported_media_type
+
     InternalServerError:
       type: object
       description: Internal server error
@@ -613,6 +696,30 @@ components:
             reason: Not Found
             error: housing_company_not_found
             message: Housing company not found
+
+    UnsupportedMediaType:
+      description: Only 'application/json' content-type is supported.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UnsupportedMediaTypeError'
+          example:
+            status: 415
+            reason: Unsupported Media Type
+            error: unsupported_media_type
+            message: Only 'application/json' Content-Type is supported.
+
+    NotAcceptable:
+      description: Only 'application/json' content-type is supported.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NotAcceptableError'
+          example:
+            status: 405
+            reason: Not Acceptable
+            error: not_acceptable
+            message: Only 'application/json' Content-Type is supported.
 
     InternalServerError:
       description: Unexpected internal server error occurred


### PR DESCRIPTION
3ff113f: error handling changes
 - implement custom handlers for 400, 404, 405, 406, 415, 500
 - 400 is implemented according to OpenAPI
 - disabled localization and internationalization, at least for now
  - this way error strings are not localized
 - added OpenAPI definitions for 406 and 415
 - added an simple OpenAPI definition for creating a housing company
   - this helps with testing 400 errors
---
6e6567b: minor style fixes
---
6de444c: Makefile: run `make format` on `make [all]`