### PR TITLE
Add Dockerfile for frontend and move docker-compose.yml to root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY = up
+
+up:
+	docker-compose up --detach --build

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # hitas
+
+## Setting up the environment
+
+Run `docker-compose up --build --detach`
+
+After that the environment is up with following accesses:
+
+* Access Hitas frontend from [localhost:8081](http://localhost:8081).
+* Access Hitas backend API from [localhost:8080/api/v1](http://localhost:8080/api/v1)
+* Access Django admin from [localhost:8080/admin](http://localhost:8080/admin). Default username/password `hitas`/`hitas`
+- Access OpenAPI documentation from [localhost:8090](http://localhost:8090)
+- Access PostgreSQL from [hitas:hitas@localhost:5432/hitas](postgres://hitas:hitas@localhost:5432/hitas)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -62,7 +62,33 @@ COPY --chown=hitas:hitas poetry.lock pyproject.toml ./
 RUN poetry export | /hitas/venv/bin/pip install -r /dev/stdin
 
 #
-# Build the image
+# Build image for django static content
+#
+FROM base AS django-collectstatic
+
+# Copy virtualenv
+COPY --from=builder --chown=hitas:hitas /hitas/venv /hitas/venv
+
+RUN mkdir -p /hitas/backend
+WORKDIR /hitas/backend
+
+COPY manage.py ./
+COPY hitas ./hitas
+COPY config ./config
+COPY users ./users
+
+RUN . /hitas/venv/bin/activate && SECRET_KEY=xxx ./manage.py collectstatic --clear --no-input --verbosity=0
+
+#
+# Build nginx image
+#
+FROM nginx:1.23-alpine AS nginx
+
+ADD nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=django-collectstatic --chown=nginx:nginx /hitas/backend/var/static /media/static
+
+#
+# Build the backend image
 #
 FROM base
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -3,8 +3,7 @@
 all: format tests build
 
 build:
-	./manage.py collectstatic --clear --no-input --verbosity=0
-	docker-compose up --detach --build
+	cd .. && docker-compose up --detach --build
 
 tests:
 	pytest --cov

--- a/backend/nginx.conf
+++ b/backend/nginx.conf
@@ -1,10 +1,10 @@
 upstream django {
-    server hitas:8888;
+    server hitas-backend:8888;
 }
 
 # configuration of the server
 server {
-    listen      8080;
+    listen      80;
     charset     utf-8;
 
     location /static {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,16 @@
 version: "3.9"
 services:
-  hitas:
-    container_name: hitas
+  hitas-frontend:
     build:
-      context: .
+      context: frontend
+    ports:
+      - 8081:80
+    depends_on:
+      - hitas-backend
+
+  hitas-backend:
+    build:
+      context: backend
     environment:
       APPLY_MIGRATIONS: 1
       COLLECT_STATIC: 1
@@ -28,15 +35,14 @@ services:
       POSTGRES_PASSWORD: hitas
       POSTGRES_DB: hitas
 
-  nginx:
-    image: nginx:1.21
+  hitas-backend-nginx:
+    build:
+      context: backend
+      target: nginx
     ports:
-      - 8080:8080
-    volumes:
-      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./var/static:/media/static
+      - 8080:80
     depends_on:
-      - hitas
+      - hitas-backend
 
   swagger-editor:
     image: swaggerapi/swagger-editor:v4.2.9
@@ -45,4 +51,4 @@ services:
     ports:
       - 8090:8080
     volumes:
-      - ./openapi.yaml:/swagger/openapi.yaml:ro
+      - ./backend/openapi.yaml:/swagger/openapi.yaml:ro

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:18-alpine AS build
+
+RUN mkdir /hitas
+WORKDIR /hitas
+
+ADD package.json ./
+ADD yarn.lock ./
+RUN yarn install
+
+ADD postcss.config.js ./
+ADD public ./public
+ADD src ./src
+ADD tsconfig.json ./
+ADD webpack.config.js ./
+
+RUN yarn build
+
+FROM nginx:1.23-alpine
+COPY --from=build /hitas/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen      80;
+    charset     utf-8;
+
+    location / {
+        root       /usr/share/nginx/html;
+        index      index.html index.htm;
+        try_files  $uri $uri/ /index.html;
+    }
+
+    error_page     500 502 503 504  /50x.html;
+
+    location = /50x.html {
+        root       /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
 - frontend now has it's own Dockerfile
 - backend/docker-compose.yml moved to docker-compose.yml
 - backend/Dockerfile now has a target for building django staticcontent
   and nginx
   - no need to run `./manage.py collectstatic` locally anymore (which
     requires all the dependencies to be installed)
 - updated README.md