### PR TITLE
docker changes for running in Platta

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -110,4 +110,4 @@ COPY --chown=hitas:hitas templates ./templates
 COPY --chown=hitas:hitas users ./users
 COPY --chown=hitas:hitas initial.json ./
 
-EXPOSE 8000
+EXPOSE 8888 8080

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -62,9 +62,9 @@ COPY --chown=hitas:hitas poetry.lock pyproject.toml ./
 RUN poetry export | /hitas/venv/bin/pip install -r /dev/stdin
 
 #
-# Build image for django static content
+# Build image for django static content and translations
 #
-FROM base AS django-collectstatic
+FROM base AS django-build-static
 
 # Copy virtualenv
 COPY --from=builder --chown=hitas:hitas /hitas/venv /hitas/venv
@@ -78,6 +78,7 @@ COPY config ./config
 COPY users ./users
 
 RUN . /hitas/venv/bin/activate && SECRET_KEY=xxx ./manage.py collectstatic --clear --no-input --verbosity=0
+RUN . /hitas/venv/bin/activate && SECRET_KEY=xxx ./manage.py compilemessages -l "fi"
 
 #
 # Build nginx image
@@ -85,7 +86,7 @@ RUN . /hitas/venv/bin/activate && SECRET_KEY=xxx ./manage.py collectstatic --cle
 FROM nginx:1.23-alpine AS nginx
 
 ADD nginx.conf /etc/nginx/conf.d/default.conf
-COPY --from=django-collectstatic --chown=nginx:nginx /hitas/backend/var/static /media/static
+COPY --from=django-build-static --chown=nginx:nginx /hitas/backend/var/static /media/static
 
 #
 # Build the backend image
@@ -104,6 +105,7 @@ ENTRYPOINT ["/hitas/backend/docker-entrypoint.sh"]
 COPY --chown=hitas:hitas manage.py uwsgi.ini ./
 COPY --chown=hitas:hitas hitas ./hitas
 COPY --chown=hitas:hitas config ./config
+COPY --from=django-build-static --chown=hitas:hitas /hitas/backend/config/locale ./config/
 COPY --chown=hitas:hitas templates ./templates
 COPY --chown=hitas:hitas users ./users
 COPY --chown=hitas:hitas initial.json ./

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         libpq5 \
         gettext \
-        mime-support
-
+        mime-support \
+        libpcre3 libpcre3-dev
 
 #
 # Build virtualenv

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -44,6 +44,8 @@ INSTALLED_APPS = [
     "hitas",
     "nested_inline",
     "rest_framework",
+    "health_check",
+    "health_check.db",
 ]
 
 MIDDLEWARE = [

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
 
+from hitas.views.health import HealthCheckView
 from hitas.views.housing_company import HousingCompanyViewSet
 
 router = routers.DefaultRouter(trailing_slash=False)
@@ -10,6 +11,7 @@ router.register(r"housing-companies", HousingCompanyViewSet, basename="housing-c
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/v1/", include((router.urls, "hitas"))),
+    path("healthz", HealthCheckView.as_view(), name="health_check"),
 ]
 
 handler404 = "hitas.error_handlers.handle_404"

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -28,10 +28,6 @@ if [[ "${LOAD_INITIAL_DATASET:-"0"}" = "1" ]]; then
     ./manage.py loaddata initial.json
 fi
 
-# Translate messages
-echo "Updating translations..."
-./manage.py compilemessages -l "fi"
-
 # Start server
 echo
 echo "Starting uwsgi-server..."

--- a/backend/hitas/views/health.py
+++ b/backend/hitas/views/health.py
@@ -1,0 +1,11 @@
+from django.http import JsonResponse
+from health_check.views import MainView
+
+
+class HealthCheckView(MainView):
+    def get(self, request, *args, **kwargs):
+        status_code = 500 if self.errors else 200
+        return JsonResponse(
+            {"status": ("ok" if status_code == 200 else "error")},
+            status=status_code,
+        )

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -241,6 +241,17 @@ python-versions = ">=3.6"
 Django = ">=2.2"
 
 [[package]]
+name = "django-health-check"
+version = "3.16.5"
+description = "Run checks on services like databases, queue servers, celery processes, etc."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+django = ">=2.2"
+
+[[package]]
 name = "django-helusers"
 version = "0.7.1"
 description = "Django app for the user infrastructure of the City of Helsinki"
@@ -1085,7 +1096,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "bb266d3425c73f3d5531e99ed68e91efbf1bb6f86eff87b449e61aeec51a74e8"
+content-hash = "0991b6a4b35979a9240fb085b8e8ee6f8a94bed3ae38677cd85e65bc9eadb1ed"
 
 [metadata.files]
 appnope = [
@@ -1235,6 +1246,10 @@ django-environ = [
 django-filter = [
     {file = "django-filter-21.1.tar.gz", hash = "sha256:632a251fa8f1aadb4b8cceff932bb52fe2f826dd7dfe7f3eac40e5c463d6836e"},
     {file = "django_filter-21.1-py3-none-any.whl", hash = "sha256:f4a6737a30104c98d2e2a5fb93043f36dd7978e0c7ddc92f5998e85433ea5063"},
+]
+django-health-check = [
+    {file = "django-health-check-3.16.5.tar.gz", hash = "sha256:1edfd49293ccebbce29f9da609c407f307aee240ab799ab4201031341ae78c0f"},
+    {file = "django_health_check-3.16.5-py2.py3-none-any.whl", hash = "sha256:8d66781a0ea82b1a8b44878187b38a27370e94f18287312e39be0593e72d8983"},
 ]
 django-helusers = [
     {file = "django-helusers-0.7.1.tar.gz", hash = "sha256:7c63ff403d3db5136fbc61dbb96db7858a74157c832953c1f9dd9032ffac7236"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,7 @@ djangorestframework = "^3.13.1"
 django-nested-inline = "^0.4.5"
 uWSGI = "^2.0.20"
 django-crum = "^0.7.9"
+django-health-check = "^3.16.5"
 
 [tool.poetry.dev-dependencies]
 autoflake = "^1.4"

--- a/backend/uwsgi.ini
+++ b/backend/uwsgi.ini
@@ -1,5 +1,6 @@
 [uwsgi]
 module = config.wsgi:application
+http = :8080
 socket = :8888
 master = true
 vacuum = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       DATABASE_URL: postgres://hitas:hitas@postgres/hitas
     ports:
       - 8888
+      - 8082:8080
     restart: on-failure
     depends_on:
       - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       context: backend
     environment:
       APPLY_MIGRATIONS: 1
-      COLLECT_STATIC: 1
       LOAD_INITIAL_DATASET: 1
       DEBUG: "True"
       ALLOWED_HOSTS: "*"


### PR DESCRIPTION
821e876: Dockerfile: add pcre support
 - previously logs stated `!!! no internal routing support, rebuild with pcre support !!!`
 - install libpcre3 to get rid of this
---
3d6e295: Dockerfile: run compilemessages during the image building
 - remove it from entrypoint.sh, call it on building instead
   - no need to write files during runtime anymore
---
6a907e0: uwsgi: expose 8080 as HTTP
---
5bad659: add django-health-check
 - GET /healthz now responds to health check
