### PR TITLE
liveness check fixes - uwsgi and healtcheck improvements

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -19,19 +19,20 @@ env = environ.Env(
     STATIC_URL=(str, "/static/"),
     MEDIA_URL=(str, "/media/"),
     CORS_ALLOWED_ORIGINS=(list, []),
+    UWSGI_WARMUP=(bool, True),
 )
 env.read_env(os.path.join(BASE_DIR, ".env"))
 
 DEBUG = env("DEBUG")
 SECRET_KEY = env("SECRET_KEY")
 ALLOWED_HOSTS = env("ALLOWED_HOSTS")
-
 var_root = env.path("VAR_ROOT")
 STATIC_ROOT = var_root("static")
 MEDIA_ROOT = var_root("media")
 STATIC_URL = env("STATIC_URL")
 MEDIA_URL = env("MEDIA_URL")
 CORS_ALLOWED_ORIGINS = env("CORS_ALLOWED_ORIGINS")
+UWSGI_WARMUP = env("UWSGI_WARMUP")
 
 # Application definition
 INSTALLED_APPS = [

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -49,7 +49,6 @@ INSTALLED_APPS = [
     "rest_framework",
     "django_filters",
     "health_check",
-    "health_check.db",
     "corsheaders",
 ]
 

--- a/backend/config/wsgi.py
+++ b/backend/config/wsgi.py
@@ -8,9 +8,49 @@ https://docs.djangoproject.com/en/3.2/howto/deployment/wsgi/
 """
 
 import os
+from io import StringIO
 
+from django.conf import settings
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
 application = get_wsgi_application()
+
+
+#
+# Hot warmup
+#
+if settings.UWSGI_WARMUP:
+    print("Running uwsgi warmup...")
+
+    def noop(status, hh, exc_info=None):
+        pass
+
+    application(
+        {
+            "CONTENT_LENGTH": "",
+            "CONTENT_TYPE": "",
+            "DOCUMENT_ROOT": "/etc/nginx/html",
+            "HTTP_HOST": "example.com",
+            "PATH_INFO": "/healthz",
+            "QUERY_STRING": "",
+            "REMOTE_ADDR": "127.0.0.1",
+            "REMOTE_PORT": "12345",
+            "REQUEST_METHOD": "GET",
+            "REQUEST_URI": "/healthz",
+            "SERVER_NAME": "example.com",
+            "SERVER_PORT": "80",
+            "SERVER_PROTOCOL": "HTTP/1.1",
+            "uwsgi.node": "f939bd542267",
+            "uwsgi.version": "2.0.22",
+            "wsgi.multiprocess": True,
+            "wsgi.multithread": False,
+            "wsgi.run_once": False,
+            "wsgi.url_scheme": "http",
+            "wsgi.version": (1, 0),
+            "wsgi.input": StringIO(),
+            "wsgi.errors": StringIO(),
+        },
+        noop,
+    )

--- a/backend/hitas/apps.py
+++ b/backend/hitas/apps.py
@@ -1,6 +1,12 @@
 from django.apps import AppConfig
+from health_check.plugins import plugin_dir
+
+from hitas.healthcheck import HitasDatabaseHealthCheck
 
 
 class HitasConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "hitas"
+
+    def ready(self):
+        plugin_dir.register(HitasDatabaseHealthCheck)

--- a/backend/hitas/healthcheck.py
+++ b/backend/hitas/healthcheck.py
@@ -1,0 +1,9 @@
+from django.db import connection
+from health_check.backends import BaseHealthCheckBackend
+
+
+class HitasDatabaseHealthCheck(BaseHealthCheckBackend):
+    def check_status(self):
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            cursor.fetchone()

--- a/backend/uwsgi.ini
+++ b/backend/uwsgi.ini
@@ -1,7 +1,12 @@
 [uwsgi]
 module = config.wsgi:application
-http = :8080
+http-socket = :8080
 socket = :8888
+processes = 8
 master = true
 vacuum = true
+harakiri = 20
+max-requests = 5000
 die-on-term = true
+thunder-lock = true
+enable-threads = true


### PR DESCRIPTION
6477c2a: backend: update uwsgi.ini
 - use http-socket instead of http
 - set processes to 8
 - enable harakiri and max-requests
 - enable thunder lock and threads
---
7628797: backend: add hot warmup for uwsgi
 - django is quite slow to startup - taking more than 1s to start
 - this means that first requests to django can take a significant
   amount of time. this is a problem for health check etc which
   expects to get response in <1s
 - add warmpup code mitigate this issue
---
c489ad0: backend: added custom healthcheck
 - default `health_chech.db` does a INSERT + DELETE operation on
   healthcheck. that's a bit excessive. create a custom one
   that only does `SELECT 1`
 - locally this is about 8-9x faster than the standard module
---
