### PR TITLE
housing company: add summary data

### DIFF
--- a/backend/hitas/views/housing_company.py
+++ b/backend/hitas/views/housing_company.py
@@ -64,14 +64,17 @@ class HousingCompanyDetailSerializer(EnumSupportSerializerMixin, HitasModelSeria
     legacy_id = ValueOrNullField(read_only=True)
     last_modified = serializers.SerializerMethodField(read_only=True)
 
-    def get_area(self, obj: HousingCompany) -> Dict[str, any]:
+    @staticmethod
+    def get_area(obj: HousingCompany) -> Dict[str, any]:
         return {"name": obj.postal_code.city, "cost_area": obj.postal_code.cost_area}
 
-    def get_date(self, obj: HousingCompany) -> Optional[datetime.date]:
+    @staticmethod
+    def get_date(obj: HousingCompany) -> Optional[datetime.date]:
         """SerializerMethodField is used instead of DateField due to date being an annotated value"""
         return getattr(obj, "date", None)
 
-    def get_last_modified(self, obj: HousingCompany) -> Dict[str, Any]:
+    @staticmethod
+    def get_last_modified(obj: HousingCompany) -> Dict[str, Any]:
         return {
             "user": {
                 "username": safe_attrgetter(obj, "last_modified_by.username", default=None),

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2087,6 +2087,7 @@ components:
         - state
         - business_id
         - real_estates
+        - summary
       properties:
         id:
           description: Housing company ID
@@ -2160,6 +2161,30 @@ components:
           allOf:
             - $ref: '#/components/schemas/PropertyManager'
             - $ref: '#/components/schemas/ReadOnlyPropertyManager'
+        summary:
+          description: Summary data for this housing company across all apartments
+          type: object
+          readOnly: true
+          required:
+            - average_price_per_square_meter
+            - total_surface_area
+            - total_shares
+          properties:
+            average_price_per_square_meter:
+              description: Average square meter price
+              type: number
+              minimum: 0
+              example: 123000
+            total_surface_area:
+              description: Total surface area across all apartments
+              type: number
+              minimum: 0
+              example: 20452.2
+            total_shares:
+              description: Total number of shares across all apartments
+              type: number
+              minimum: 0
+              example: 98500
         acquisition_price:
           description: Acquisition price information
           type: object


### PR DESCRIPTION
f8eed66: backend: hitas/views/housing_company.py: use staticmethod

---

815750a: backend: add summary data to housing company details
 - `GET /housing-companies/{housing-company-id}` now returns following
   new read-only fields:
   - summary.average_price_per_square_meter
   - summary.total_shares
   - summary.total_surface_area

---
