### PR TITLE
fix random test failure and always generate random test data

### DIFF
--- a/backend/hitas/tests/apis/test_api_person.py
+++ b/backend/hitas/tests/apis/test_api_person.py
@@ -103,9 +103,9 @@ def test__api__person__retrieve__invalid_id(api_client: HitasAPIClient):
 def get_person_create_data() -> dict[str, Any]:
     pc: PostalCode = PostalCodeFactory.create(value="00100")
 
-    data = {
-        "first_name": "Matti Matias",
-        "last_name": "Meikäläinen",
+    return {
+        "first_name": "fake-first-name",
+        "last_name": "fake-last-name",
         "social_security_number": "010199-123A",
         "email": "test@hitas.com",
         "address": {
@@ -113,7 +113,6 @@ def get_person_create_data() -> dict[str, Any]:
             "street": "test-street-address-1",
         },
     }
-    return data
 
 
 @pytest.mark.parametrize("minimal_data", [False, True])
@@ -214,9 +213,9 @@ def test__api__person__delete(api_client: HitasAPIClient):
 @pytest.mark.parametrize(
     "selected_filter",
     [
-        {"first_name": "Matti"},
-        {"first_name": "Matias"},
-        {"last_name": "Meikäläinen"},
+        {"first_name": "fake-first"},
+        {"first_name": "first-name"},
+        {"last_name": "fake-last"},
         {"social_security_number": "010199-123A"},
         {"email": "hitas"},
         {"street_address": "test-street"},

--- a/backend/hitas/tests/factories/__init__.py
+++ b/backend/hitas/tests/factories/__init__.py
@@ -1,3 +1,5 @@
+import factory
+
 from hitas.tests.factories.codes import (
     ApartmentTypeFactory,
     BuildingTypeFactory,
@@ -14,3 +16,7 @@ from hitas.tests.factories.housing_company import (
 from hitas.tests.factories.person import OwnerFactory, PersonFactory
 from hitas.tests.factories.property_manager import PropertyManagerFactory
 from hitas.tests.factories.user import UserFactory
+
+# Force faker to always use finnish locale - otherwise we would either
+# need to pass the locale on each attribute or use contextlibs
+factory.Faker._DEFAULT_LOCALE = "fi_FI"

--- a/backend/hitas/tests/factories/codes.py
+++ b/backend/hitas/tests/factories/codes.py
@@ -8,7 +8,7 @@ from faker import Faker
 
 from hitas.models import ApartmentType, BuildingType, Developer, FinancingMethod, PostalCode
 
-fake = Faker(locale="fi_FI")
+faker = Faker(locale="fi_FI")
 
 
 class AbstractCodeFactory(DjangoModelFactory):
@@ -17,7 +17,7 @@ class AbstractCodeFactory(DjangoModelFactory):
         abstract = True
 
     value = None
-    description = fake.sentence()
+    description = factory.Faker("sentence")
     in_use = True
     order = None
     legacy_code_number = factory.Sequence(lambda n: f"{n%1000:03}")
@@ -31,8 +31,8 @@ class PostalCodeFactory(AbstractCodeFactory):
         django_get_or_create = ("value",)
 
     # # Helsinki area postal code e.g. 00100
-    value = factory.Sequence(lambda n: fake.bothify(f"0{n%100:02}#0"))
-    description = fake.city()
+    value = factory.Sequence(lambda n: faker.bothify(f"0{n%100:02}#0"))
+    description = factory.Faker("city")
 
 
 class BuildingTypeFactory(AbstractCodeFactory):
@@ -96,7 +96,7 @@ class DeveloperFactory(AbstractCodeFactory):
         model = Developer
         django_get_or_create = ("value",)
 
-    value = factory.LazyAttribute(lambda self: f"As Oy {fake.last_name()}")
+    value = factory.LazyAttribute(lambda _: f"As Oy {faker.last_name()}")
 
 
 class ApartmentTypeFactory(AbstractCodeFactory):

--- a/backend/hitas/tests/factories/housing_company.py
+++ b/backend/hitas/tests/factories/housing_company.py
@@ -5,23 +5,20 @@ from decimal import Decimal
 import factory
 from factory import fuzzy
 from factory.django import DjangoModelFactory
-from faker import Faker
 
 from hitas.models import Apartment, Building, HousingCompany, HousingCompanyState, RealEstate
 from hitas.models.apartment import ApartmentState
-
-fake = Faker(locale="fi_FI")
 
 
 class HousingCompanyFactory(DjangoModelFactory):
     class Meta:
         model = HousingCompany
 
-    display_name = fake.last_name()
+    display_name = factory.Faker("last_name")
     official_name = factory.LazyAttribute(lambda self: f"As Oy {self.display_name}")
     state = HousingCompanyState.NOT_READY
-    business_id = fake.company_business_id()
-    street_address = fake.street_address()
+    business_id = factory.Faker("company_business_id")
+    street_address = factory.Faker("street_address")
     postal_code = factory.SubFactory("hitas.tests.factories.PostalCodeFactory")
     building_type = factory.SubFactory("hitas.tests.factories.BuildingTypeFactory")
     financing_method = factory.SubFactory("hitas.tests.factories.FinancingMethodFactory")
@@ -38,7 +35,7 @@ class HousingCompanyFactory(DjangoModelFactory):
     sales_price_catalogue_confirmation_date = fuzzy.FuzzyDate(date(2010, 1, 1))
     notification_date = fuzzy.FuzzyDate(date(2010, 1, 1))
     legacy_id = factory.Sequence(lambda n: f"{n:03}")
-    notes = fake.text()
+    notes = factory.Faker("text")
     last_modified_datetime = fuzzy.FuzzyDate(date(2010, 1, 1))
     last_modified_by = factory.SubFactory("hitas.tests.factories.UserFactory")
 
@@ -48,8 +45,8 @@ class RealEstateFactory(DjangoModelFactory):
         model = RealEstate
 
     housing_company = factory.SubFactory("hitas.tests.factories.HousingCompanyFactory")
-    property_identifier = fake.bothify("####-####-####-####")
-    street_address = fake.street_address()
+    property_identifier = factory.Faker("bothify", text="####-####-####-####")
+    street_address = factory.Faker("street_address")
     postal_code = factory.SubFactory("hitas.tests.factories.PostalCodeFactory")
 
 
@@ -59,8 +56,8 @@ class BuildingFactory(DjangoModelFactory):
 
     real_estate = factory.SubFactory("hitas.tests.factories.RealEstateFactory")
     completion_date = fuzzy.FuzzyDate(date(2010, 1, 1))
-    building_identifier = fake.bothify("1########?")
-    street_address = fake.street_address()
+    building_identifier = factory.Faker("bothify", text="1########?")
+    street_address = factory.Faker("street_address")
     postal_code = factory.SubFactory("hitas.tests.factories.PostalCodeFactory")
 
 
@@ -74,15 +71,15 @@ class ApartmentFactory(DjangoModelFactory):
     surface_area = fuzzy.FuzzyDecimal(10, 99, precision=2)
     share_number_start = factory.Sequence(lambda n: n * 50)
     share_number_end = factory.LazyAttribute(lambda self: (self.share_number_start + 50))
-    street_address = fake.street_address()
+    street_address = factory.Faker("street_address")
     postal_code = factory.SubFactory("hitas.tests.factories.PostalCodeFactory")
     apartment_number = fuzzy.FuzzyInteger(1, 99)
     floor = fuzzy.FuzzyInteger(1, 9)
-    stair = fake.bothify("?")  # Random letter
+    stair = factory.Faker("bothify", text="?")  # Random letter
     debt_free_purchase_price = fuzzy.FuzzyDecimal(100000, 200000, precision=2)
     purchase_price = fuzzy.FuzzyDecimal(100000, 200000, precision=2)
     acquisition_price = fuzzy.FuzzyDecimal(100000, 200000, precision=2)
     primary_loan_amount = fuzzy.FuzzyDecimal(100000, 200000, precision=2)
     loans_during_construction = fuzzy.FuzzyDecimal(100000, 200000, precision=2)
     interest_during_construction = fuzzy.FuzzyDecimal(10000, 20000, precision=2)
-    notes = fake.text()
+    notes = factory.Faker("text")

--- a/backend/hitas/tests/factories/person.py
+++ b/backend/hitas/tests/factories/person.py
@@ -14,11 +14,11 @@ class PersonFactory(DjangoModelFactory):
     class Meta:
         model = Person
 
-    first_name = fake.first_name()
-    last_name = fake.last_name()
-    social_security_number = fake.ssn()
-    email = fake.email()
-    street_address = fake.street_address()
+    first_name = factory.Faker("first_name")
+    last_name = factory.Faker("last_name")
+    social_security_number = factory.Faker("ssn")
+    email = factory.Faker("email")
+    street_address = factory.Faker("street_address")
     postal_code = factory.SubFactory("hitas.tests.factories.PostalCodeFactory")
 
 

--- a/backend/hitas/tests/factories/property_manager.py
+++ b/backend/hitas/tests/factories/property_manager.py
@@ -1,17 +1,14 @@
 import factory
 from factory.django import DjangoModelFactory
-from faker import Faker
 
 from hitas.models import PropertyManager
-
-fake = Faker(locale="fi_FI")
 
 
 class PropertyManagerFactory(DjangoModelFactory):
     class Meta:
         model = PropertyManager
 
-    name = fake.name()
-    email = fake.email()
-    street_address = fake.street_address()
+    name = factory.Faker("name")
+    email = factory.Faker("email")
+    street_address = factory.Faker("street_address")
     postal_code = factory.SubFactory("hitas.tests.factories.PostalCodeFactory")

--- a/backend/hitas/tests/factories/user.py
+++ b/backend/hitas/tests/factories/user.py
@@ -1,10 +1,7 @@
 import factory
 from factory.django import DjangoModelFactory
-from faker import Faker
 
 from users.models import User
-
-fake = Faker(locale="fi_FI")
 
 
 class UserFactory(DjangoModelFactory):


### PR DESCRIPTION
f61bece: backend: always generate random data for each element in factories
 - previosly test used `first_name = faker.first_name()` in class
   declarations. as this generates a static string then it's always
   shared between generated objects
 - now `factory.Faker` is used instead to guarantee random strings
   for each object
---
c18adec: backend: fix random test failure with `test__api__person__filter`
 - removed `Matti` from test__api__person` as that's a random
   string that can be generated by `faker` and when that happens
   test will fail
---