### PR TITLE
API searches documented

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -104,8 +104,11 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
 }
 
-# Disable browseable API renderer if DEBUG is not set
-if not DEBUG:
+if DEBUG:
+    # Enable session authentication for browseable API renderer
+    REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"].append("rest_framework.authentication.SessionAuthentication")
+else:
+    # Disable browseable API renderer if DEBUG is not set
     REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] = ("rest_framework.renderers.JSONRenderer",)
 
 TEMPLATES = [

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
 if settings.DEBUG_TOOLBAR:
     urlpatterns += [
         path("__debug__/", include("debug_toolbar.urls")),
+        path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     ]
 
 handler404 = "hitas.error_handlers.handle_404"

--- a/backend/hitas/tests/apis/test_api_apartment_list.py
+++ b/backend/hitas/tests/apis/test_api_apartment_list.py
@@ -174,6 +174,7 @@ def test__api__apartment__list(api_client: HitasAPIClient):
         {"owner_name": "megatr"},
         {"owner_name": "etimus pri"},
         {"owner_social_security_number": "010199-123A"},
+        {"owner_social_security_number": "010199-123a"},
     ],
 )
 @pytest.mark.django_db

--- a/backend/hitas/tests/apis/test_api_building.py
+++ b/backend/hitas/tests/apis/test_api_building.py
@@ -2,7 +2,6 @@ import uuid
 
 import pytest
 from django.urls import reverse
-from django.utils.http import urlencode
 from rest_framework import status
 
 from hitas.models import Apartment, Building, HousingCompany, RealEstate
@@ -368,37 +367,3 @@ def test__api__building__delete__with_references(api_client: HitasAPIClient):
 
     response = api_client.get(url)
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
-
-
-# Filter tests
-
-
-@pytest.mark.parametrize(
-    "selected_filter",
-    [
-        {"building_identifier": "100012345"},
-        {"building_identifier": "1000"},
-        {"building_identifier": "12345"},
-        {"street_address": "test-street"},
-    ],
-)
-@pytest.mark.django_db
-def test__api__building__filter(api_client: HitasAPIClient, selected_filter):
-    bu: Building = BuildingFactory.create()
-    BuildingFactory.create(building_identifier="100012345A", real_estate=bu.real_estate)
-    BuildingFactory.create(street_address="test-street", real_estate=bu.real_estate)
-
-    url = (
-        reverse(
-            "hitas:building-list",
-            kwargs={
-                "housing_company_uuid": bu.real_estate.housing_company.uuid.hex,
-                "real_estate_uuid": bu.real_estate.uuid.hex,
-            },
-        )
-        + "?"
-        + urlencode(selected_filter)
-    )
-    response = api_client.get(url)
-    assert response.status_code == status.HTTP_200_OK, response.json()
-    assert len(response.json()["contents"]) == 1, response.json()

--- a/backend/hitas/tests/apis/test_api_codes.py
+++ b/backend/hitas/tests/apis/test_api_codes.py
@@ -196,15 +196,12 @@ def test__api__code__delete(api_client: HitasAPIClient, url_basename, model, fac
     "selected_filter,result_count",
     [
         [{"value": "TestN"}, 1],
-        [{"description": "TestD"}, 1],
-        [{"code": "111"}, 1],
-        [{"code": "11"}, 0],
+        [{"value": "testn"}, 1],
     ],
 )
 @pytest.mark.django_db
 def test__api__code__filter(api_client: HitasAPIClient, url_basename, model, factory, selected_filter, result_count):
     factory.create(legacy_code_number="111", value="TestName")
-    factory.create(legacy_code_number="112", value="Second Code", description="TestDescription")
     factory.create(legacy_code_number="113", value="123")
 
     url = reverse(f"hitas:{url_basename}-list") + "?" + urlencode(selected_filter)

--- a/backend/hitas/tests/apis/test_api_person.py
+++ b/backend/hitas/tests/apis/test_api_person.py
@@ -102,7 +102,7 @@ def get_person_create_data() -> dict[str, Any]:
         "first_name": "fake-first-name",
         "last_name": "fake-last-name",
         "social_security_number": "010199-123Y",
-        "email": "test@hitas.com",
+        "email": "hitas@example.com",
     }
 
 
@@ -155,7 +155,7 @@ def test__api__person__update(api_client: HitasAPIClient):
         "first_name": "Matti Matias",
         "last_name": "Meikäläinen",
         "social_security_number": "010199-123Y",
-        "email": "test@hitas.com",
+        "email": "test@example.com",
     }
 
     url = reverse("hitas:person-detail", kwargs={"uuid": person.uuid.hex})
