### PR TITLE
backend: validate query params

### DIFF
--- a/backend/hitas/exceptions.py
+++ b/backend/hitas/exceptions.py
@@ -216,7 +216,15 @@ def _convert_field_errors(field_name: str, errors: List[Dict[str, Any]]):
             retval.append({"field": formatted_field_name, "message": "This field is mandatory and cannot be null."})
         elif error["code"] in ["blank"]:
             retval.append({"field": formatted_field_name, "message": "This field is mandatory and cannot be blank."})
-        elif error["code"] in ["invalid", "invalid_choice", "min_value", "max_value", "unique"]:
+        elif error["code"] in [
+            "invalid",
+            "invalid_choice",
+            "min_value",
+            "max_value",
+            "unique",
+            "min_length",
+            "max_length",
+        ]:
             retval.append({"field": formatted_field_name, "message": error["message"]})
         else:
             raise Exception(f"Unhandled error code '{error['code']}'.")

--- a/backend/hitas/tests/apis/test_api_apartment_list.py
+++ b/backend/hitas/tests/apis/test_api_apartment_list.py
@@ -197,3 +197,64 @@ def test__api__apartment__filter(api_client: HitasAPIClient, selected_filter):
     response = api_client.get(url)
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert len(response.json()["contents"]) == 1, response.json()
+
+
+@pytest.mark.parametrize(
+    "selected_filter,fields",
+    [
+        (
+            {"housing_company_name": "aa"},
+            [{"field": "housing_company_name", "message": "Ensure this value has at least 3 characters (it has 2)."}],
+        ),
+        (
+            {"street_address": "aa"},
+            [{"field": "street_address", "message": "Ensure this value has at least 3 characters (it has 2)."}],
+        ),
+        (
+            {"postal_code": "abcde"},
+            [{"field": "postal_code", "message": "Enter a valid value."}],
+        ),
+        (
+            {"postal_code": "1234"},
+            [{"field": "postal_code", "message": "Enter a valid value."}],
+        ),
+        (
+            {"postal_code": "123456"},
+            [{"field": "postal_code", "message": "Enter a valid value."}],
+        ),
+        (
+            {"owner_name": "aa"},
+            [{"field": "owner_name", "message": "Ensure this value has at least 3 characters (it has 2)."}],
+        ),
+        (
+            {"owner_social_security_number": "1234567890"},
+            [
+                {
+                    "field": "owner_social_security_number",
+                    "message": "Ensure this value has at least 11 characters (it has 10).",
+                }
+            ],
+        ),
+        (
+            {"owner_social_security_number": "123456789012"},
+            [
+                {
+                    "field": "owner_social_security_number",
+                    "message": "Ensure this value has at most 11 characters (it has 12).",
+                }
+            ],
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test__api__apartment__filter__invalid_data(api_client: HitasAPIClient, selected_filter, fields):
+    url = reverse("hitas:apartment-list") + "?" + urlencode(selected_filter)
+    response = api_client.get(url)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.json() == {
+        "error": "bad_request",
+        "fields": fields,
+        "message": "Bad request",
+        "reason": "Bad Request",
+        "status": 400,
+    }

--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -696,3 +696,50 @@ def test__api__housing_company__filter(api_client: HitasAPIClient, selected_filt
     response = api_client.get(url)
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert len(response.json()["contents"]) == 1, response.json()
+
+
+@pytest.mark.parametrize(
+    "selected_filter,fields",
+    [
+        (
+            {"display_name": "aa"},
+            [{"field": "display_name", "message": "Ensure this value has at least 3 characters (it has 2)."}],
+        ),
+        (
+            {"street_address": "aa"},
+            [{"field": "street_address", "message": "Ensure this value has at least 3 characters (it has 2)."}],
+        ),
+        (
+            {"property_manager": "aa"},
+            [{"field": "property_manager", "message": "Ensure this value has at least 3 characters (it has 2)."}],
+        ),
+        (
+            {"developer": "aa"},
+            [{"field": "developer", "message": "Ensure this value has at least 3 characters (it has 2)."}],
+        ),
+        (
+            {"postal_code": "abcde"},
+            [{"field": "postal_code", "message": "Enter a valid value."}],
+        ),
+        (
+            {"postal_code": "1234"},
+            [{"field": "postal_code", "message": "Enter a valid value."}],
+        ),
+        (
+            {"postal_code": "123456"},
+            [{"field": "postal_code", "message": "Enter a valid value."}],
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test__api__housing_company__filter__invalid_data(api_client: HitasAPIClient, selected_filter, fields):
+    url = reverse("hitas:housing-company-list") + "?" + urlencode(selected_filter)
+    response = api_client.get(url)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.json() == {
+        "error": "bad_request",
+        "fields": fields,
+        "message": "Bad request",
+        "reason": "Bad Request",
+        "status": 400,
+    }

--- a/backend/hitas/views/apartment_list.py
+++ b/backend/hitas/views/apartment_list.py
@@ -1,5 +1,4 @@
 from django.db.models import Q
-from django_filters.rest_framework import filters
 from enumfields.drf import EnumSupportSerializerMixin
 from rest_framework import mixins, serializers, viewsets
 
@@ -7,17 +6,26 @@ from hitas.models import Apartment
 from hitas.models.apartment import ApartmentState
 from hitas.views.apartment import ApartmentHitasAddressSerializer, create_links
 from hitas.views.ownership import OwnershipSerializer
-from hitas.views.utils import HitasDecimalField, HitasEnumField, HitasFilterSet, HitasModelMixin, HitasModelSerializer
+from hitas.views.utils import (
+    HitasCharFilter,
+    HitasDecimalField,
+    HitasEnumField,
+    HitasFilterSet,
+    HitasModelMixin,
+    HitasModelSerializer,
+    HitasPostalCodeFilter,
+)
+from hitas.views.utils.filters import HitasSSNFilter
 
 
 class ApartmentFilterSet(HitasFilterSet):
-    housing_company_name = filters.CharFilter(
+    housing_company_name = HitasCharFilter(
         field_name="building__real_estate__housing_company__display_name", lookup_expr="icontains"
     )
-    street_address = filters.CharFilter(lookup_expr="icontains")
-    postal_code = filters.CharFilter(field_name="building__real_estate__housing_company__postal_code__value")
-    owner_name = filters.CharFilter(method="owner_name_filter")
-    owner_social_security_number = filters.CharFilter(
+    street_address = HitasCharFilter(lookup_expr="icontains")
+    postal_code = HitasPostalCodeFilter(field_name="building__real_estate__housing_company__postal_code__value")
+    owner_name = HitasCharFilter(method="owner_name_filter")
+    owner_social_security_number = HitasSSNFilter(
         field_name="ownerships__owner__social_security_number", lookup_expr="icontains"
     )
 

--- a/backend/hitas/views/housing_company.py
+++ b/backend/hitas/views/housing_company.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional
 
 from django.db.models import F, IntegerField, Min, Prefetch, Sum
 from django.db.models.functions import Round
-from django_filters.rest_framework import filters
 from enumfields.drf.serializers import EnumSupportSerializerMixin
 from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
@@ -19,21 +18,23 @@ from hitas.views.property_manager import ReadOnlyPropertyManagerSerializer
 from hitas.views.real_estate import RealEstateSerializer
 from hitas.views.utils import (
     HitasAddressSerializer,
+    HitasCharFilter,
     HitasDecimalField,
     HitasEnumField,
     HitasFilterSet,
     HitasModelSerializer,
     HitasModelViewSet,
+    HitasPostalCodeFilter,
     ValueOrNullField,
 )
 
 
 class HousingCompanyFilterSet(HitasFilterSet):
-    display_name = filters.CharFilter(lookup_expr="icontains")
-    street_address = filters.CharFilter(lookup_expr="icontains")
-    postal_code = filters.CharFilter(field_name="postal_code__value")
-    property_manager = filters.CharFilter(field_name="property_manager__name", lookup_expr="icontains")
-    developer = filters.CharFilter(field_name="developer__value", lookup_expr="icontains")
+    display_name = HitasCharFilter(lookup_expr="icontains")
+    street_address = HitasCharFilter(lookup_expr="icontains")
+    postal_code = HitasPostalCodeFilter(field_name="postal_code__value")
+    property_manager = HitasCharFilter(field_name="property_manager__name", lookup_expr="icontains")
+    developer = HitasCharFilter(field_name="developer__value", lookup_expr="icontains")
 
     class Meta:
         model = HousingCompany

--- a/backend/hitas/views/utils/__init__.py
+++ b/backend/hitas/views/utils/__init__.py
@@ -6,7 +6,13 @@ from hitas.views.utils.fields import (
     UUIDRelatedField,
     ValueOrNullField,
 )
-from hitas.views.utils.filters import HitasFilterBackend, HitasFilterSet, HitasUUIDFilter
+from hitas.views.utils.filters import (
+    HitasCharFilter,
+    HitasFilterBackend,
+    HitasFilterSet,
+    HitasPostalCodeFilter,
+    HitasUUIDFilter,
+)
 from hitas.views.utils.paginator import HitasPagination
 from hitas.views.utils.serializers import AddressSerializer, HitasAddressSerializer, HitasModelSerializer
 from hitas.views.utils.viewsets import HitasModelMixin, HitasModelViewSet

--- a/backend/hitas/views/utils/filters.py
+++ b/backend/hitas/views/utils/filters.py
@@ -1,9 +1,10 @@
 from copy import deepcopy
 from uuid import UUID
 
+from django.core.validators import RegexValidator
 from django_filters import CharFilter
 from django_filters.constants import EMPTY_VALUES
-from django_filters.rest_framework import DjangoFilterBackend, FilterSet, filterset
+from django_filters.rest_framework import DjangoFilterBackend, FilterSet, filters, filterset
 
 # By default exact matches are used
 # Set a lookup expression for all text-type fields
@@ -17,6 +18,25 @@ for (field_class, filter_class) in FILTER_FOR_DBFIELD_DEFAULTS.items():
 
 class HitasFilterSet(FilterSet):
     FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS
+
+
+class HitasCharFilter(filters.CharFilter):
+    def __init__(self, *args, **kwargs):
+        kwargs["min_length"] = 3
+        super().__init__(*args, **kwargs)
+
+
+class HitasPostalCodeFilter(filters.CharFilter):
+    def __init__(self, *args, **kwargs):
+        kwargs["validators"] = [RegexValidator(r"^\d{5}$")]
+        super().__init__(*args, **kwargs)
+
+
+class HitasSSNFilter(filters.CharFilter):
+    def __init__(self, *args, **kwargs):
+        kwargs["min_length"] = 11
+        kwargs["max_length"] = 11
+        super().__init__(*args, **kwargs)
 
 
 class HitasFilterBackend(DjangoFilterBackend):

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -19,6 +19,7 @@ paths:
           in: query
           schema:
             type: string
+            minLength: 3
             example: helmi
         - name: street_address
           description: Search housing companies with street address containing the given search string (case-insensitive)
@@ -26,6 +27,7 @@ paths:
           in: query
           schema:
             type: string
+            minLength: 3
             example: Hannunkatu
         - name: postal_code
           description: Search housing companies located in given postal code
@@ -33,6 +35,7 @@ paths:
           in: query
           schema:
             type: string
+            pattern: '^\d{5}$'
             example: "00100"
         - name: developer
           description: Search housing companies with developer name containing the given search string (case-insensitive)
@@ -40,6 +43,7 @@ paths:
           in: query
           schema:
             type: string
+            minLength: 5
             example: Rakennuttaja
         - name: property_manager
           description: Search housing companies with property manager name matching to the given search string (case-insensitive)
@@ -47,6 +51,7 @@ paths:
           in: query
           schema:
             type: string
+            minLength: 5
             example: isännöinti
       responses:
         '200':
@@ -836,6 +841,7 @@ paths:
           in: query
           schema:
             type: string
+            minLength: 3
             example: helmi
         - name: street_address
           description: Search apartments with street address containing the given search string (case-insensitive)
@@ -843,6 +849,7 @@ paths:
           in: query
           schema:
             type: string
+            minLength: 3
             example: Hannunkatu
         - name: postal_code
           description: Search apartments located in given postal code
@@ -850,6 +857,7 @@ paths:
           in: query
           schema:
             type: string
+            pattern: '^\d{5}$'
             example: "00100"
         - name: owner_name
           description: Search apartments whose owner first name or last name contains the given search string (case-insensitive)
@@ -857,6 +865,7 @@ paths:
           in: query
           schema:
             type: string
+            minLength: 3
             example: matti
         - name: owner_social_security_number
           description: Search apartments whose social security number matches the given search string (case-insensitive)
@@ -864,6 +873,8 @@ paths:
           in: query
           schema:
             type: string
+            minLength: 11
+            maxLength: 11
             example: 131052-308T
       responses:
         '200':


### PR DESCRIPTION
 - OpenAPI: define query parameters constraints (min length, patterns...)
 - add validation to query parameters
  - min length is always 3
  - postal codes has to have 5 digits
  - ssn is always 11 chars