### PR TITLE
frontend: docker: add `/healthz` endpoint without authentication

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -2,6 +2,12 @@ server {
     listen      8080;
     charset     utf-8;
 
+    location /healthz {
+        access_log off;
+        default_type text/plain;
+        return 200 "OK\n";
+    }
+
     location / {
         auth_basic           "Hitas";
         auth_basic_user_file /usr/share/nginx/.htpasswd;


### PR DESCRIPTION
 - e0d3adbbac1eb7d1a2ebadb4e6cb8e8c79a423cc added basic auth to `/`. add `/healtz` endpoint without authentication to respond `200 OK` instead of `401 Unauthorized`