### PR TITLE
backend: fix updating housing companies without changing the names

### DIFF
--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -635,6 +635,35 @@ def test__api__housing_company__update(api_client: HitasAPIClient):
     assert response.json() == get_response.json()
 
 
+@pytest.mark.django_db
+def test__api__housing_company__update__no_changes(api_client: HitasAPIClient):
+    hc: HousingCompany = HousingCompanyFactory.create()
+
+    data = {
+        "acquisition_price": {"initial": hc.acquisition_price, "realized": hc.realized_acquisition_price},
+        "address": {
+            "street_address": hc.street_address,
+            "postal_code": hc.postal_code.value,
+        },
+        "building_type": {"id": hc.building_type.uuid.hex},
+        "business_id": hc.business_id,
+        "developer": {"id": hc.developer.uuid.hex},
+        "financing_method": {"id": hc.financing_method.uuid.hex},
+        "name": {
+            "display": hc.display_name,
+            "official": hc.official_name,
+        },
+        "notes": hc.notes,
+        "primary_loan": hc.primary_loan,
+        "property_manager": {"id": hc.property_manager.uuid.hex},
+        "state": hc.state.value,
+        "sales_price_catalogue_confirmation_date": hc.sales_price_catalogue_confirmation_date,
+    }
+
+    response = api_client.put(reverse("hitas:housing-company-detail", args=[hc.uuid.hex]), data=data, format="json")
+    assert response.status_code == status.HTTP_200_OK, response.json()
+
+
 # Delete tests
 
 

--- a/backend/hitas/views/housing_company.py
+++ b/backend/hitas/views/housing_company.py
@@ -5,7 +5,7 @@ from django.db.models import F, IntegerField, Min, Prefetch, Sum
 from django.db.models.functions import Round
 from enumfields.drf.serializers import EnumSupportSerializerMixin
 from rest_framework import serializers
-from rest_framework.validators import UniqueValidator
+from rest_framework.exceptions import ValidationError
 
 from hitas.models import HousingCompany, HousingCompanyState, RealEstate
 from hitas.utils import safe_attrgetter
@@ -41,24 +41,31 @@ class HousingCompanyFilterSet(HitasFilterSet):
         fields = ["display_name", "street_address", "postal_code", "property_manager", "developer"]
 
 
-class HitasUniqueValidator(UniqueValidator):
-    def __init__(self, queryset, field, message=None, lookup="exact"):
-        self.field = field
-        super().__init__(queryset, message=message, lookup=lookup)
-
-    def __call__(self, value, serializer_field):
-        self.message = f"{self.field} provided is already in use. Conflicting {self.field.lower()}: '{value}'."
-        super().__call__(value, serializer_field)
-
-
 class HousingCompanyNameSerializer(serializers.Serializer):
-    display = serializers.CharField(
-        source="display_name", validators=[HitasUniqueValidator(queryset=HousingCompany.objects, field="Display name")]
-    )
-    official = serializers.CharField(
-        source="official_name",
-        validators=[HitasUniqueValidator(queryset=HousingCompany.objects, field="Official name")],
-    )
+    display = serializers.CharField(source="display_name")
+    official = serializers.CharField(source="official_name")
+
+    def _validate_qs(self):
+        qs = HousingCompany.objects
+        if self.parent.instance:
+            qs = qs.exclude(id=self.parent.instance.id)
+        return qs
+
+    def validate_display(self, value):
+        if self._validate_qs().filter(display_name=value).exists():
+            raise ValidationError(
+                f"Display name provided is already in use. Conflicting display name: '{value}'.", code="unique"
+            )
+
+        return value
+
+    def validate_official(self, value):
+        if self._validate_qs().filter(official_name=value).exists():
+            raise ValidationError(
+                f"Official name provided is already in use. Conflicting official name: '{value}'.", code="unique"
+            )
+
+        return value
 
 
 class HousingCompanyAcquisitionPriceSerializer(serializers.Serializer):


### PR DESCRIPTION
 - previously updating an existing housing company without changing housing company's display name or official name failed due to duplicate check that did not take into account current instance is being updated with the same name

 - UniqueValidator cannot be used without more heavy modifications due to the fact that it will always check `<field>.instance` and we need to check `<field>.parent.instance`