### PR TITLE
backend: fix filtering apartments by housing company id

### DIFF
--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -669,6 +669,7 @@ def test__api__apartment__delete__invalid(api_client: HitasAPIClient):
 @pytest.mark.parametrize(
     "selected_filter",
     [
+        {"housing_company": "38432c233a914dfb9c2f54d9f5ad9063"},
         {"housing_company_name": "testdisplay"},
         {"street_address": "test-str"},
         {"postal_code": "99999"},
@@ -679,6 +680,11 @@ def test__api__apartment__delete__invalid(api_client: HitasAPIClient):
 )
 @pytest.mark.django_db
 def test__api__apartment__filter(api_client: HitasAPIClient, selected_filter):
+    ApartmentFactory.create(
+        state=ApartmentState.FREE,
+        building__real_estate__housing_company__uuid=UUID("38432c23-3a91-4dfb-9c2f-54d9f5ad9063"),
+    )
+
     ApartmentFactory.create(
         state=ApartmentState.FREE, building__real_estate__housing_company__display_name="TestDisplayName"
     )

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -20,11 +20,13 @@ from hitas.views.utils import (
     HitasFilterSet,
     HitasModelSerializer,
     HitasModelViewSet,
+    HitasUUIDFilter,
     UUIDRelatedField,
 )
 
 
 class ApartmentFilterSet(HitasFilterSet):
+    housing_company = HitasUUIDFilter(field_name="building__real_estate__housing_company__uuid")
     housing_company_name = filters.CharFilter(
         field_name="building__real_estate__housing_company__display_name", lookup_expr="icontains"
     )

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -617,6 +617,13 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
+        - name: housing_company
+          description: Search apartments that belong to housing company with given id
+          required: false
+          in: query
+          schema:
+            type: string
+            example: a3181b8fa60b47df8ccba0d554a913bb
         - name: housing_company_name
           description: Search apartments that belong to housing companies with display name containing the given search string (case-insensitive)
           required: false


### PR DESCRIPTION
 - this is used in frontend in housing company page
   and was removed in 58edb3f1407695dd73f96b7f397635d100359d0b
 - revert the change and document the query parameter