### PR TITLE
API error msg improvements

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -162,6 +162,6 @@ LANGUAGES = [
 LOCALE_PATHS = ["./templates/locale"]
 
 TIME_ZONE = "Europe/Helsinki"
-USE_I18N = True
+USE_I18N = False
 USE_L10N = True
 USE_TZ = True

--- a/backend/hitas/exceptions.py
+++ b/backend/hitas/exceptions.py
@@ -207,7 +207,9 @@ def _convert_field_errors(field_name: str, errors: List[Dict[str, Any]]):
             formatted_field_name = f"{field_name}.{nested_field_name}"
             error = error[nested_field_name][0]
 
-        if error["code"] in ["required", "null", "blank"]:
+        if error["code"] in ["required", "null"]:
+            retval.append({"field": formatted_field_name, "message": "This field is mandatory and cannot be null."})
+        elif error["code"] in ["blank"]:
             retval.append({"field": formatted_field_name, "message": "This field is mandatory and cannot be blank."})
         elif error["code"] in ["invalid", "invalid_choice", "min_value", "max_value"]:
             retval.append({"field": formatted_field_name, "message": error["message"]})

--- a/backend/hitas/exceptions.py
+++ b/backend/hitas/exceptions.py
@@ -202,10 +202,15 @@ def _convert_field_errors(field_name: str, errors: List[Dict[str, Any]]):
 
         formatted_field_name = field_name
         # Handle nested serializer field errors where error message be in a nested dict
-        if "code" not in error:
-            nested_field_name = next(iter(error))
-            formatted_field_name = f"{field_name}.{nested_field_name}"
-            error = error[nested_field_name][0]
+        while True:
+            if "code" not in error:
+                nested_field_name = next(iter(error))
+                formatted_field_name += f".{nested_field_name}"
+                error = error[nested_field_name]
+                if isinstance(error, list):
+                    error = error[0]
+            else:
+                break
 
         if error["code"] in ["required", "null"]:
             retval.append({"field": formatted_field_name, "message": "This field is mandatory and cannot be null."})

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -611,7 +611,7 @@ def test__api__apartment__create(api_client: HitasAPIClient, minimal_data: bool)
                 {
                     "field": "ownerships.percentage",
                     "message": "Ownership percentage of all ownerships combined must"
-                    " be equal to 100. (Given sum was 150.00)",
+                    " be equal to 100. Given sum was 150.00.",
                 }
             ],
         ),
@@ -636,7 +636,7 @@ def test__api__apartment__create(api_client: HitasAPIClient, minimal_data: bool)
                 {
                     "field": "ownerships.percentage",
                     "message": "Ownership percentage of all ownerships combined must"
-                    " be equal to 100. (Given sum was 20.00)",
+                    " be equal to 100. Given sum was 20.00.",
                 }
             ],
         ),