@@ -194,11 +194,13 @@ def test__api__person__delete(api_client: HitasAPIClient):
 @pytest.mark.parametrize(
     "selected_filter",
     [
-        {"first_name": "fake-first"},
-        {"first_name": "first-name"},
-        {"last_name": "fake-last"},
+        {"name": "fake-first"},
+        {"name": "first-name"},
+        {"name": "fake-last"},
         {"social_security_number": "010199-123Y"},
-        {"email": "hitas"},
+        {"social_security_number": "010199-123y"},
+        {"email": "hitas@example.com"},
+        {"email": "HITAS@EXAMPLE.com"},
     ],
 )
 @pytest.mark.django_db

--- a/backend/hitas/tests/apis/test_api_property_manager.py
+++ b/backend/hitas/tests/apis/test_api_property_manager.py
@@ -212,11 +212,6 @@ def test__api__property_manager__delete(api_client: HitasAPIClient):
         {"name": "TestN"},
         {"name": "testname"},
         {"name": "stNa"},
-        {"email": "test@hitas.com"},
-        {"email": "hitas.com"},
-        {"street_address": "test-street"},
-        {"postal_code": "99999"},
-        {"city": "test-city"},
     ],
 )
 @pytest.mark.django_db

--- a/backend/hitas/tests/apis/test_api_real_estate.py
+++ b/backend/hitas/tests/apis/test_api_real_estate.py
@@ -1,6 +1,5 @@
 import pytest
 from django.urls import reverse
-from django.utils.http import urlencode
 from rest_framework import status
 
 from hitas.models import Apartment, Building, HousingCompany, RealEstate
@@ -276,30 +275,3 @@ def test__api__real_estate__delete__with_references(api_client: HitasAPIClient):
 
     response = api_client.get(url)
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
-
-
-# Filter tests
-
-
-@pytest.mark.parametrize(
-    "selected_filter",
-    [
-        {"property_identifier": "1-1234-321-56"},
-        {"property_identifier": "1-1234-"},
-        {"property_identifier": "321-56"},
-        {"street_address": "test-street"},
-    ],
-)
-@pytest.mark.django_db
-def test__api__real_estate__filter(api_client: HitasAPIClient, selected_filter):
-    re: RealEstate = RealEstateFactory.create(property_identifier="1-1234-321-56")
-    RealEstateFactory.create(street_address="test-street", housing_company=re.housing_company)
-
-    url = (
-        reverse("hitas:real-estate-list", kwargs={"housing_company_uuid": re.housing_company.uuid.hex})
-        + "?"
-        + urlencode(selected_filter)
-    )
-    response = api_client.get(url)
-    assert response.status_code == status.HTTP_200_OK, response.json()
-    assert len(response.json()["contents"]) == 1, response.json()

--- a/backend/hitas/views/apartment_list.py
+++ b/backend/hitas/views/apartment_list.py
@@ -14,8 +14,8 @@ from hitas.views.utils import (
     HitasModelMixin,
     HitasModelSerializer,
     HitasPostalCodeFilter,
+    HitasSSNFilter,
 )
-from hitas.views.utils.filters import HitasSSNFilter
 
 
 class ApartmentFilterSet(HitasFilterSet):
@@ -26,7 +26,7 @@ class ApartmentFilterSet(HitasFilterSet):
     postal_code = HitasPostalCodeFilter(field_name="building__real_estate__housing_company__postal_code__value")
     owner_name = HitasCharFilter(method="owner_name_filter")
     owner_social_security_number = HitasSSNFilter(
-        field_name="ownerships__owner__social_security_number", lookup_expr="icontains"
+        field_name="ownerships__owner__social_security_number", lookup_expr="iexact"
     )
 
     def owner_name_filter(self, queryset, name, value):

--- a/backend/hitas/views/codes.py
+++ b/backend/hitas/views/codes.py
@@ -1,8 +1,7 @@
-from django_filters.rest_framework import filters
 from rest_framework import serializers
 
 from hitas.models.codes import AbstractCode, ApartmentType, BuildingType, Developer, FinancingMethod
-from hitas.views.utils import HitasFilterSet, HitasModelSerializer, HitasModelViewSet, UUIDRelatedField
+from hitas.views.utils import HitasCharFilter, HitasFilterSet, HitasModelSerializer, HitasModelViewSet, UUIDRelatedField
 from hitas.views.utils.serializers import ReadOnlySerializer
 
 
@@ -66,11 +65,11 @@ class AbstractCodeViewSet(HitasModelViewSet):
 
     def get_filterset_class(self):
         class CodeFilterSet(HitasFilterSet):
-            code = filters.CharFilter(field_name="legacy_code_number", lookup_expr="exact")
+            value = HitasCharFilter(lookup_expr="icontains")
 
             class Meta:
                 model = self.model_class
-                fields = ["value", "description", "code"]
+                fields = ["value"]
 
         CodeFilterSet.__name__ = f"{self.model_class}FilterSet"
 

