### PR TITLE
OpenAPI request validation

### DIFF
--- a/backend/hitas/tests/apis/helpers.py
+++ b/backend/hitas/tests/apis/helpers.py
@@ -10,7 +10,6 @@ from openapi_core.unmarshalling.schemas import oas30_request_schema_unmarshaller
 from openapi_core.validation.request.protocols import Request
 from openapi_core.validation.request.validators import RequestValidator
 from openapi_core.validation.response import openapi_response_validator
-from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
@@ -41,10 +40,6 @@ def validate_openapi(
 
     if not validate_request and not validate_response:
         return
-
-    # Add the `Content-Type` key to response, so DjangoOpenAPIResponseFactory doesn't crash on DELETE requests
-    if response.status_code == status.HTTP_204_NO_CONTENT:
-        response["Content-Type"] = None
 
     # Validate request
     if validate_request:

--- a/backend/hitas/tests/apis/helpers.py
+++ b/backend/hitas/tests/apis/helpers.py
@@ -2,8 +2,13 @@ from typing import Optional
 
 import yaml
 from django.conf import settings
+from django.core.handlers.wsgi import WSGIRequest
 from openapi_core import Spec
 from openapi_core.contrib.django import DjangoOpenAPIRequest, DjangoOpenAPIResponse
+from openapi_core.templating.paths.datatypes import ServerOperationPath
+from openapi_core.unmarshalling.schemas import oas30_request_schema_unmarshallers_factory
+from openapi_core.validation.request.protocols import Request
+from openapi_core.validation.request.validators import RequestValidator
 from openapi_core.validation.response import openapi_response_validator
 from rest_framework import status
 from rest_framework.response import Response
@@ -13,20 +18,64 @@ with open(f"{settings.BASE_DIR}/openapi.yaml", "r") as spec_file:
     _openapi_spec = Spec.create(yaml.safe_load(spec_file))
 
 
-def validate_openapi(response: Response) -> None:
+class WSGIRequestWorkaround:
+    """
+    Body is only readable once so keep a copy of it for validation purposes. DRF reads it once before us
+    """
+
+    def __init__(self, r: WSGIRequest, request_body: str):
+        self.r = r
+        self.request_body = request_body
+
+    def __getattr__(self, item):
+        if item == "body":
+            return self.request_body
+
+        return getattr(self.r, item)
+
+
+def validate_openapi(
+    request_body: str, response: Response, validate_request: bool = True, validate_response: bool = True
+) -> None:
     global _openapi_spec
+
+    if not validate_request and not validate_response:
+        return
 
     # Add the `Content-Type` key to response, so DjangoOpenAPIResponseFactory doesn't crash on DELETE requests
     if response.status_code == status.HTTP_204_NO_CONTENT:
         response["Content-Type"] = None
 
-    result = openapi_response_validator.validate(
-        _openapi_spec,
-        OpenAPIUrlPatternWorkaround(response.wsgi_request),
-        DjangoOpenAPIResponse(response),
-    )
+    # Validate request
+    if validate_request:
+        result = RequestValidatorWorkaround(
+            schema_unmarshallers_factory=oas30_request_schema_unmarshallers_factory
+        ).validate(
+            _openapi_spec, OpenAPIUrlPatternWorkaround(WSGIRequestWorkaround(response.wsgi_request, request_body))
+        )
 
-    result.raise_for_errors()
+        result.raise_for_errors()
+
+    # Validate response
+    if validate_response:
+        result = openapi_response_validator.validate(
+            _openapi_spec,
+            OpenAPIUrlPatternWorkaround(response.wsgi_request),
+            DjangoOpenAPIResponse(response),
+        )
+        result.raise_for_errors()
+
+
+class RequestValidatorWorkaround(RequestValidator):
+    def _find_path(self, spec: Spec, request: Request, base_url: Optional[str] = None) -> ServerOperationPath:
+        result = super()._find_path(spec, request, base_url)
+
+        # Workaround
+        for k, v in result[3].variables.items():
+            if k not in request.parameters.path:
+                request.parameters.path[k] = v
+
+        return result
 
 
 class OpenAPIUrlPatternWorkaround(DjangoOpenAPIRequest):
@@ -58,11 +107,24 @@ class OpenAPIUrlPatternWorkaround(DjangoOpenAPIRequest):
 
 class HitasAPIClient(APIClient):
     def generic(
-        self, method, path, data="", content_type="json", secure=False, openapi_validate=True, **kwargs
+        self,
+        method,
+        path,
+        data="",
+        content_type="json",
+        secure=False,
+        openapi_validate=True,
+        openapi_validate_request=True,
+        openapi_validate_response=True,
+        **kwargs,
     ) -> Response:
         response: Response = super().generic(method, path, data, content_type, secure=False, **kwargs)
 
-        if openapi_validate:
-            validate_openapi(response)
+        validate_openapi(
+            data,
+            response,
+            openapi_validate and openapi_validate_request,
+            openapi_validate and openapi_validate_response,
+        )
 
         return response

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -945,6 +945,7 @@ def test__api__apartment__create__invalid_data(api_client: HitasAPIClient, inval
         ),
         data=data,
         format="json",
+        openapi_validate_request=False,
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert response.json() == {

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -459,7 +459,7 @@ def test__api__apartment__create(api_client: HitasAPIClient, minimal_data: bool)
                 },
             }
         )
