### PR TITLE
Max price calculations - missing index handling

### DIFF
--- a/backend/hitas/calculations/max_price.py
+++ b/backend/hitas/calculations/max_price.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 from dateutil.relativedelta import relativedelta
 from django.db.models import Prefetch, Sum
+from django.utils import timezone
 
 from hitas.models import (
     Apartment,
@@ -27,7 +28,7 @@ def calculate_max_price(
     apartment_share_of_housing_company_loans: int,
 ):
     if calculation_date is None:
-        calculation_date = datetime.date.today()
+        calculation_date = timezone.now().today()
 
     # Fetch apartment
     apartment = fetch_apartment(housing_company_uuid, apartment_uuid, calculation_date)
@@ -103,7 +104,7 @@ def calculate_max_price(
             "market_price_index": market_price_index,
             "surface_area_price_ceiling": surface_area_price_ceiling,
         },
-        "created": datetime.datetime.now(),
+        "created": timezone.now(),
         "valid_until": valid_until,
         "max_price": max_price,
         "index": max_index,

--- a/backend/hitas/calculations/max_price.py
+++ b/backend/hitas/calculations/max_price.py
@@ -103,6 +103,7 @@ def calculate_max_price(
             "market_price_index": market_price_index,
             "surface_area_price_ceiling": surface_area_price_ceiling,
         },
+        "created": datetime.datetime.now(),
         "valid_until": valid_until,
         "max_price": max_price,
         "index": max_index,

--- a/backend/hitas/calculations/max_price.py
+++ b/backend/hitas/calculations/max_price.py
@@ -73,7 +73,7 @@ def calculate_max_price(
     )
     surface_area_price_ceiling = {
         "max_price": roundup(apartment.surface_area_price_ceiling),
-        "valid_until": calculation_date,  # FIXME: use how long index is valid
+        "valid_until": calculation_date + relativedelta(months=1),  # FIXME: use how long index is valid
     }
 
     # Find and mark the maximum
@@ -82,16 +82,20 @@ def calculate_max_price(
         market_price_index["max_price"],
         surface_area_price_ceiling["max_price"],
     )
+
     surface_area_price_ceiling["maximum"] = max_price == surface_area_price_ceiling["max_price"]
     market_price_index["maximum"] = max_price == market_price_index["max_price"]
     construction_price_index["maximum"] = max_price == construction_price_index["max_price"]
 
     if market_price_index["maximum"]:
         max_index = "market_price_index"
+        valid_until = market_price_index["valid_until"]
     elif construction_price_index["maximum"]:
         max_index = "construction_price_index"
+        valid_until = construction_price_index["valid_until"]
     else:
         max_index = "surface_area_price_ceiling"
+        valid_until = surface_area_price_ceiling["valid_until"]
 
     return {
         "calculations": {
@@ -99,6 +103,7 @@ def calculate_max_price(
             "market_price_index": market_price_index,
             "surface_area_price_ceiling": surface_area_price_ceiling,
         },
+        "valid_until": valid_until,
         "max_price": max_price,
         "index": max_index,
         "apartment": {

--- a/backend/hitas/calculations/max_price.py
+++ b/backend/hitas/calculations/max_price.py
@@ -86,6 +86,13 @@ def calculate_max_price(
     market_price_index["maximum"] = max_price == market_price_index["max_price"]
     construction_price_index["maximum"] = max_price == construction_price_index["max_price"]
 
+    if market_price_index["maximum"]:
+        max_index = "market_price_index"
+    elif construction_price_index["maximum"]:
+        max_index = "construction_price_index"
+    else:
+        max_index = "surface_area_price_ceiling"
+
     return {
         "calculations": {
             "construction_price_index": construction_price_index,
@@ -93,11 +100,7 @@ def calculate_max_price(
             "surface_area_price_ceiling": surface_area_price_ceiling,
         },
         "max_price": max_price,
-        "index": (
-            "market_price_index"
-            if market_price_index["maximum"]
-            else ("construction_price_index" if construction_price_index["maximum"] else "surfare_area_price_ceiling")
-        ),
+        "index": max_index,
         "apartment": {
             "shares": {
                 "start": apartment.share_number_start,

--- a/backend/hitas/tests/apis/test_api_apartment_max_price.py
+++ b/backend/hitas/tests/apis/test_api_apartment_max_price.py
@@ -66,6 +66,9 @@ def test__api__apartment_max_price__construction_price_index(api_client: HitasAP
     response = api_client.get(reverse("hitas:max-price-list", args=[hc.uuid, a.uuid]) + "?" + urlencode(query))
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert response.json() == {
+        "max_price": 223558,
+        "valid_until": "2022-10-05",
+        "index": "construction_price_index",
         "calculations": {
             "construction_price_index": {
                 "max_price": 223558,
@@ -109,12 +112,10 @@ def test__api__apartment_max_price__construction_price_index(api_client: HitasAP
             },
             "surface_area_price_ceiling": {
                 "max_price": 146070,
-                "valid_until": "2022-07-05",  # FIXME: dummy value
+                "valid_until": "2022-08-05",  # FIXME: dummy value
                 "maximum": False,
             },
         },
-        "max_price": 223558,
-        "index": "construction_price_index",
         "apartment": {
             "address": {
                 "apartment_number": a.apartment_number,
@@ -198,6 +199,9 @@ def test__api__apartment_max_price__market_price_index(api_client: HitasAPIClien
     response = api_client.get(reverse("hitas:max-price-list", args=[hc.uuid, a.uuid]) + "?" + urlencode(query))
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert response.json() == {
+        "max_price": 275925,
+        "valid_until": "2022-10-05",
+        "index": "market_price_index",
         "calculations": {
             "construction_price_index": {
                 "calculation_variables": {
@@ -241,12 +245,10 @@ def test__api__apartment_max_price__market_price_index(api_client: HitasAPIClien
             },
             "surface_area_price_ceiling": {
                 "max_price": 233712,
-                "valid_until": "2022-07-05",  # FIXME: dummy value
+                "valid_until": "2022-08-05",  # FIXME: dummy value
                 "maximum": False,
             },
         },
-        "max_price": 275925,
-        "index": "market_price_index",
         "apartment": {
             "shares": {"start": 1, "end": 142, "total": 142},
             "rooms": a.rooms,

--- a/backend/hitas/tests/apis/test_api_apartment_max_price.py
+++ b/backend/hitas/tests/apis/test_api_apartment_max_price.py
@@ -65,7 +65,11 @@ def test__api__apartment_max_price__construction_price_index(api_client: HitasAP
 
     response = api_client.get(reverse("hitas:max-price-list", args=[hc.uuid, a.uuid]) + "?" + urlencode(query))
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.json() == {
+
+    response_json = response.json()
+    assert_created(response_json.pop("created"))
+
+    assert response_json == {
         "max_price": 223558,
         "valid_until": "2022-10-05",
         "index": "construction_price_index",
@@ -198,7 +202,11 @@ def test__api__apartment_max_price__market_price_index(api_client: HitasAPIClien
 
     response = api_client.get(reverse("hitas:max-price-list", args=[hc.uuid, a.uuid]) + "?" + urlencode(query))
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.json() == {
+
+    response_json = response.json()
+    assert_created(response_json.pop("created"))
+
+    assert response_json == {
         "max_price": 275925,
         "valid_until": "2022-10-05",
         "index": "market_price_index",
@@ -381,3 +389,9 @@ def test__api__apartment_max_price__missing_index(api_client: HitasAPIClient, mi
         "reason": "Conflict",
         "status": 409,
     }
+
+
+def assert_created(created: str):
+    created = datetime.datetime.fromisoformat(created)
+    # created timestamp is created 0-10 seconds in the past so effectively "now"
+    assert 0 < (datetime.datetime.now() - created).total_seconds() < 10

--- a/backend/hitas/tests/apis/test_api_apartment_max_price.py
+++ b/backend/hitas/tests/apis/test_api_apartment_max_price.py
@@ -3,6 +3,8 @@ import datetime
 import pytest
 from dateutil import relativedelta
 from django.urls import reverse
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
 from django.utils.http import urlencode
 from rest_framework import status
 
@@ -392,6 +394,6 @@ def test__api__apartment_max_price__missing_index(api_client: HitasAPIClient, mi
 
 
 def assert_created(created: str):
-    created = datetime.datetime.fromisoformat(created)
+    created = parse_datetime(created)
     # created timestamp is created 0-10 seconds in the past so effectively "now"
-    assert 0 < (datetime.datetime.now() - created).total_seconds() < 10
+    assert 0 < (timezone.now() - created).total_seconds() < 10

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -911,6 +911,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '406':
           $ref: '#/components/responses/NotAcceptable'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -4135,10 +4137,12 @@ components:
 
             Can have the following values:
             - owner_in_use
+            - index_missing
           type: string
           example: owner_in_use
           x-extensible-enum:
             - owner_in_use
+            - index_missing
 
     UnsupportedMediaTypeError:
       description: Unsupported media type error

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3087,6 +3087,7 @@ components:
       required:
         - max_price
         - index
+        - valid_until
         - calculations
       properties:
         max_price:
@@ -3094,6 +3095,11 @@ components:
           type: integer
           minimum: 0
           example: 223558
+        valid_until:
+          description: TBD
+          type: string
+          format: date
+          example: 2022-10-05
         index:
           description: TBD
           type: string

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3087,6 +3087,7 @@ components:
       required:
         - max_price
         - index
+        - created
         - valid_until
         - calculations
       properties:
@@ -3095,6 +3096,11 @@ components:
           type: integer
           minimum: 0
           example: 223558
+        created:
+          description: TBD
+          type: string
+          format: date-time
+          example: 2022-07-05T15:39:50.742380
         valid_until:
           description: TBD
           type: string


### PR DESCRIPTION
1b283be: backend: better missing indices handling for max price calculations
 - previously 500 was returned and missing indices were not really
   handled. now `409 Conflict` is returned
 - added tests

---

18c53ee: backend: minor code style improvement on how to determinate max index

---

8f21c0f: backend: add global 'valid_until` for max price calculations
 - add validity for the "global" max price calculations so there's
   no need to dig it up from the selected index calculation
 - also correct surface area price ceiling validity, it requires
   +1 additional month

---

d8a03cf: backend: add `created` timestamp to max price calculation

---
