### PR TITLE
backend: Fix HousingCompany empty string to be a valid business id value

### DIFF
--- a/backend/hitas/views/housing_company.py
+++ b/backend/hitas/views/housing_company.py
@@ -153,6 +153,8 @@ class HousingCompanyDetailSerializer(EnumSupportSerializerMixin, HitasModelSeria
         return instance
 
     def validate_business_id(self, value):
+        if value == "":
+            value = None
         validate_business_id(value)
         return value
 


### PR DESCRIPTION
- The empty string is converted to None when it's being validated

Requires [22ffb8a](https://github.com/City-of-Helsinki/hitas/pull/93/commits/22ffb8a4ca2ae548e83878066503ecf569268a85) from #93 to be fully functional

refs. HT-30 Comments. Fixes to address the comments had been made already, but this one issue seems to have still slipped through