@@ -661,7 +661,7 @@ def test__api__apartment__create(api_client: HitasAPIClient, minimal_data: bool)
                 {
                     "field": "ownerships.percentage",
                     "message": "Ownership percentage greater than 0 and less than"
-                    " or equal to 100. (Given value was 0.00)",
+                    " or equal to 100. Given value was 0.00.",
                 }
             ],
         ),

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -740,7 +740,7 @@ def test__api__apartment__create__incorrect_building_id(api_client: HitasAPIClie
     b1: Building = BuildingFactory.create()
     b2: Building = BuildingFactory.create()
     data = get_apartment_create_data(b1)
-    data["building"] = (b2.uuid.hex,)
+    data["building"] = b2.uuid.hex
 
     response = api_client.post(
         reverse(

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -439,7 +439,16 @@ def test__api__apartment__create(api_client: HitasAPIClient, minimal_data: bool)
     "invalid_data,fields",
     [
         ({"state": None}, [{"field": "state", "message": "This field is mandatory and cannot be null."}]),
-        ({"state": "invalid_state"}, [{"field": "state", "message": "Unsupported ApartmentState 'invalid_state'."}]),
+        ({"state": ""}, [{"field": "state", "message": "This field is mandatory and cannot be blank."}]),
+        (
+            {"state": "invalid_state"},
+            [
+                {
+                    "field": "state",
+                    "message": "Unsupported value 'invalid_state'. Supported values are: ['free', 'reserved', 'sold'].",
+                }
+            ],
+        ),
         (
             {"type": None},
             [{"field": "type", "message": "This field is mandatory and cannot be null."}],

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -438,15 +438,15 @@ def test__api__apartment__create(api_client: HitasAPIClient, minimal_data: bool)
 @pytest.mark.parametrize(
     "invalid_data,fields",
     [
-        ({"state": None}, [{"field": "state", "message": "This field is mandatory and cannot be blank."}]),
+        ({"state": None}, [{"field": "state", "message": "This field is mandatory and cannot be null."}]),
         ({"state": "invalid_state"}, [{"field": "state", "message": "Unsupported ApartmentState 'invalid_state'."}]),
         (
             {"type": None},
-            [{"field": "type", "message": "This field is mandatory and cannot be blank."}],
+            [{"field": "type", "message": "This field is mandatory and cannot be null."}],
         ),
         (
             {"surface_area": None},
-            [{"field": "surface_area", "message": "This field is mandatory and cannot be blank."}],
+            [{"field": "surface_area", "message": "This field is mandatory and cannot be null."}],
         ),
         ({"surface_area": "foo"}, [{"field": "surface_area", "message": "A valid number is required."}]),
         (
@@ -457,23 +457,23 @@ def test__api__apartment__create(api_client: HitasAPIClient, minimal_data: bool)
             {"shares": {"start": "foo"}},
             [
                 {"field": "shares.start", "message": "A valid integer is required."},
-                {"field": "shares.end", "message": "This field is mandatory and cannot be blank."},
+                {"field": "shares.end", "message": "This field is mandatory and cannot be null."},
             ],
         ),
         (
             {"shares": {"end": "foo"}},
             [
-                {"field": "shares.start", "message": "This field is mandatory and cannot be blank."},
+                {"field": "shares.start", "message": "This field is mandatory and cannot be null."},
                 {"field": "shares.end", "message": "A valid integer is required."},
             ],
         ),
         (
             {"shares": {"start": 100}},
-            [{"field": "shares.end", "message": "This field is mandatory and cannot be blank."}],
+            [{"field": "shares.end", "message": "This field is mandatory and cannot be null."}],
         ),
         (
             {"shares": {"start": None, "end": 100}},
-            [{"field": "shares.start", "message": "This field is mandatory and cannot be blank."}],
+            [{"field": "shares.start", "message": "This field is mandatory and cannot be null."}],
         ),
         (
             {"shares": {"start": 100, "end": 50}},
@@ -486,7 +486,7 @@ def test__api__apartment__create(api_client: HitasAPIClient, minimal_data: bool)
                 {"field": "shares.end", "message": "Ensure this value is greater than or equal to 1."},
             ],
         ),
-        ({"address": None}, [{"field": "address", "message": "This field is mandatory and cannot be blank."}]),
+        ({"address": None}, [{"field": "address", "message": "This field is mandatory and cannot be null."}]),
         (
             {
                 "address": {
@@ -496,8 +496,22 @@ def test__api__apartment__create(api_client: HitasAPIClient, minimal_data: bool)
                 }
             },
             [
+                {"field": "address.street_address", "message": "This field is mandatory and cannot be null."},
+                {"field": "address.apartment_number", "message": "This field is mandatory and cannot be null."},
+                {"field": "address.stair", "message": "This field is mandatory and cannot be null."},
+            ],
+        ),
+        (
+            {
+                "address": {
+                    "street_address": "",
+                    "apartment_number": "",
+                    "stair": "",
+                }
+            },
+            [
                 {"field": "address.street_address", "message": "This field is mandatory and cannot be blank."},
-                {"field": "address.apartment_number", "message": "This field is mandatory and cannot be blank."},
+                {"field": "address.apartment_number", "message": "A valid integer is required."},
                 {"field": "address.stair", "message": "This field is mandatory and cannot be blank."},
             ],
         ),
@@ -564,8 +578,9 @@ def test__api__apartment__create(api_client: HitasAPIClient, minimal_data: bool)
                 }
             ],
         ),
-        ({"building": None}, [{"field": "building", "message": "This field is mandatory and cannot be blank."}]),
-        ({"ownerships": None}, [{"field": "ownerships", "message": "This field is mandatory and cannot be blank."}]),
+        ({"building": None}, [{"field": "building", "message": "This field is mandatory and cannot be null."}]),
+        ({"building": ""}, [{"field": "building", "message": "This field is mandatory and cannot be blank."}]),
+        ({"ownerships": None}, [{"field": "ownerships", "message": "This field is mandatory and cannot be null."}]),
         (
             {
                 "ownerships": [

--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -475,6 +475,10 @@ def test__api__housing_company__create__empty(api_client: HitasAPIClient):
             {"field": "financing_method.id", "message": "This field is mandatory and cannot be null."},
         ),
         (
+            {"financing_method": {"id": "foo"}},
+            {"field": "financing_method.id", "message": "Object does not exist with given id 'foo'."},
+        ),
+        (
             {"building_type": None},
             {"field": "building_type", "message": "This field is mandatory and cannot be null."},
         ),
@@ -486,8 +490,16 @@ def test__api__housing_company__create__empty(api_client: HitasAPIClient):
             {"building_type": {}},
             {"field": "building_type.id", "message": "This field is mandatory and cannot be null."},
         ),
+        (
+            {"building_type": {"id": "foo"}},
+            {"field": "building_type.id", "message": "Object does not exist with given id 'foo'."},
+        ),
         ({"developer": None}, {"field": "developer", "message": "This field is mandatory and cannot be null."}),
         ({"developer": 123}, {"field": "developer", "message": "Invalid data. Expected a dictionary, but got int."}),
+        (
+            {"developer": {"id": "foo"}},
+            {"field": "developer.id", "message": "Object does not exist with given id 'foo'."},
+        ),
         (
             {"property_manager": None},
             {"field": "property_manager", "message": "This field is mandatory and cannot be null."},
@@ -499,6 +511,10 @@ def test__api__housing_company__create__empty(api_client: HitasAPIClient):
         (
             {"property_manager": {}},
             {"field": "property_manager.id", "message": "This field is mandatory and cannot be null."},
+        ),
+        (
+            {"property_manager": {"id": "foo"}},
+            {"field": "property_manager.id", "message": "Object does not exist with given id 'foo'."},
         ),
         (
             {"acquisition_price": None},
@@ -522,15 +538,6 @@ def test__api__housing_company__create__invalid_data(api_client: HitasAPIClient,
         "reason": "Bad Request",
         "status": 400,
     }
-
-
-@pytest.mark.django_db
-def test__api__housing_company__create__invalid_foreign_key(api_client: HitasAPIClient):
-    data = get_housing_company_create_data()
-    data.update({"property_manager": {"id": "foo"}})
-
-    response = api_client.post(reverse("hitas:housing-company-list"), data=data, format="json")
-    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
 
 
 # Update tests

--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -423,16 +423,16 @@ def test__api__housing_company__create__empty(api_client: HitasAPIClient):
     assert response.json() == {
         "error": "bad_request",
         "fields": [
-            {"field": "business_id", "message": "This field is mandatory and cannot be blank."},
-            {"field": "name", "message": "This field is mandatory and cannot be blank."},
-            {"field": "state", "message": "This field is mandatory and cannot be blank."},
-            {"field": "address", "message": "This field is mandatory and cannot be blank."},
-            {"field": "financing_method", "message": "This field is mandatory and cannot be blank."},
-            {"field": "building_type", "message": "This field is mandatory and cannot be blank."},
-            {"field": "developer", "message": "This field is mandatory and cannot be blank."},
-            {"field": "property_manager", "message": "This field is mandatory and cannot be blank."},
-            {"field": "acquisition_price", "message": "This field is mandatory and cannot be blank."},
-            {"field": "primary_loan", "message": "This field is mandatory and cannot be blank."},
+            {"field": "business_id", "message": "This field is mandatory and cannot be null."},
+            {"field": "name", "message": "This field is mandatory and cannot be null."},
+            {"field": "state", "message": "This field is mandatory and cannot be null."},
+            {"field": "address", "message": "This field is mandatory and cannot be null."},
+            {"field": "financing_method", "message": "This field is mandatory and cannot be null."},
+            {"field": "building_type", "message": "This field is mandatory and cannot be null."},
+            {"field": "developer", "message": "This field is mandatory and cannot be null."},
+            {"field": "property_manager", "message": "This field is mandatory and cannot be null."},
+            {"field": "acquisition_price", "message": "This field is mandatory and cannot be null."},
+            {"field": "primary_loan", "message": "This field is mandatory and cannot be null."},
         ],
         "message": "Bad request",
         "reason": "Bad Request",
@@ -443,18 +443,17 @@ def test__api__housing_company__create__empty(api_client: HitasAPIClient):
 @pytest.mark.parametrize(
     "invalid_data,field",
     [
-        ({"business_id": None}, {"field": "business_id", "message": "This field is mandatory and cannot be blank."}),
+        ({"business_id": None}, {"field": "business_id", "message": "This field is mandatory and cannot be null."}),
         ({"business_id": "#"}, {"field": "business_id", "message": "'#' is not a valid business id."}),
         ({"business_id": "123"}, {"field": "business_id", "message": "'123' is not a valid business id."}),
-        ({"name": None}, {"field": "name", "message": "This field is mandatory and cannot be blank."}),
+        ({"name": None}, {"field": "name", "message": "This field is mandatory and cannot be null."}),
         ({"name": 0}, {"field": "name", "message": "Invalid data. Expected a dictionary, but got int."}),
-        ({"state": None}, {"field": "state", "message": "This field is mandatory and cannot be blank."}),
         ({"state": "invalid_state"}, {"field": "state", "message": "Unsupported HousingCompanyState 'invalid_state'."}),
-        ({"address": None}, {"field": "address", "message": "This field is mandatory and cannot be blank."}),
+        ({"address": None}, {"field": "address", "message": "This field is mandatory and cannot be null."}),
         ({"address": 123}, {"field": "address", "message": "Invalid data. Expected a dictionary, but got int."}),
         (
             {"financing_method": None},
-            {"field": "financing_method", "message": "This field is mandatory and cannot be blank."},
+            {"field": "financing_method", "message": "This field is mandatory and cannot be null."},
         ),
         (
             {"financing_method": "foo"},
@@ -462,11 +461,11 @@ def test__api__housing_company__create__empty(api_client: HitasAPIClient):
         ),
         (
             {"financing_method": {}},
-            {"field": "financing_method.id", "message": "This field is mandatory and cannot be blank."},
+            {"field": "financing_method.id", "message": "This field is mandatory and cannot be null."},
         ),
         (
             {"building_type": None},
-            {"field": "building_type", "message": "This field is mandatory and cannot be blank."},
+            {"field": "building_type", "message": "This field is mandatory and cannot be null."},
         ),
         (
             {"building_type": 123},
@@ -474,13 +473,13 @@ def test__api__housing_company__create__empty(api_client: HitasAPIClient):
         ),
         (
             {"building_type": {}},
-            {"field": "building_type.id", "message": "This field is mandatory and cannot be blank."},
+            {"field": "building_type.id", "message": "This field is mandatory and cannot be null."},
         ),
-        ({"developer": None}, {"field": "developer", "message": "This field is mandatory and cannot be blank."}),
+        ({"developer": None}, {"field": "developer", "message": "This field is mandatory and cannot be null."}),
         ({"developer": 123}, {"field": "developer", "message": "Invalid data. Expected a dictionary, but got int."}),
         (
             {"property_manager": None},
-            {"field": "property_manager", "message": "This field is mandatory and cannot be blank."},
+            {"field": "property_manager", "message": "This field is mandatory and cannot be null."},
         ),
         (
             {"property_manager": 123},
@@ -488,13 +487,13 @@ def test__api__housing_company__create__empty(api_client: HitasAPIClient):
         ),
         (
             {"property_manager": {}},
-            {"field": "property_manager.id", "message": "This field is mandatory and cannot be blank."},
+            {"field": "property_manager.id", "message": "This field is mandatory and cannot be null."},
         ),
         (
             {"acquisition_price": None},
-            {"field": "acquisition_price", "message": "This field is mandatory and cannot be blank."},
+            {"field": "acquisition_price", "message": "This field is mandatory and cannot be null."},
         ),
-        ({"primary_loan": None}, {"field": "primary_loan", "message": "This field is mandatory and cannot be blank."}),
+        ({"primary_loan": None}, {"field": "primary_loan", "message": "This field is mandatory and cannot be null."}),
         ({"primary_loan": "foo"}, {"field": "primary_loan", "message": "A valid number is required."}),
     ],
 )

--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -448,7 +448,18 @@ def test__api__housing_company__create__empty(api_client: HitasAPIClient):
         ({"business_id": "123"}, {"field": "business_id", "message": "'123' is not a valid business id."}),
         ({"name": None}, {"field": "name", "message": "This field is mandatory and cannot be null."}),
         ({"name": 0}, {"field": "name", "message": "Invalid data. Expected a dictionary, but got int."}),
-        ({"state": "invalid_state"}, {"field": "state", "message": "Unsupported HousingCompanyState 'invalid_state'."}),
+        ({"state": None}, {"field": "state", "message": "This field is mandatory and cannot be null."}),
+        (
+            {"state": "invalid_state"},
+            {
+                "field": "state",
+                "message": (
+                    "Unsupported value 'invalid_state'. Supported values are:"
+                    " ['not_ready', 'lt_30_years', 'gt_30_years_not_free', 'gt_30_years_free', "
+                    "'gt_30_years_plot_department_notification', 'half_hitas', 'ready_no_statistics']."
+                ),
+            },
+        ),
         ({"address": None}, {"field": "address", "message": "This field is mandatory and cannot be null."}),
         ({"address": 123}, {"field": "address", "message": "Invalid data. Expected a dictionary, but got int."}),
         (

--- a/backend/hitas/tests/apis/test_api_postal_codes.py
+++ b/backend/hitas/tests/apis/test_api_postal_codes.py
@@ -112,11 +112,11 @@ def test__api__postal_code__create(api_client: HitasAPIClient):
 @pytest.mark.parametrize(
     "invalid_data,field",
     [
-        ({"value": None}, {"field": "value", "message": "This field is mandatory and cannot be blank."}),
+        ({"value": None}, {"field": "value", "message": "This field is mandatory and cannot be null."}),
         ({"value": ""}, {"field": "value", "message": "This field is mandatory and cannot be blank."}),
-        ({"city": None}, {"field": "city", "message": "This field is mandatory and cannot be blank."}),
+        ({"city": None}, {"field": "city", "message": "This field is mandatory and cannot be null."}),
         ({"city": ""}, {"field": "city", "message": "This field is mandatory and cannot be blank."}),
-        ({"cost_area": None}, {"field": "cost_area", "message": "This field is mandatory and cannot be blank."}),
+        ({"cost_area": None}, {"field": "cost_area", "message": "This field is mandatory and cannot be null."}),
         ({"cost_area": "foo"}, {"field": "cost_area", "message": "A valid integer is required."}),
         ({"cost_area": -1}, {"field": "cost_area", "message": "Ensure this value is greater than or equal to 1."}),
         ({"cost_area": 0}, {"field": "cost_area", "message": "Ensure this value is greater than or equal to 1."}),

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -147,6 +147,20 @@ class ApartmentDetailSerializer(EnumSupportSerializerMixin, HitasModelSerializer
     def get_links(self, instance: Apartment):
         return create_links(instance)
 
+    def validate_building(self, building: Building):
+        housing_company_uuid = self.context["view"].kwargs["housing_company_uuid"]
+        try:
+            import uuid
+
+            hc = HousingCompany.objects.only("id").get(uuid=uuid.UUID(hex=housing_company_uuid))
+        except (HousingCompany.DoesNotExist, ValueError, TypeError):
+            raise
+
+        if building.real_estate.housing_company.id != hc.id:
+            raise ValidationError(f"Object does not exist with given id '{building.uuid.hex}'.", code="invalid")
+
+        return building
+
     def validate_ownerships(self, ownerships: OrderedDict):
         if not ownerships:
             return ownerships

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Union
 
 from django.core.exceptions import ValidationError
 from django.urls import reverse
-from django.utils.translation import gettext_lazy as _
 from enumfields.drf import EnumSupportSerializerMixin
 from rest_framework import serializers
 from rest_framework.fields import SkipField, empty
@@ -157,18 +156,20 @@ class ApartmentDetailSerializer(EnumSupportSerializerMixin, HitasModelSerializer
             if not 0 < op <= 100:
                 raise ValidationError(
                     {
-                        "percentage": _(
-                            "Ownership percentage greater than 0 and less than or equal to 100. (Given value was {})"
-                        ).format(op)
+                        "percentage": (
+                            "Ownership percentage greater than 0 and"
+                            f" less than or equal to 100. Given value was {op}."
+                        )
                     },
                 )
 
         if (sum_op := sum(o["percentage"] for o in ownerships)) != 100:
             raise ValidationError(
                 {
-                    "percentage": _(
-                        "Ownership percentage of all ownerships combined must be equal to 100. (Given sum was {})"
-                    ).format(sum_op)
+                    "percentage": (
+                        "Ownership percentage of all ownerships combined"
+                        f" must be equal to 100. Given sum was {sum_op}."
+                    )
                 }
             )
 

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -10,7 +10,7 @@ from rest_framework.fields import SkipField, empty
 from hitas.models import Apartment, Building, HousingCompany, Ownership
 from hitas.models.apartment import ApartmentState
 from hitas.models.utils import validate_share_numbers
-from hitas.views.codes import ApartmentTypeSerializer
+from hitas.views.codes import ReadOnlyApartmentTypeSerializer
 from hitas.views.ownership import OwnershipSerializer
 from hitas.views.utils import (
     HitasDecimalField,
@@ -134,7 +134,7 @@ def create_links(instance: Apartment) -> Dict[str, Any]:
 
 class ApartmentDetailSerializer(EnumSupportSerializerMixin, HitasModelSerializer):
     state = HitasEnumField(enum=ApartmentState)
-    type = ApartmentTypeSerializer(source="apartment_type")
+    type = ReadOnlyApartmentTypeSerializer(source="apartment_type")
     address = ApartmentHitasAddressSerializer(source="*")
     completion_date = serializers.DateField(required=False, allow_null=True)
     surface_area = HitasDecimalField()
@@ -144,7 +144,8 @@ class ApartmentDetailSerializer(EnumSupportSerializerMixin, HitasModelSerializer
     links = serializers.SerializerMethodField()
     building = UUIDRelatedField(queryset=Building.objects.all(), write_only=True)
 
-    def get_links(self, instance: Apartment):
+    @staticmethod
+    def get_links(instance: Apartment):
         return create_links(instance)
 
     def validate_building(self, building: Building):
@@ -161,7 +162,8 @@ class ApartmentDetailSerializer(EnumSupportSerializerMixin, HitasModelSerializer
 
         return building
 
-    def validate_ownerships(self, ownerships: OrderedDict):
+    @staticmethod
+    def validate_ownerships(ownerships: OrderedDict):
         if not ownerships:
             return ownerships
 

--- a/backend/hitas/views/ownership.py
+++ b/backend/hitas/views/ownership.py
@@ -1,8 +1,29 @@
 from rest_framework import serializers
 
-from hitas.models import Ownership
-from hitas.views.person import PersonSerializer
-from hitas.views.utils import HitasDecimalField
+from hitas.models import Ownership, Person
+from hitas.views.utils import HitasDecimalField, UUIDRelatedField
+from hitas.views.utils.serializers import ReadOnlySerializer
+
+
+class PersonSerializer(ReadOnlySerializer):
+    id = UUIDRelatedField(queryset=Person.objects, source="uuid")
+
+    first_name = serializers.CharField(read_only=True)
+    last_name = serializers.CharField(read_only=True)
+    social_security_number = serializers.CharField(read_only=True)
+    email = serializers.CharField(read_only=True)
+
+    def get_model_class(self):
+        return Person
+
+    class Meta:
+        fields = [
+            "id",
+            "first_name",
+            "last_name",
+            "social_security_number",
+            "email",
+        ]
 
 
 class OwnershipSerializer(serializers.ModelSerializer):

--- a/backend/hitas/views/property_manager.py
+++ b/backend/hitas/views/property_manager.py
@@ -1,5 +1,9 @@
+import uuid
+
+from rest_framework import serializers
+
 from hitas.models import PropertyManager
-from hitas.views.utils import HitasModelSerializer, HitasModelViewSet, UUIDField
+from hitas.views.utils import HitasModelSerializer, HitasModelViewSet, UUIDRelatedField
 
 
 class PropertyManagerAddressSerializer(HitasModelSerializer):
@@ -21,12 +25,22 @@ class PropertyManagerSerializer(HitasModelSerializer):
         ]
 
 
-class ReadOnlyPropertyManagerSerializer(PropertyManagerSerializer):
-    id = UUIDField(source="uuid")
+class ReadOnlyPropertyManagerSerializer(serializers.Serializer):
+    id = UUIDRelatedField(queryset=PropertyManager.objects, source="uuid")
+    name = serializers.CharField(read_only=True)
+    email = serializers.CharField(read_only=True)
     address = PropertyManagerAddressSerializer(source="*", read_only=True)
 
-    class Meta(PropertyManagerSerializer.Meta):
-        read_only_fields = ["name", "email", "address"]
+    def to_internal_value(self, data):
+        super().to_internal_value(data)
+
+        try:
+            return PropertyManager.objects.only("id").get(uuid=uuid.UUID(hex=data["id"]))
+        except (PropertyManager.DoesNotExist, ValueError, TypeError):
+            return {}
+
+    class Meta:
+        fields = ["id", "name", "email", "address"]
 
 
 class PropertyManagerViewSet(HitasModelViewSet):

--- a/backend/hitas/views/utils/fields.py
+++ b/backend/hitas/views/utils/fields.py
@@ -74,7 +74,14 @@ class HitasEnumField(serializers.ChoiceField):
         return enum.value
 
     def to_internal_value(self, data: str):
+        if data == "":
+            raise serializers.ValidationError(code="blank")
+
         try:
             return self.enum_class(data)
         except ValueError:
-            raise serializers.ValidationError(f"Unsupported {self.enum_class.__name__} '{data}'.")
+            supported_values = [f"'{e.value}'" for e in self.enum_class]
+
+            raise serializers.ValidationError(
+                f"Unsupported value '{data}'. Supported values are: [{', '.join(supported_values)}]."
+            )

--- a/backend/hitas/views/utils/fields.py
+++ b/backend/hitas/views/utils/fields.py
@@ -2,6 +2,7 @@ from uuid import UUID
 
 from enumfields import Enum
 from rest_framework import serializers
+from rest_framework.fields import empty
 from rest_framework.relations import SlugRelatedField
 
 from hitas.exceptions import HitasModelNotFound
@@ -32,6 +33,12 @@ class UUIDField(serializers.Field):
 class UUIDRelatedField(SlugRelatedField):
     def __init__(self, **kwargs):
         super().__init__(slug_field="uuid", **kwargs)
+
+    def run_validation(self, data=empty):
+        if data == "":
+            raise serializers.ValidationError(code="blank")
+
+        return super().run_validation(data)
 
     def to_representation(self, obj):
         return getattr(obj, self.slug_field).hex


### PR DESCRIPTION
403722d: backend: config/settings: disable i18n
 - mainly for disabling API error message translations

---

49a52d5: backend: improve error messages when value is null vs blank
 - previously field error always contained "field x is required and cannot be blank".
   that did not make much sense for fields that are not strings (for
   example when numeric field was null).
 - now we mainly return "field x is required and cannot be null". when
   field is a string field and it's blank then we return the old version

---

c51011f: backend: improve error messages on enum fields
 - previously errornous values returned 1Unsupported <internal-enum-name> '<value>'.`
 - now message is 1Unsupported value '<value>'. Supported values are: ['<example-value-1>', '<example-value-2>'...].`

---

73eeeae: backend: hitas/views/apartment.py: don't translate error message

---

9ad29d9: backend: fix bug where apartment could be associated to any building
 - previously building could be any existing building from any housing
   company
 - there was a test for this but it was broken (id was invalid)
 - fix the test and add validation to check the building's housing company

---

b763b00: backend: improve error messages on related fields
 - instead of returning 404, return 400 and tell which field was
   errorneous in the `fields` with message `Object does not exist with given id '<value>'.`
 - add a lot of new checks to verify the functionality

---