-        del data["shares"]
+        data["shares"] = None
         del data["prices"]
 
     response = api_client.post(
@@ -1002,8 +1002,6 @@ def test__api__apartment__update__clear_ownerships_and_improvements(api_client: 
         },
         "address": {
             "street_address": "TestStreet 3",
-            "postal_code": ap.building.real_estate.housing_company.postal_code.value,
-            "city": "Helsinki",
             "apartment_number": 9,
             "floor": "5",
             "stair": "X",
@@ -1024,6 +1022,7 @@ def test__api__apartment__update__clear_ownerships_and_improvements(api_client: 
         "notes": "Test Notes",
         "building": ap.building.uuid.hex,
         "ownerships": [],
+        "completion_date": None,
         "improvements": {
             "construction_price_index": [],
             "market_price_index": [],
@@ -1047,8 +1046,6 @@ def test__api__apartment__update__clear_ownerships_and_improvements(api_client: 
     assert ap.share_number_start == data["shares"]["start"]
     assert ap.share_number_end == data["shares"]["end"]
     assert ap.street_address == data["address"]["street_address"]
-    assert ap.building.real_estate.housing_company.postal_code.value == data["address"]["postal_code"]
-    assert ap.building.real_estate.housing_company.city == data["address"]["city"]
     assert ap.apartment_number == data["address"]["apartment_number"]
     assert ap.floor == data["address"]["floor"]
     assert ap.stair == data["address"]["stair"]
@@ -1061,7 +1058,6 @@ def test__api__apartment__update__clear_ownerships_and_improvements(api_client: 
     assert ap.interest_during_construction == data["prices"]["construction"]["interest"]
     assert ap.debt_free_purchase_price_during_construction == data["prices"]["construction"]["debt_free_purchase_price"]
     assert ap.additional_work_during_construction == data["prices"]["construction"]["additional_work"]
-    assert ap.building_id == ap.building.id
     assert ap.notes == data["notes"]
     assert ap.ownerships.count() == 0
     assert ap.construction_price_improvements.count() == 0
@@ -1133,6 +1129,14 @@ def test__api__apartment__update__update_owner(api_client: HitasAPIClient, owner
     OwnerFactory.create(uuid=uuid.UUID("2b44c90e-8e04-48a3-b753-99e66a220a1d"))
 
     data = ApartmentDetailSerializer(ap).data
+    del data["id"]
+    del data["type"]["value"]
+    del data["type"]["description"]
+    del data["type"]["code"]
+    del data["shares"]["total"]
+    del data["address"]["postal_code"]
+    del data["address"]["city"]
+    del data["links"]
     data["ownerships"] = owner_data
     data["building"] = b.uuid.hex
 

--- a/backend/hitas/tests/apis/test_api_apartment_list.py
+++ b/backend/hitas/tests/apis/test_api_apartment_list.py
@@ -247,7 +247,7 @@ def test__api__apartment__filter(api_client: HitasAPIClient, selected_filter):
 @pytest.mark.django_db
 def test__api__apartment__filter__invalid_data(api_client: HitasAPIClient, selected_filter, fields):
     url = reverse("hitas:apartment-list") + "?" + urlencode(selected_filter)
-    response = api_client.get(url)
+    response = api_client.get(url, openapi_validate_request=False)
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert response.json() == {
         "error": "bad_request",

--- a/backend/hitas/tests/apis/test_api_building.py
+++ b/backend/hitas/tests/apis/test_api_building.py
@@ -228,7 +228,6 @@ def test__api__building__create__no_building_identifier(api_client: HitasAPIClie
     re: RealEstate = RealEstateFactory.create(housing_company=hc)
     data = {
         "address": {
-            "postal_code": re.housing_company.postal_code.value,
             "street_address": "test-street-address-1",
         },
     }
@@ -256,7 +255,6 @@ def test__api__building__create__invalid_building_identifier(api_client: HitasAP
     re: RealEstate = RealEstateFactory.create()
     data = {
         "address": {
-            "postal_code": re.postal_code.value,
             "street_address": "test-street-address-1",
         },
         "building_identifier": building_identifier,
@@ -275,7 +273,6 @@ def test__api__building__create__invalid_real_estate(api_client: HitasAPIClient)
     re: RealEstate = RealEstateFactory.create()
     data = {
         "address": {
-            "postal_code": re.postal_code.value,
             "street_address": "test-street-address-1",
         },
         "building_identifier": "100012345A",
@@ -300,7 +297,6 @@ def test__api__building__update(api_client: HitasAPIClient):
 
     data = {
         "address": {
-            "postal_code": re.postal_code.value,
             "street_address": "test-street-address-1",
         },
         "building_identifier": "100012345A",
@@ -315,8 +311,8 @@ def test__api__building__update(api_client: HitasAPIClient):
     assert response.json() == {
         "id": bu.uuid.hex,
         "address": {
-            "city": "Helsinki",
-            "postal_code": data["address"]["postal_code"],
+            "city": hc.postal_code.city,
+            "postal_code": hc.postal_code.value,
             "street_address": data["address"]["street_address"],
         },
         "building_identifier": data["building_identifier"],

--- a/backend/hitas/tests/apis/test_api_building.py
+++ b/backend/hitas/tests/apis/test_api_building.py
@@ -266,7 +266,7 @@ def test__api__building__create__invalid_building_identifier(api_client: HitasAP
         "hitas:building-list",
         kwargs={"housing_company_uuid": re.housing_company.uuid.hex, "real_estate_uuid": re.uuid.hex},
     )
-    response = api_client.post(url, data=data, format="json")
+    response = api_client.post(url, data=data, format="json", openapi_validate_request=False)
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 

--- a/backend/hitas/tests/apis/test_api_codes.py
+++ b/backend/hitas/tests/apis/test_api_codes.py
@@ -147,7 +147,7 @@ def test__api__code__create__invalid_data(api_client: HitasAPIClient, url_basena
     data.update(invalid_data)
 
     url = reverse(f"hitas:{url_basename}-list")
-    response = api_client.post(url, data=data, format="json")
+    response = api_client.post(url, data=data, format="json", openapi_validate_request=False)
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 

--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -971,9 +971,13 @@ def test__api__housing_company__delete__with_references(api_client: HitasAPIClie
     "selected_filter",
     [
         {"display_name": "TestDisplayName"},
+        {"display_name": "Di"},
         {"street_address": "test-street"},
+        {"street_address": "te"},
         {"property_manager": "TestPropertyManager"},
+        {"property_manager": "Te"},
         {"developer": "TestDeveloper"},
+        {"developer": "Te"},
         {"postal_code": "99999"},
         {"archive_id": 999},
     ],
@@ -1027,6 +1031,14 @@ def test__api__housing_company__filter(api_client: HitasAPIClient, selected_filt
         (
             {"postal_code": "123456"},
             [{"field": "postal_code", "message": "Enter a valid value."}],
+        ),
+        (
+            {"archive_id": "-1"},
+            [{"field": "archive_id", "message": "Ensure this value is greater than or equal to 1."}],
+        ),
+        (
+            {"archive_id": "0"},
+            [{"field": "archive_id", "message": "Ensure this value is greater than or equal to 1."}],
         ),
     ],
 )

--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -156,7 +156,9 @@ def test__api__housing_company__list__paging(api_client: HitasAPIClient):
 @pytest.mark.parametrize("page_number", ["a", "#", " ", ""])
 @pytest.mark.django_db
 def test__api__housing_company__list__paging__invalid(api_client: HitasAPIClient, page_number):
-    response = api_client.get(reverse("hitas:housing-company-list"), {"page": page_number})
+    response = api_client.get(
+        reverse("hitas:housing-company-list"), {"page": page_number}, openapi_validate_request=False
+    )
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert response.json() == exceptions.InvalidPage().data
 
@@ -513,7 +515,9 @@ def test__api__housing_company__create__duplicate_display_name(api_client: Hitas
 
 @pytest.mark.django_db
 def test__api__housing_company__create__empty(api_client: HitasAPIClient):
-    response = api_client.post(reverse("hitas:housing-company-list"), data={}, format="json")
+    response = api_client.post(
+        reverse("hitas:housing-company-list"), data={}, format="json", openapi_validate_request=False
+    )
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert response.json() == {
         "error": "bad_request",
@@ -709,7 +713,9 @@ def test__api__housing_company__create__invalid_data(api_client: HitasAPIClient,
     data = get_housing_company_create_data()
     data.update(invalid_data)
 
-    response = api_client.post(reverse("hitas:housing-company-list"), data=data, format="json")
+    response = api_client.post(
+        reverse("hitas:housing-company-list"), data=data, format="json", openapi_validate_request=False
+    )
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert response.json() == {
         "error": "bad_request",
@@ -1027,7 +1033,7 @@ def test__api__housing_company__filter(api_client: HitasAPIClient, selected_filt
 @pytest.mark.django_db
 def test__api__housing_company__filter__invalid_data(api_client: HitasAPIClient, selected_filter, fields):
     url = reverse("hitas:housing-company-list") + "?" + urlencode(selected_filter)
-    response = api_client.get(url)
+    response = api_client.get(url, openapi_validate_request=False)
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert response.json() == {
         "error": "bad_request",

--- a/backend/hitas/tests/apis/test_api_indices.py
+++ b/backend/hitas/tests/apis/test_api_indices.py
@@ -136,7 +136,7 @@ def test__api__indices__retrieve__unexisting_valid_month(api_client: HitasAPICli
 @pytest.mark.parametrize("index,month", product(indices, ["foo", "", "0-1", "2022-1", "2022-13", "2022-00"]))
 @pytest.mark.django_db
 def test__api__indices__retrieve__invalid_month(api_client: HitasAPIClient, index, month):
-    response = api_client.get(reverse(f"hitas:{index}-detail", kwargs={"month": "foo"}))
+    response = api_client.get(reverse(f"hitas:{index}-detail", kwargs={"month": "foo"}), openapi_validate_request=False)
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert response.json() == {
         "error": "bad_request",

--- a/backend/hitas/tests/apis/test_api_owner.py
+++ b/backend/hitas/tests/apis/test_api_owner.py
@@ -141,7 +141,7 @@ def test__api__owner__create__invalid_data(api_client: HitasAPIClient, invalid_d
     data.update(invalid_data)
 
     url = reverse("hitas:owner-list")
-    response = api_client.post(url, data=data, format="json")
+    response = api_client.post(url, data=data, format="json", openapi_validate_request=False)
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 

--- a/backend/hitas/tests/apis/test_api_postal_codes.py
+++ b/backend/hitas/tests/apis/test_api_postal_codes.py
@@ -132,7 +132,9 @@ def test__api__postal_code__create__invalid_data(api_client: HitasAPIClient, inv
     }
     data.update(invalid_data)
 
-    response = api_client.post(reverse("hitas:postal-code-list"), data=data, format="json")
+    response = api_client.post(
+        reverse("hitas:postal-code-list"), data=data, format="json", openapi_validate_request=False
+    )
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert response.json() == {
         "error": "bad_request",

--- a/backend/hitas/tests/apis/test_api_property_manager.py
+++ b/backend/hitas/tests/apis/test_api_property_manager.py
@@ -155,7 +155,7 @@ def test__api__property_manager__create__invalid_data(api_client: HitasAPIClient
     data.update(invalid_data)
 
     url = reverse("hitas:property-manager-list")
-    response = api_client.post(url, data=data, format="json")
+    response = api_client.post(url, data=data, format="json", openapi_validate_request=False)
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 

--- a/backend/hitas/tests/apis/test_api_real_estate.py
+++ b/backend/hitas/tests/apis/test_api_real_estate.py
@@ -178,7 +178,6 @@ def test__api__real_estate__create(api_client: HitasAPIClient):
     hc: HousingCompany = HousingCompanyFactory.create()
     data = {
         "address": {
-            "postal_code": hc.postal_code.value,
             "street_address": "test-street-address-1",
         },
         "property_identifier": "1-1234-321-56",
@@ -199,7 +198,6 @@ def test__api__real_estate__create__invalid_property_identifier(api_client: Hita
     hc: HousingCompany = HousingCompanyFactory.create()
     data = {
         "address": {
-            "postal_code": hc.postal_code.value,
             "street_address": "test-street-address-1",
         },
         "property_identifier": "1-1234-321-56-a",
@@ -219,7 +217,6 @@ def test__api__real_estate__update(api_client: HitasAPIClient):
     re: RealEstate = RealEstateFactory.create(housing_company=hc)
     data = {
         "address": {
-            "postal_code": hc.postal_code.value,
             "street_address": "test-street-address-1",
         },
         "property_identifier": "1111-1111-1111-1111",
@@ -231,8 +228,8 @@ def test__api__real_estate__update(api_client: HitasAPIClient):
     assert response.json() == {
         "id": re.uuid.hex,
         "address": {
-            "city": "Helsinki",
-            "postal_code": data["address"]["postal_code"],
+            "city": hc.postal_code.city,
+            "postal_code": hc.postal_code.value,
             "street_address": data["address"]["street_address"],
         },
         "property_identifier": data["property_identifier"],

--- a/backend/hitas/tests/apis/test_api_real_estate.py
+++ b/backend/hitas/tests/apis/test_api_real_estate.py
@@ -206,7 +206,7 @@ def test__api__real_estate__create__invalid_property_identifier(api_client: Hita
     }
 
     url = reverse("hitas:real-estate-list", kwargs={"housing_company_uuid": hc.uuid.hex})
-    response = api_client.post(url, data=data, format="json")
+    response = api_client.post(url, data=data, format="json", openapi_validate_request=False)
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 

--- a/backend/hitas/tests/test_merge.py
+++ b/backend/hitas/tests/test_merge.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 from hitas.views.utils.merge import merge
 
 
-class TestClass:
+class ValueHolder:
     def __init__(self, value, other_value):
         self.value = value
         self.other_value = other_value
@@ -101,9 +101,9 @@ def test__merge__complex_update__total_less():
     wanted1 = {"value": 44, "other_value": 44}  # New one, will replace `existing1`
     wanted2 = {"value": 3, "other_value": 3}  # Existing one, matches `existing3`
 
-    existing1 = TestClass(value=1, other_value=1)
-    existing2 = TestClass(value=2, other_value=2)
-    existing3 = TestClass(value=3, other_value=3)
+    existing1 = ValueHolder(value=1, other_value=1)
+    existing2 = ValueHolder(value=2, other_value=2)
+    existing3 = ValueHolder(value=3, other_value=3)
 
     # Test
     merge([existing1, existing2, existing3], [wanted1, wanted2], create_fn, eq, save_fn, delete_fn)
@@ -133,9 +133,9 @@ def test__merge__complex_update__total_more():
     wanted3 = {"value": 33, "other_value": 33}  # New one, will be created
     wanted4 = {"value": 3, "other_value": 3}  # Existing one, matches `existing3`
 
-    existing1 = TestClass(value=1, other_value=1)
-    existing2 = TestClass(value=2, other_value=2)
-    existing3 = TestClass(value=3, other_value=3)
+    existing1 = ValueHolder(value=1, other_value=1)
+    existing2 = ValueHolder(value=2, other_value=2)
+    existing3 = ValueHolder(value=3, other_value=3)
 
     # Test
     merge([existing1, existing2, existing3], [wanted1, wanted2, wanted3, wanted4], create_fn, eq, save_fn, delete_fn)

--- a/backend/hitas/views/housing_company.py
+++ b/backend/hitas/views/housing_company.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional
 
 from django.db.models import F, IntegerField, Min, Prefetch, Sum
 from django.db.models.functions import Round
-from django_filters import NumberFilter
 from enumfields.drf.serializers import EnumSupportSerializerMixin
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -31,6 +30,7 @@ from hitas.views.utils import (
     HitasFilterSet,
     HitasModelSerializer,
     HitasModelViewSet,
+    HitasNumberFilter,
     HitasPostalCodeFilter,
     ValueOrNullField,
 )
@@ -44,7 +44,7 @@ class HousingCompanyFilterSet(HitasFilterSet):
     postal_code = HitasPostalCodeFilter(field_name="postal_code__value")
     property_manager = HitasCharFilter(field_name="property_manager__name", lookup_expr="icontains")
     developer = HitasCharFilter(field_name="developer__value", lookup_expr="icontains")
-    archive_id = NumberFilter(field_name="id")
+    archive_id = HitasNumberFilter(field_name="id", min_value=1)
 
     class Meta:
         model = HousingCompany

--- a/backend/hitas/views/utils/__init__.py
+++ b/backend/hitas/views/utils/__init__.py
@@ -10,6 +10,7 @@ from hitas.views.utils.filters import (
     HitasCharFilter,
     HitasFilterBackend,
     HitasFilterSet,
+    HitasNumberFilter,
     HitasPostalCodeFilter,
     HitasSSNFilter,
     HitasUUIDFilter,

--- a/backend/hitas/views/utils/filters.py
+++ b/backend/hitas/views/utils/filters.py
@@ -33,6 +33,13 @@ class HitasPostalCodeFilter(filters.CharFilter):
         super().__init__(*args, **kwargs)
 
 
+class HitasNumberFilter(filters.NumberFilter):
+    def __init__(self, *args, **kwargs):
+        if not kwargs.get("min_value"):
+            kwargs["min_value"] = 0
+        super().__init__(*args, **kwargs)
+
+
 class HitasSSNFilter(filters.CharFilter):
     def __init__(self, *args, **kwargs):
         kwargs["min_length"] = 11

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -19,7 +19,7 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 3
+            minLength: 2
             example: helmi
         - name: street_address
           description: Search housing companies with street address containing the given search string (case-insensitive)
@@ -27,7 +27,7 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 3
+            minLength: 2
             example: Hannunkatu
         - name: postal_code
           description: Search housing companies located in given postal code
@@ -43,7 +43,7 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 5
+            minLength: 2
             example: Rakennuttaja
         - name: property_manager
           description: Search housing companies with property manager name matching to the given search string (case-insensitive)
@@ -51,8 +51,16 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 5
+            minLength: 2
             example: isännöinti
+        - name: archive_id
+          description: Search housing companies with exact archive id
+          required: false
+          in: query
+          schema:
+            type: number
+            minimum: 1
+            example: 421
       responses:
         '200':
           description: Successfully fetched list of housing companies
@@ -867,7 +875,7 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 3
+            minLength: 2
             example: helmi
         - name: street_address
           description: Search apartments with street address containing the given search string (case-insensitive)
@@ -875,7 +883,7 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 3
+            minLength: 2
             example: Hannunkatu
         - name: postal_code
           description: Search apartments located in given postal code
@@ -891,7 +899,7 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 3
+            minLength: 2
             example: matti
         - name: owner_identifier
           description: Search apartments whose social security number matches the given search string (case-insensitive)
@@ -899,7 +907,6 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 11
             maxLength: 11
             example: 131052-308T
       responses:
@@ -947,7 +954,7 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 3
+            minLength: 2
             example: Matti
         - name: identifier
           description: Search owners whose identifier (social security number, business id, etc) matches the given search string (case-insensitive)
@@ -964,7 +971,7 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 3
+            minLength: 2
             example: matti.meikalainen@example.com
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
@@ -1136,7 +1143,7 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 3
+            minLength: 2
             example: Matti
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
@@ -1308,7 +1315,7 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 3
+            minLength: 2
             example: Sato
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
@@ -1640,7 +1647,7 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 3
+            minLength: 2
             example: kerrostalo
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
@@ -1810,7 +1817,7 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 3
+            minLength: 2
             example: Hitas II
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
@@ -1980,7 +1987,7 @@ paths:
           in: query
           schema:
             type: string
-            minLength: 3
+            minLength: 2
             example: h+kk
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
@@ -2540,7 +2547,7 @@ components:
           description: Archive ID for this housing company
           type: integer
           readOnly: true
-          minimum: 0
+          minimum: 1
         notes:
           description: Optional notes for this housing company
           type: string

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -61,6 +61,7 @@ paths:
               schema:
                 description: Single page of housing companies
                 type: object
+                additionalProperties: false
                 required:
                   - page
                   - contents
@@ -93,6 +94,7 @@ paths:
         content:
           application/json:
             schema:
+              additionalProperties: false
               $ref: '#/components/schemas/HousingCompanyDetails'
       responses:
         '201':
@@ -100,6 +102,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: false
                 $ref: '#/components/schemas/HousingCompanyDetails'
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -134,6 +137,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: false
                 $ref: '#/components/schemas/HousingCompanyDetails'
         '404':
           $ref: '#/components/responses/NotFound'
@@ -160,6 +164,7 @@ paths:
         content:
           application/json:
             schema:
+              additionalProperties: false
               $ref: '#/components/schemas/HousingCompanyDetails'
       responses:
         '200':
@@ -167,6 +172,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: false
                 $ref: '#/components/schemas/HousingCompanyDetails'
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -228,6 +234,7 @@ paths:
               schema:
                 description: Single page of real estates
                 type: object
+                additionalProperties: false
                 required:
                   - page
                   - contents
@@ -237,6 +244,7 @@ paths:
                   contents:
                     description: List of real estates
                     type: array
+                    additionalProperties: false
                     items:
                       $ref: '#/components/schemas/RealEstate'
         '400':
@@ -268,6 +276,7 @@ paths:
         content:
           application/json:
             schema:
+              additionalProperties: false
               $ref: '#/components/schemas/RealEstate'
       responses:
         '201':
@@ -275,6 +284,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: false
                 $ref: '#/components/schemas/RealEstate'
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -316,6 +326,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: false
                 $ref: '#/components/schemas/RealEstate'
         '404':
           $ref: '#/components/responses/NotFound'
@@ -349,6 +360,7 @@ paths:
         content:
           application/json:
             schema:
+              additionalProperties: false
               $ref: '#/components/schemas/RealEstate'
       responses:
         '200':
@@ -356,6 +368,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: false
                 $ref: '#/components/schemas/RealEstate'
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -431,6 +444,7 @@ paths:
               schema:
                 description: Single page of buildings
                 type: object
+                additionalProperties: false
                 required:
                   - page
                   - contents
@@ -478,6 +492,7 @@ paths:
         content:
           application/json:
             schema:
+              additionalProperties: false
               $ref: '#/components/schemas/Building'
       responses:
         '201':
@@ -485,6 +500,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: false
                 $ref: '#/components/schemas/Building'
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -533,6 +549,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: false
                 $ref: '#/components/schemas/Building'
         '404':
           $ref: '#/components/responses/NotFound'
@@ -573,6 +590,7 @@ paths:
         content:
           application/json:
             schema:
+              additionalProperties: false
               $ref: '#/components/schemas/Building'
       responses:
         '200':
@@ -580,6 +598,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: false
                 $ref: '#/components/schemas/Building'
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -655,6 +674,7 @@ paths:
               schema:
                 description: Single page of apartments
                 type: object
+                additionalProperties: false
                 required:
                   - page
                   - contents
@@ -695,6 +715,7 @@ paths:
         content:
           application/json:
             schema:
+              additionalProperties: false
               $ref: '#/components/schemas/ApartmentDetails'
       responses:
         '201':
@@ -702,6 +723,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: false
                 $ref: '#/components/schemas/ApartmentDetails'
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -744,6 +766,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: false
                 $ref: '#/components/schemas/ApartmentDetails'
         '404':
           $ref: '#/components/responses/NotFound'
@@ -777,6 +800,7 @@ paths:
         content:
           application/json:
             schema:
+              additionalProperties: false
               $ref: '#/components/schemas/ApartmentDetails'
       responses:
         '200':
@@ -886,6 +910,7 @@ paths:
               schema:
                 description: Single page of apartments
                 type: object
+                additionalProperties: false
                 required:
                   - page
                   - contents
@@ -951,6 +976,7 @@ paths:
               schema:
                 description: Single page of owners
                 type: object
+                additionalProperties: false
                 required:
                   - page
                   - contents
@@ -1122,6 +1148,7 @@ paths:
               schema:
                 description: Single page of property managers
                 type: object
+                additionalProperties: false
                 required:
                   - page
                   - contents
@@ -1293,6 +1320,7 @@ paths:
               schema:
                 description: Single page of developers
                 type: object
+                additionalProperties: false
                 required:
                   - page
                   - contents
@@ -1454,6 +1482,7 @@ paths:
               schema:
                 description: Single page of postal codes
                 type: object
+                additionalProperties: false
                 required:
                   - page
                   - contents
@@ -1623,6 +1652,7 @@ paths:
               schema:
                 description: Single page of building types
                 type: object
+                additionalProperties: false
                 required:
                   - page
                   - contents
@@ -1792,6 +1822,7 @@ paths:
               schema:
                 description: Single page of financing methods
                 type: object
+                additionalProperties: false
                 required:
                   - page
                   - contents
@@ -1961,6 +1992,7 @@ paths:
               schema:
                 description: Single page of apartment types
                 type: object
+                additionalProperties: false
                 required:
                   - page
                   - contents
@@ -2124,6 +2156,7 @@ paths:
               schema:
                 description: Single page of indices
                 type: object
+                additionalProperties: false
                 required:
                   - page
                   - contents
@@ -2259,6 +2292,13 @@ components:
     PageInfo:
       description: Page metadata
       type: object
+      additionalProperties: false
+      required:
+        - size
+        - total_items
+        - current_page
+        - total_pages
+        - links
       properties:
         size:
           description: Size of the returned page
@@ -2287,6 +2327,7 @@ components:
         links:
           description: Links to other pages
           type: object
+          additionalProperties: false
           properties:
             next:
               description: Link to next page
@@ -2298,16 +2339,11 @@ components:
               type: string
               nullable: true
               example: 'https://example.com/api/v1/housing-companies?page=2'
-      required:
-        - size
-        - total_items
-        - current_page
-        - total_pages
-        - links
 
     HousingCompany:
       description: Single housing company
       type: object
+      additionalProperties: false
       required:
         - address
         - area
@@ -2333,6 +2369,7 @@ components:
         area:
           description: Hitas cost area information related to the housing company
           type: object
+          additionalProperties: false
           readOnly: true
           required:
             - name
@@ -2359,6 +2396,7 @@ components:
     HousingCompanyDetails:
       description: Single housing company's details
       type: object
+      additionalProperties: false
       required:
         - address
         - area
@@ -2379,6 +2417,7 @@ components:
         name:
           description: Name information about the housing company
           type: object
+          additionalProperties: false
           required:
             - official
             - display
@@ -2405,6 +2444,7 @@ components:
         area:
           description: Hitas cost area information related to the housing company
           type: object
+          additionalProperties: false
           readOnly: true
           required:
             - name
@@ -2446,6 +2486,7 @@ components:
         summary:
           description: Summary data for this housing company across all apartments
           type: object
+          additionalProperties: false
           readOnly: true
           required:
             - average_price_per_square_meter
@@ -2470,6 +2511,7 @@ components:
         acquisition_price:
           description: Acquisition price information
           type: object
+          additionalProperties: false
           required:
             - initial
             - realized
@@ -2514,6 +2556,7 @@ components:
         last_modified:
           description: Last modified information
           type: object
+          additionalProperties: false
           readOnly: true
           required:
             - user
@@ -2522,6 +2565,7 @@ components:
             user:
               description: User who last modified this housing company
               type: object
+              additionalProperties: false
               required:
                 - username
                 - first_name
@@ -2555,6 +2599,7 @@ components:
         improvements:
           description: Contains housing company improvements
           type: object
+          additionalProperties: false
           required:
             - market_price_index
             - construction_price_index
@@ -2565,6 +2610,7 @@ components:
               items:
                 description: Improvement
                 type: object
+                additionalProperties: false
                 required:
                   - name
                   - value
@@ -2590,6 +2636,7 @@ components:
               items:
                 description: Improvement
                 type: object
+                additionalProperties: false
                 required:
                   - name
                   - value
@@ -2613,6 +2660,7 @@ components:
     RealEstate:
       description: Single real estate
       type: object
+      additionalProperties: false
       required:
         - id
         - property_identifier
@@ -2640,6 +2688,7 @@ components:
     Building:
       description: Single building
       type: object
+      additionalProperties: false
       required:
         - id
         - address
@@ -2661,6 +2710,7 @@ components:
     MinimalHousingCompany:
       description: Housing company identifier
       type: object
+      additionalProperties: false
       required:
         - id
         - name
@@ -2679,6 +2729,7 @@ components:
     Apartment:
       description: Single apartment
       type: object
+      additionalProperties: false
       required:
         - id
         - state
@@ -2722,6 +2773,7 @@ components:
     ApartmentDetails:
       description: Single apartment details
       type: object
+      additionalProperties: false
       required:
         - id
         - state
@@ -2755,6 +2807,7 @@ components:
         shares:
           description: Share information
           type: object
+          additionalProperties: false
           nullable: true
           required:
             - start
@@ -2806,6 +2859,7 @@ components:
         improvements:
           description: Contains housing company improvements
           type: object
+          additionalProperties: false
           required:
             - market_price_index
             - construction_price_index
@@ -2816,6 +2870,7 @@ components:
               items:
                 description: Improvement
                 type: object
+                additionalProperties: false
                 required:
                   - name
                   - value
@@ -2841,6 +2896,7 @@ components:
               items:
                 description: Improvement
                 type: object
+                additionalProperties: false
                 required:
                   - name
                   - value
@@ -2879,6 +2935,7 @@ components:
     ApartmentLinks:
       description: Links to apartment's related object
       type: object
+      additionalProperties: false
       readOnly: true
       required:
         - housing_company
@@ -2889,6 +2946,7 @@ components:
         housing_company:
           description: Links to apartment's housing company
           type: object
+          additionalProperties: false
           required:
             - id
             - display_name
@@ -2909,6 +2967,7 @@ components:
         real_estate:
           description: Links to apartment's real estate
           type: object
+          additionalProperties: false
           required:
             - id
             - link
@@ -2924,6 +2983,7 @@ components:
         building:
           description: Links to apartment's building
           type: object
+          additionalProperties: false
           required:
             - id
             - link
@@ -2939,6 +2999,7 @@ components:
         apartment:
           description: Links to apartment's details
           type: object
+          additionalProperties: false
           required:
             - id
             - link
@@ -2955,6 +3016,7 @@ components:
     ApartmentPrices:
       description: Single apartment price information
       type: object
+      additionalProperties: false
       properties:
         debt_free_purchase_price:
           description: TBD
@@ -2995,6 +3057,7 @@ components:
         construction:
           description: Single apartment construction price information
           type: object
+          additionalProperties: false
           properties:
             loans:
               description: Loans during construction
@@ -3024,6 +3087,7 @@ components:
     Ownership:
       description: Ownership information
       type: object
+      additionalProperties: false
       required:
         - owner
         - percentage
@@ -3056,6 +3120,7 @@ components:
     Owner:
       description: Owner information
       type: object
+      additionalProperties: false
       required:
         - id
         - name
@@ -3094,6 +3159,7 @@ components:
     Address:
       description: Address information
       type: object
+      additionalProperties: false
       required:
         - street_address
         - postal_code
@@ -3115,6 +3181,7 @@ components:
     HitasPostalCode:
       description: Hitas postal code
       type: object
+      additionalProperties: false
       required:
         - value
         - city
@@ -3138,6 +3205,7 @@ components:
     HitasHousingCompanyAddress:
       description: Hitas address information for a housing company (includes postal code)
       type: object
+      additionalProperties: false
       required:
         - street_address
         - postal_code
@@ -3160,6 +3228,7 @@ components:
     ApartmentAddress:
       description: Apartment address information
       type: object
+      additionalProperties: false
       required:
         - street_address
         - postal_code
@@ -3202,6 +3271,7 @@ components:
     HitasAddress:
       description: Hitas address information
       type: object
+      additionalProperties: false
       required:
         - street_address
         - postal_code
@@ -3235,6 +3305,7 @@ components:
     Code:
       description: Hitas codebook entry
       type: object
+      additionalProperties: false
       required:
         - id
         - value
@@ -3272,6 +3343,7 @@ components:
     PropertyManager:
       description: Property manager information
       type: object
+      additionalProperties: false
       required:
         - id
         - name
@@ -3302,6 +3374,7 @@ components:
     Index:
       description: Index contains month this index is active and a its value
       type: object
+      additionalProperties: false
       required:
         - month
         - value
@@ -3360,6 +3433,7 @@ components:
     BadRequestError:
       description: Bad request error
       type: object
+      additionalProperties: false
       required:
         - status
         - reason
@@ -3396,6 +3470,7 @@ components:
           items:
             description: Single field validation details
             type: object
+            additionalProperties: false
             required:
               - field
               - message
@@ -3412,6 +3487,7 @@ components:
     UnauthorizedError:
       description: Unauthorized error
       type: object
+      additionalProperties: false
       required:
         - status
         - reason
@@ -3438,6 +3514,7 @@ components:
     NotFoundError:
       description: Not found error
       type: object
+      additionalProperties: false
       required:
         - status
         - reason
@@ -3490,6 +3567,7 @@ components:
     NotAcceptableError:
       description: Not acceptable error
       type: object
+      additionalProperties: false
       required:
         - status
         - reason
@@ -3519,6 +3597,7 @@ components:
     ConflictError:
       description: Conflict error
       type: object
+      additionalProperties: false
       required:
         - status
         - reason
@@ -3553,6 +3632,7 @@ components:
     UnsupportedMediaTypeError:
       description: Unsupported media type error
       type: object
+      additionalProperties: false
       required:
         - status
         - reason
@@ -3581,6 +3661,7 @@ components:
 
     InternalServerError:
       type: object
+      additionalProperties: false
       description: Internal server error
       required:
         - status

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2412,8 +2412,8 @@ components:
         id:
           description: Housing company ID
           type: string
-          example: a3181b8fa60b47df8ccba0d554a913bb
           readOnly: true
+          example: a3181b8fa60b47df8ccba0d554a913bb
         name:
           description: Name information about the housing company
           type: object
@@ -2468,21 +2468,13 @@ components:
           nullable: true
           readOnly: true
         financing_method:
-          allOf:
-            - $ref: '#/components/schemas/Code'
-            - $ref: '#/components/schemas/ReadOnlyCode'
+          $ref: '#/components/schemas/ReadOnlyCode'
         building_type:
-          allOf:
-            - $ref: '#/components/schemas/Code'
-            - $ref: '#/components/schemas/ReadOnlyCode'
+          $ref: '#/components/schemas/ReadOnlyCode'
         developer:
-          allOf:
-            - $ref: '#/components/schemas/Code'
-            - $ref: '#/components/schemas/ReadOnlyCode'
+          $ref: '#/components/schemas/ReadOnlyCode'
         property_manager:
-          allOf:
-            - $ref: '#/components/schemas/PropertyManager'
-            - $ref: '#/components/schemas/ReadOnlyPropertyManager'
+          $ref: '#/components/schemas/ReadOnlyPropertyManager'
         summary:
           description: Summary data for this housing company across all apartments
           type: object
@@ -2571,10 +2563,9 @@ components:
                 - first_name
                 - last_name
               properties:
-                user:
+                username:
                   description: Username of this user
                   type: string
-                  nullable: true
                   example: mameik01
                 first_name:
                   description: First name of this user
@@ -2756,7 +2747,7 @@ components:
           minimum: 0
           example: 67
         address:
-          $ref: '#/components/schemas/HitasAddress'
+          $ref: '#/components/schemas/ApartmentAddress'
         completion_date:
           description: Date that the apartment was completed on
           type: string
@@ -2768,6 +2759,7 @@ components:
           items:
             $ref: '#/components/schemas/Ownership'
         links:
+          readOnly: true
           $ref: '#/components/schemas/ApartmentLinks'
 
     ApartmentDetails:
@@ -2796,9 +2788,7 @@ components:
         state:
           $ref: '#/components/schemas/ApartmentState'
         type:
-          allOf:
-            - $ref: '#/components/schemas/Code'
-            - $ref: '#/components/schemas/ReadOnlyCode'
+          $ref: '#/components/schemas/ReadOnlyCode'
         surface_area:
           description: Surface area of the apartment measured in square meters
           type: number
@@ -2845,6 +2835,7 @@ components:
           items:
             $ref: '#/components/schemas/Ownership'
         links:
+          readOnly: true
           $ref: '#/components/schemas/ApartmentLinks'
         building:
           description: Building ID this apartment is associated with
@@ -3095,9 +3086,7 @@ components:
         - end_date
       properties:
         owner:
-          allOf:
-            - $ref: '#/components/schemas/Owner'
-            - $ref: '#/components/schemas/ReadOnlyOwner'
+          $ref: '#/components/schemas/ReadOnlyOwner'
         percentage:
           description: Percentage that the owner owns of the apartment
           type: number
@@ -3130,6 +3119,7 @@ components:
         id:
           description: ID of this owner
           type: string
+          readOnly: true
           example: dc1072975bab4ba69f64814f021c6785
         name:
           description: Name of this owner
@@ -3147,14 +3137,62 @@ components:
           example: martti.virtanen@example.com
 
     ReadOnlyOwner:
-      description: Read-only owner
+      description: Owner information
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - identifier
+        - email
       properties:
+        id:
+          description: ID of this owner
+          type: string
+          example: dc1072975bab4ba69f64814f021c6785
         name:
+          description: Name of this owner
+          type: string
           readOnly: true
+          example: Martti Virtanen
         identifier:
+          description: Identifier (social security number, business id, etc) of this owner
+          type: string
           readOnly: true
+          nullable: true
+          example: 260969-420B
         email:
+          description: Email for this owner
+          type: string
           readOnly: true
+          nullable: true
+          example: martti.virtanen@example.com
+
+    ReadOnlyAddress:
+      description: Address information
+      type: object
+      additionalProperties: false
+      readOnly: true
+      required:
+        - street_address
+        - postal_code
+        - city
+      properties:
+        street_address:
+          description: Street address
+          type: string
+          readOnly: true
+          example: Torikatu 16 B 4
+        postal_code:
+          description: Postal code
+          type: string
+          readOnly: true
+          example: "90100"
+        city:
+          description: City
+          type: string
+          readOnly: true
+          example: Oulu
 
     Address:
       description: Address information
@@ -3183,10 +3221,16 @@ components:
       type: object
       additionalProperties: false
       required:
+        - id
         - value
         - city
         - cost_area
       properties:
+        id:
+          description: ID of this code
+          type: string
+          readOnly: true
+          example: 21d25cc973d8450f8f89937b9eba0a04
         value:
           description: Hitas postal code
           type: string
@@ -3293,14 +3337,35 @@ components:
           example: Helsinki
 
     ReadOnlyCode:
-      description: Read-only Hitas codebook entry
+      description: Hitas codebook entry
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - value
+        - description
+        - code
       properties:
+        id:
+          description: ID of this code
+          type: string
+          example: 21d25cc973d8450f8f89937b9eba0a04
         value:
+          description: Value for this code
+          type: string
           readOnly: true
+          example: luhtitalo
         description:
+          description: Description of this code
+          type: string
+          nullable: true
           readOnly: true
+          example: This building type is for luhtitalo
         code:
+          description: Code number
+          type: string
           readOnly: true
+          example: 001
 
     Code:
       description: Hitas codebook entry
@@ -3315,6 +3380,7 @@ components:
         id:
           description: ID of this code
           type: string
+          readOnly: true
           example: 21d25cc973d8450f8f89937b9eba0a04
         value:
           description: Value for this code
@@ -3332,13 +3398,31 @@ components:
 
     ReadOnlyPropertyManager:
       description: Property manager information
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - email
+        - address
       properties:
+        id:
+          description: ID of this property manager
+          type: string
+          example: dc1072975bab4ba69f64814f021c6785
         name:
+          description: Name of this property manager
+          type: string
           readOnly: true
+          example: Ismo Isännöitsijät Oy
         email:
+          description: Email for this property manager
+          type: string
           readOnly: true
+          example: ismo@example.com
         address:
           readOnly: true
+          $ref: '#/components/schemas/ReadOnlyAddress'
 
     PropertyManager:
       description: Property manager information
@@ -3353,6 +3437,7 @@ components:
         id:
           description: ID of this property manager
           type: string
+          readOnly: true
           example: dc1072975bab4ba69f64814f021c6785
         name:
           description: Name of this property manager

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -47,7 +47,7 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "autoflake"
-version = "1.6.0"
+version = "1.6.1"
 description = "Removes unused imports and unused variables"
 category = "dev"
 optional = false
@@ -96,7 +96,7 @@ python-versions = "~=3.7"
 
 [[package]]
 name = "certifi"
-version = "2022.9.14"
+version = "2022.9.24"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -134,7 +134,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.4.4"
+version = "6.5.0"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -175,7 +175,7 @@ packaging = "*"
 
 [[package]]
 name = "django"
-version = "3.2.15"
+version = "3.2.16"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 category = "main"
 optional = false
@@ -214,7 +214,7 @@ django = ">=1.8"
 
 [[package]]
 name = "django-debug-toolbar"
-version = "3.6.0"
+version = "3.7.0"
 description = "A configurable set of panels that display various debug information about the current request/response."
 category = "dev"
 optional = false
@@ -296,7 +296,7 @@ python-versions = "*"
 
 [[package]]
 name = "django-safedelete"
-version = "1.3.0"
+version = "1.3.1"
 description = "Mask your objects instead of deleting them from your database."
 category = "main"
 optional = false
@@ -307,14 +307,14 @@ Django = "*"
 
 [[package]]
 name = "djangorestframework"
-version = "3.13.1"
+version = "3.14.0"
 description = "Web APIs for Django, made easy."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-django = ">=2.2"
+django = ">=3.0"
 pytz = "*"
 
 [[package]]
@@ -364,11 +364,14 @@ gmpy2 = ["gmpy2"]
 
 [[package]]
 name = "executing"
-version = "1.0.0"
+version = "1.1.0"
 description = "Get the currently executing AST node of a frame, and other information"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[package.extras]
+tests = ["rich", "littleutils", "pytest", "asttokens"]
 
 [[package]]
 name = "factory-boy"
@@ -387,11 +390,11 @@ doc = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
 name = "faker"
-version = "14.2.0"
+version = "15.0.0"
 description = "Faker is a Python package that generates fake data for you."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 python-dateutil = ">=2.4"
@@ -427,6 +430,18 @@ description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "importlib-resources"
+version = "5.9.0"
+description = "Read resources from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -528,6 +543,28 @@ format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validat
 format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
 
 [[package]]
+name = "jsonschema-spec"
+version = "0.1.2"
+description = "JSONSchema Spec with object-oriented paths"
+category = "dev"
+optional = false
+python-versions = ">=3.7.0,<4.0.0"
+
+[package.dependencies]
+jsonschema = ">=4.0.0,<5.0.0"
+pathable = ">=0.4.1,<0.5.0"
+PyYAML = ">=5.1"
+typing-extensions = ">=4.3.0,<5.0.0"
+
+[[package]]
+name = "lazy-object-proxy"
+version = "1.7.1"
+description = "A fast and thorough lazy object proxy."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "markdown"
 version = "3.4.1"
 description = "Python implementation of Markdown."
@@ -583,7 +620,7 @@ python-versions = "*"
 
 [[package]]
 name = "openapi-core"
-version = "0.15.0"
+version = "0.16.0"
 description = "client-side and server-side support for the OpenAPI Specification v3"
 category = "dev"
 optional = false
@@ -591,9 +628,10 @@ python-versions = ">=3.7.0,<4.0.0"
 
 [package.dependencies]
 isodate = "*"
+jsonschema-spec = ">=0.1.1,<0.2.0"
 more-itertools = "*"
-openapi-schema-validator = ">=0.2.0,<0.3.0"
-openapi-spec-validator = ">=0.4.0,<0.5.0"
+openapi-schema-validator = ">=0.3.0,<0.4.0"
+openapi-spec-validator = ">=0.5.0,<0.6.0"
 parse = "*"
 pathable = ">=0.4.0,<0.5.0"
 typing-extensions = ">=4.3.0,<5.0.0"
@@ -607,14 +645,15 @@ requests = ["requests"]
 
 [[package]]
 name = "openapi-schema-validator"
-version = "0.2.3"
+version = "0.3.4"
 description = "OpenAPI schema validation for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7.0,<4.0.0"
 
 [package.dependencies]
-jsonschema = ">=3.0.0,<5.0.0"
+attrs = ">=19.2.0"
+jsonschema = ">=4.0.0,<5.0.0"
 
 [package.extras]
 isodate = ["isodate"]
@@ -623,15 +662,18 @@ rfc3339-validator = ["rfc3339-validator"]
 
 [[package]]
 name = "openapi-spec-validator"
-version = "0.4.0"
-description = "OpenAPI 2.0 (aka Swagger) and OpenAPI 3.0 spec validator"
+version = "0.5.1"
+description = "OpenAPI 2.0 (aka Swagger) and OpenAPI 3 spec validator"
 category = "dev"
 optional = false
 python-versions = ">=3.7.0,<4.0.0"
 
 [package.dependencies]
-jsonschema = ">=3.2.0,<5.0.0"
-openapi-schema-validator = ">=0.2.0,<0.3.0"
+importlib-resources = ">=5.8.0,<6.0.0"
+jsonschema = ">=4.0.0,<5.0.0"
+jsonschema-spec = ">=0.1.1,<0.2.0"
+lazy-object-proxy = ">=1.7.1,<2.0.0"
+openapi-schema-validator = ">=0.3.2,<0.4.0"
 PyYAML = ">=5.1"
 
 [package.extras]
@@ -857,7 +899,7 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.
 
 [[package]]
 name = "pytest-cov"
-version = "3.0.0"
+version = "4.0.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
@@ -916,7 +958,7 @@ pycryptodome = ["pycryptodome (>=3.3.1,<4.0.0)", "pyasn1"]
 
 [[package]]
 name = "pytz"
-version = "2022.2.1"
+version = "2022.4"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -1009,7 +1051,7 @@ sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
 name = "sqlparse"
-version = "0.4.2"
+version = "0.4.3"
 description = "A non-validating SQL parser."
 category = "main"
 optional = false
@@ -1017,7 +1059,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "stack-data"
-version = "0.5.0"
+version = "0.5.1"
 description = "Extract data from python stack frames and tracebacks for informative displays"
 category = "dev"
 optional = false
@@ -1033,7 +1075,7 @@ tests = ["cython", "littleutils", "pygments", "typeguard", "pytest"]
 
 [[package]]
 name = "testcontainers"
-version = "3.6.1"
+version = "3.7.0"
 description = "Library provides lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container"
 category = "dev"
 optional = false
@@ -1048,6 +1090,7 @@ wrapt = "*"
 
 [package.extras]
 arangodb = ["python-arango"]
+azurite = ["azure-storage-blob"]
 clickhouse = ["clickhouse-driver"]
 docker-compose = ["docker-compose"]
 google-cloud-pubsub = ["google-cloud-pubsub (<2)"]
@@ -1157,7 +1200,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "1e397aa9d474dc10058d4d7b404c8f5a08edab838b585911b255a48a2055d6a4"
+content-hash = "d46f771b609f18d1e8f03523b737f3bf0ea7d3605598c87a228e41aa8251d0fc"
 
 [metadata.files]
 appnope = [
@@ -1223,10 +1266,7 @@ django-nested-inline = [
     {file = "django_nested_inline-0.4.5-py3-none-any.whl", hash = "sha256:fc6998e7d607c1414e25897ae1a544105ada93d63c5cff3ac9582fbf14d8ec63"},
 ]
 django-safedelete = []
-djangorestframework = [
-    {file = "djangorestframework-3.13.1-py3-none-any.whl", hash = "sha256:24c4bf58ed7e85d1fe4ba250ab2da926d263cd57d64b03e8dcef0ac683f8b1aa"},
-    {file = "djangorestframework-3.13.1.tar.gz", hash = "sha256:0c33407ce23acc68eca2a6e46424b008c9c02eceb8cf18581921d0092bc1f2ee"},
-]
+djangorestframework = []
 docker = []
 drf-nested-routers = []
 ecdsa = []
@@ -1239,6 +1279,7 @@ faker = []
 flake8 = []
 greenlet = []
 idna = []
+importlib-resources = []
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
@@ -1257,6 +1298,46 @@ jedi = [
     {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
 ]
 jsonschema = []
+jsonschema-spec = []
+lazy-object-proxy = [
+    {file = "lazy-object-proxy-1.7.1.tar.gz", hash = "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb8c5fd1684d60a9902c60ebe276da1f2281a318ca16c1d0a96db28f62e9166b"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a57d51ed2997e97f3b8e3500c984db50a554bb5db56c50b5dab1b41339b37e36"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd45683c3caddf83abbb1249b653a266e7069a09f486daa8863fb0e7496a9fdb"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8561da8b3dd22d696244d6d0d5330618c993a215070f473b699e00cf1f3f6443"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fccdf7c2c5821a8cbd0a9440a456f5050492f2270bd54e94360cac663398739b"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-win32.whl", hash = "sha256:898322f8d078f2654d275124a8dd19b079080ae977033b713f677afcfc88e2b9"},
+    {file = "lazy_object_proxy-1.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:85b232e791f2229a4f55840ed54706110c80c0a210d076eee093f2b2e33e1bfd"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:46ff647e76f106bb444b4533bb4153c7370cdf52efc62ccfc1a28bdb3cc95442"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12f3bb77efe1367b2515f8cb4790a11cffae889148ad33adad07b9b55e0ab22c"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c19814163728941bb871240d45c4c30d33b8a2e85972c44d4e63dd7107faba44"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:e40f2013d96d30217a51eeb1db28c9ac41e9d0ee915ef9d00da639c5b63f01a1"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:2052837718516a94940867e16b1bb10edb069ab475c3ad84fd1e1a6dd2c0fcfc"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-win32.whl", hash = "sha256:6a24357267aa976abab660b1d47a34aaf07259a0c3859a34e536f1ee6e76b5bb"},
+    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-win_amd64.whl", hash = "sha256:6aff3fe5de0831867092e017cf67e2750c6a1c7d88d84d2481bd84a2e019ec35"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6a6e94c7b02641d1311228a102607ecd576f70734dc3d5e22610111aeacba8a0"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4ce15276a1a14549d7e81c243b887293904ad2d94ad767f42df91e75fd7b5b6"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e368b7f7eac182a59ff1f81d5f3802161932a41dc1b1cc45c1f757dc876b5d2c"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:6ecbb350991d6434e1388bee761ece3260e5228952b1f0c46ffc800eb313ff42"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:553b0f0d8dbf21890dd66edd771f9b1b5f51bd912fa5f26de4449bfc5af5e029"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-win32.whl", hash = "sha256:c7a683c37a8a24f6428c28c561c80d5f4fd316ddcf0c7cab999b15ab3f5c5c69"},
+    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-win_amd64.whl", hash = "sha256:df2631f9d67259dc9620d831384ed7732a198eb434eadf69aea95ad18c587a28"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:07fa44286cda977bd4803b656ffc1c9b7e3bc7dff7d34263446aec8f8c96f88a"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4dca6244e4121c74cc20542c2ca39e5c4a5027c81d112bfb893cf0790f96f57e"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91ba172fc5b03978764d1df5144b4ba4ab13290d7bab7a50f12d8117f8630c38"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:043651b6cb706eee4f91854da4a089816a6606c1428fd391573ef8cb642ae4f7"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b9e89b87c707dd769c4ea91f7a31538888aad05c116a59820f28d59b3ebfe25a"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-win32.whl", hash = "sha256:9d166602b525bf54ac994cf833c385bfcc341b364e3ee71e3bf5a1336e677b55"},
+    {file = "lazy_object_proxy-1.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:8f3953eb575b45480db6568306893f0bd9d8dfeeebd46812aa09ca9579595148"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:dd7ed7429dbb6c494aa9bc4e09d94b778a3579be699f9d67da7e6804c422d3de"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70ed0c2b380eb6248abdef3cd425fc52f0abd92d2b07ce26359fcbc399f636ad"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7096a5e0c1115ec82641afbdd70451a144558ea5cf564a896294e346eb611be1"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f769457a639403073968d118bc70110e7dce294688009f5c24ab78800ae56dc8"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:39b0e26725c5023757fc1ab2a89ef9d7ab23b84f9251e28f9cc114d5b59c1b09"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-win32.whl", hash = "sha256:2130db8ed69a48a3440103d4a520b89d8a9405f1b06e2cc81640509e8bf6548f"},
+    {file = "lazy_object_proxy-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:677ea950bef409b47e51e733283544ac3d660b709cfce7b187f5ace137960d61"},
+    {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
+]
 markdown = []
 markupsafe = []
 matplotlib-inline = []
@@ -1268,10 +1349,7 @@ mypy-extensions = [
 ]
 openapi-core = []
 openapi-schema-validator = []
-openapi-spec-validator = [
-    {file = "openapi-spec-validator-0.4.0.tar.gz", hash = "sha256:97f258850afc97b048f7c2653855e0f88fa66ac103c2be5077c7960aca2ad49a"},
-    {file = "openapi_spec_validator-0.4.0-py3-none-any.whl", hash = "sha256:06900ac4d546a1df3642a779da0055be58869c598e3042a2fef067cfd99d04d0"},
-]
+openapi-spec-validator = []
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
@@ -1431,10 +1509,7 @@ pyrsistent = [
     {file = "pyrsistent-0.18.1.tar.gz", hash = "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96"},
 ]
 pytest = []
-pytest-cov = [
-    {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
-    {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
-]
+pytest-cov = []
 pytest-django = [
     {file = "pytest-django-4.5.2.tar.gz", hash = "sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2"},
     {file = "pytest_django-4.5.2-py3-none-any.whl", hash = "sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e"},
@@ -1494,10 +1569,7 @@ six = [
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 sqlalchemy = []
-sqlparse = [
-    {file = "sqlparse-0.4.2-py3-none-any.whl", hash = "sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d"},
-    {file = "sqlparse-0.4.2.tar.gz", hash = "sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae"},
-]
+sqlparse = []
 stack-data = []
 testcontainers = []
 tomli = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,10 +30,10 @@ factory-boy = "^3.2.1"
 flake8 = "^5.0.4"
 isort = "^5.10.1"
 pytest = "^7.1.2"
-pytest-cov = "^3.0.0"
+pytest-cov = "4.0.0"
 pytest-django = "^4.5.2"
 ipython = "^8.4.0"
-openapi-core = "^0.15.0"
+openapi-core = "0.16.0"
 testcontainers = {extras = ["postgresql"], version = "^3.6.0"}
 django-debug-toolbar = "^3.6.0"
 


### PR DESCRIPTION
3350e61: backend: remove warning on test class
 - fix warning `cannot collect test class 'TestClass' because it has a
   __init__ constructor`

---

7a5329a: backend: update dependencies

---

5c7374d: frontend: dependency updates

---

ef88903: backend: implement OpenAPI request validation
 - now requests are also validated along with the responses
 - only used in tests but helps us to verify the OpenAPI definitions and
   test cases are valid
 - note: this will break a lot of tests, future commit will fix
   those
 - don't validate requests when the request is on purpose invalid
   - when we expect 400 Bad Request it's OK to ignore the request
     validation

---

5215a25: backend: OpenAPI: add `additionalProperties: false`
 - annoying workaround to force openapi-core to verify the default
   behaviour
 - causes test failures, will be fixed in future commit

---

2db454d: backend: OpenAPI / test fixes based on the request validation
 - fixes tests broken after request validation implemented in ef88903
   and 5215a25

---

70a79bb: backend: validate_openapi: remove unnecessary workaround

---

bc4a0a9: backend: validate_openapi: print better error messages on validation errors

---

3c6c5d2: backend: fix OpenAPI definitions on different searches

---