### PR TITLE
frontend: Fix entering share numbers for existing Apartments

### DIFF
--- a/frontend/src/common/models.ts
+++ b/frontend/src/common/models.ts
@@ -212,7 +212,7 @@ export interface IApartmentDetails {
         start: number;
         end: number;
         readonly total: number;
-    };
+    } | null;
     links: {
         housing_company: ILinkedModel & {display_name: string};
         real_estate: ILinkedModel;

--- a/frontend/src/features/apartment/ApartmentCreatePage.tsx
+++ b/frontend/src/features/apartment/ApartmentCreatePage.tsx
@@ -41,6 +41,7 @@ const apartmentStateOptions = ApartmentStates.map((state) => {
 const convertApartmentDetailToWritable = (ap: IApartmentDetails): IApartmentWritable => {
     return {
         ...ap,
+        shares: ap.shares || {start: null, end: null},
         ownerships: [], // Stored in a separate state, not needed here
         building: ap.links.building.id,
         address: {

--- a/frontend/src/features/apartment/ApartmentImprovementsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentImprovementsPage.tsx
@@ -25,6 +25,7 @@ type IWritableConsImprovement = Omit<IApartmentConstructionPriceIndexImprovement
 const convertApartmentDetailToWritable = (ap: IApartmentDetails): IApartmentWritable => {
     return {
         ...ap,
+        shares: ap.shares || {start: null, end: null},
         building: ap.links.building.id,
         address: {
             ...ap.address,


### PR DESCRIPTION
Previous fix fixed these only for new apartments, this fixes shares for updating Apartments that previously had no shares set

refs. HT-278 comments