--- a/backend/hitas/views/person.py
+++ b/backend/hitas/views/person.py
@@ -1,5 +1,7 @@
+from django.db.models import Q
+
 from hitas.models import Person
-from hitas.views.utils import HitasModelSerializer, HitasModelViewSet
+from hitas.views.utils import HitasCharFilter, HitasFilterSet, HitasModelSerializer, HitasModelViewSet, HitasSSNFilter
 
 
 class PersonSerializer(HitasModelSerializer):
@@ -14,9 +16,25 @@ class PersonSerializer(HitasModelSerializer):
         ]
 
 
+class PersonFilterSet(HitasFilterSet):
+    name = HitasCharFilter(method="name_filter")
+    social_security_number = HitasSSNFilter(lookup_expr="iexact")
+    email = HitasCharFilter(lookup_expr="iexact")
+
+    def name_filter(self, queryset, name, value):
+        return queryset.filter(Q(first_name__icontains=value) | Q(last_name__icontains=value))
+
+    class Meta:
+        model = Person
+        fields = ["name", "social_security_number", "email"]
+
+
 class PersonViewSet(HitasModelViewSet):
     serializer_class = PersonSerializer
     model_class = Person
 
     def get_queryset(self):
         return Person.objects.all().order_by("id")
+
+    def get_filterset_class(self):
+        return PersonFilterSet

--- a/backend/hitas/views/property_manager.py
+++ b/backend/hitas/views/property_manager.py
@@ -3,13 +3,21 @@ import uuid
 from rest_framework import serializers
 
 from hitas.models import PropertyManager
-from hitas.views.utils import HitasModelSerializer, HitasModelViewSet, UUIDRelatedField
+from hitas.views.utils import HitasCharFilter, HitasFilterSet, HitasModelSerializer, HitasModelViewSet, UUIDRelatedField
 
 
 class PropertyManagerAddressSerializer(HitasModelSerializer):
     class Meta:
         model = PropertyManager
         fields = ["street_address", "postal_code", "city"]
+
+
+class PropertyManagerFilterSet(HitasFilterSet):
+    name = HitasCharFilter(lookup_expr="icontains")
+
+    class Meta:
+        model = PropertyManager
+        fields = ["name"]
 
 
 class PropertyManagerSerializer(HitasModelSerializer):
@@ -49,3 +57,6 @@ class PropertyManagerViewSet(HitasModelViewSet):
 
     def get_queryset(self):
         return PropertyManager.objects.all().order_by("id")
+
+    def get_filterset_class(self):
+        return PropertyManagerFilterSet

--- a/backend/hitas/views/utils/__init__.py
+++ b/backend/hitas/views/utils/__init__.py
@@ -11,6 +11,7 @@ from hitas.views.utils.filters import (
     HitasFilterBackend,
     HitasFilterSet,
     HitasPostalCodeFilter,
+    HitasSSNFilter,
     HitasUUIDFilter,
 )
 from hitas.views.utils.paginator import HitasPagination

--- a/backend/hitas/views/utils/viewsets.py
+++ b/backend/hitas/views/utils/viewsets.py
@@ -1,12 +1,10 @@
 from uuid import UUID
 
-from django.db import models
 from django.http import Http404
-from django_filters.rest_framework import filters
 from rest_framework import viewsets
 
 from hitas.exceptions import HitasModelNotFound
-from hitas.views.utils import HitasFilterSet, HitasPagination
+from hitas.views.utils import HitasPagination
 
 
 class HitasModelMixin:
@@ -55,26 +53,6 @@ class HitasModelMixin:
             return model_class.objects.only("id").get(uuid=uuid, **kwargs).id
         except model_class.DoesNotExist:
             raise HitasModelNotFound(model=model_class)
-
-    def get_filterset_class(self):
-        """Automagically generate a Filter Set class for subclassing ViewSets"""
-
-        class HitasModelFilterSet(HitasFilterSet):
-
-            if (
-                hasattr(self.model_class, "postal_code")
-                and hasattr(self.model_class.postal_code, "field")
-                and self.model_class.postal_code.field.__class__ == models.ForeignKey
-            ):
-                postal_code = filters.CharFilter(field_name="postal_code__value")
-
-            class Meta:
-                model = self.model_class
-                fields = "__all__"
-
-        HitasModelFilterSet.__name__ = f"{self.model_class}FilterSet"
-
-        return HitasModelFilterSet
 
 
 class HitasModelViewSet(HitasModelMixin, viewsets.ModelViewSet):

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1102,6 +1102,14 @@ paths:
       tags:
         - Property managers
       parameters:
+        - name: name
+          description: Search property managers with name containing the given search string (case-insensitive)
+          required: false
+          in: query
+          schema:
+            type: string
+            minLength: 3
+            example: Matti
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
       responses:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1273,6 +1273,14 @@ paths:
       tags:
         - Developers
       parameters:
+        - name: value
+          description: Search developers with value containing the given search string (case-insensitive)
+          required: false
+          in: query
+          schema:
+            type: string
+            minLength: 3
+            example: Sato
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
       responses:
@@ -1595,6 +1603,14 @@ paths:
       tags:
         - Building types
       parameters:
+        - name: value
+          description: Search building types with value containing the given search string (case-insensitive)
+          required: false
+          in: query
+          schema:
+            type: string
+            minLength: 3
+            example: kerrostalo
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
       responses:
@@ -1756,6 +1772,14 @@ paths:
       tags:
         - Financing methods
       parameters:
+        - name: value
+          description: Search financing methods with value containing the given search string (case-insensitive)
+          required: false
+          in: query
+          schema:
+            type: string
+            minLength: 3
+            example: Hitas II
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
       responses:
@@ -1917,6 +1941,14 @@ paths:
       tags:
         - Apartment types
       parameters:
+        - name: value
+          description: Search apartment types with value containing the given search string (case-insensitive)
+          required: false
+          in: query
+          schema:
+            type: string
+            minLength: 3
+            example: h+kk
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
       responses:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -916,6 +916,31 @@ paths:
       tags:
         - Persons
       parameters:
+        - name: name
+          description: Search persons with first name or last name containing the given search string (case-insensitive)
+          required: false
+          in: query
+          schema:
+            type: string
+            minLength: 3
+            example: Matti
+        - name: social_security_number
+          description: Search persons whose social security number matches the given search string (case-insensitive)
+          required: false
+          in: query
+          schema:
+            type: string
+            minLength: 11
+            maxLength: 11
+            example: 131052-308T
+        - name: email
+          description: Search persons whose email address matches the given search string (case-insensitive)
+          required: false
+          in: query
+          schema:
+            type: string
+            minLength: 3
+            example: matti.meikalainen@example.com
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
       responses:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -141,6 +141,7 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
     put:
       description: Update a housing company
       operationId: update-housing-company
@@ -750,6 +751,7 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
     put:
       description: Update an apartment
       operationId: update-apartment
@@ -1004,6 +1006,7 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
     put:
       description: Update a person
       operationId: update-person
@@ -1164,6 +1167,7 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
     put:
       description: Update a property manager
       operationId: update-property-manager
@@ -1326,6 +1330,7 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
     put:
       description: Update a developer
       operationId: update-developer
@@ -1486,6 +1491,7 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
     put:
       description: Update a postal code
       operationId: update-postal-code
@@ -1646,6 +1652,7 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
     put:
       description: Update a building type
       operationId: update-building-type
@@ -1806,6 +1813,7 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
     put:
       description: Update a financing method
       operationId: update-financing-method
@@ -1966,6 +1974,7 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+
     put:
       description: Update an apartment type
       operationId: update-apartment-type
@@ -2090,12 +2099,12 @@ components:
               description: Link to next page
               type: string
               nullable: true
-              example: 'http://example.com/api/v1/housing-companies?page=4'
+              example: 'https://example.com/api/v1/housing-companies?page=4'
             previous:
               description: Link to previous page
               type: string
               nullable: true
-              example: 'http://example.com/api/v1/housing-companies?page=2'
+              example: 'https://example.com/api/v1/housing-companies?page=2'
       required:
         - size
         - total_items


### PR DESCRIPTION
e360dc7: backend: fix browseable API by enable session authentication
 - it's only enabled when `DEBUG=true`

---

e284cba: backend: OpenAPI: trivial improvements
 - use secure links in examples

---

5bb4b2f: backend: search apartments by ssn: only allow exact matches
 - this is how the API is documented so fix it by only allowing exact
   matches

---

3e3ae2b: backend: document and implement person searches
 - person search query parameters has now been documented. fields are:
   - `name`
   - `social_security_number`
   - `email`
 - previous, undocumented implementation supported `first_name` and
   `last_name` but this has been dropped and now works similar to
   apartment search query `owner_name`

---

888601c: backend: document and implement property manager searches
 - property manager search query parameters has now been documented.
   Only field is `name`
 - previous, undocumented implementation supported `email`,
   `street_address`, `postal_code` and `city` but support for these has
   been dropped

---

77987be: backend: document and implement code searches
 - code search query parameters has now been documented. Only field is
   `value`. This applies to apartment types, developers, financing
   methods and building types
 - previous, undocumented implementation supported `description` and
   `code` but support for these has been dropped

---

3511838: backend: remove support for searching by any field by default
 - `HitasModelMixin` implemented generic `HitasModelFilterSet`
   which allowed to search by any model field. This has been
   now disabled. All query parameters have been documented
   and each model needs to implement their own versions
   of it
 - This removes (unused and undocumented) all support for
   filtering buildings / real estates

---
