### PR TITLE
max price - OpenAPI fixes

### DIFF
--- a/backend/hitas/calculations/max_price.py
+++ b/backend/hitas/calculations/max_price.py
@@ -75,6 +75,11 @@ def calculate_max_price(
     surface_area_price_ceiling = {
         "max_price": roundup(apartment.surface_area_price_ceiling),
         "valid_until": surface_area_price_ceiling_validity(calculation_date),
+        "calculation_variables": {
+            "calculation_date": calculation_date,
+            "calculation_date_value": apartment.surface_area_price_ceiling_m2,
+            "surface_area": apartment.surface_area,
+        },
     }
 
     # Find and mark the maximum
@@ -248,8 +253,13 @@ WHERE a.id = hitas_apartment.id
         ON sapc.month = DATE_TRUNC('month', %s)
     WHERE a.id = hitas_apartment.id
 """,
+                "surface_area_price_ceiling_m2": """
+    SELECT value
+    FROM hitas_surfaceareapriceceiling
+    WHERE month = DATE_TRUNC('month', %s)
+""",
             },
-            select_params=(calculation_date, calculation_date, calculation_date),
+            select_params=(calculation_date, calculation_date, calculation_date, calculation_date),
         )
         .get(uuid=apartment_uuid, building__real_estate__housing_company__uuid=housing_company_uuid)
     )

--- a/backend/hitas/calculations/max_price.py
+++ b/backend/hitas/calculations/max_price.py
@@ -280,6 +280,9 @@ def calculate_index(
     # 'yhtiön parannukset'
     apartment_housing_company_improvements = Decimal(0)
     for improvement in housing_company_improvements:
+        if improvement.completion_date_index is None:
+            raise IndexMissingException()
+
         # 'omavastuu'
         excess = 30 * total_surface_area
         if excess >= improvement.value:
@@ -287,9 +290,6 @@ def calculate_index(
 
         # 'arvon lisäys'
         value_addition = improvement.value - excess
-
-        if improvement.completion_date_index is None:
-            raise IndexMissingException()
 
         improvement_value = value_addition * (calculation_date_index / improvement.completion_date_index)
         apartment_housing_company_improvements += improvement_value / total_surface_area * apartment.surface_area

--- a/backend/hitas/oracle_migration/runner.py
+++ b/backend/hitas/oracle_migration/runner.py
@@ -42,6 +42,7 @@ from hitas.models import (
     SurfaceAreaPriceCeiling,
 )
 from hitas.models.apartment import DepreciationPercentage
+from hitas.models.indices import AbstractIndex
 from hitas.oracle_migration.cost_areas import hitas_cost_area, init_cost_areas
 from hitas.oracle_migration.globals import anonymize_data, faker, should_anonymize
 from hitas.oracle_migration.oracle_schema import (
@@ -102,7 +103,7 @@ class ConvertedData:
 BULK_INSERT_THRESHOLD = 1000
 
 
-def create_indices(codes: List[LegacyRow], model_class: type[AbstractCode]) -> None:
+def create_indices(codes: List[LegacyRow], model_class: type[AbstractIndex]) -> None:
     for code in codes:
         index = model_class()
 

--- a/backend/hitas/oracle_migration/runner.py
+++ b/backend/hitas/oracle_migration/runner.py
@@ -763,4 +763,12 @@ def do_truncate():
     ]:
         model_class.objects.all_with_deleted().delete(force_policy=HARD_DELETE)
 
-    get_user_model().objects.all().delete()
+    for model_class in [
+        get_user_model(),
+        SurfaceAreaPriceCeiling,
+        ConstructionPriceIndex2005Equal100,
+        ConstructionPriceIndex,
+        MarketPriceIndex,
+        MarketPriceIndex2005Equal100,
+    ]:
+        model_class.objects.all().delete()

--- a/backend/hitas/oracle_migration/types.py
+++ b/backend/hitas/oracle_migration/types.py
@@ -36,8 +36,8 @@ class HitasYearMonth(types.TypeDecorator):
         return str_to_year_month(value)
 
 
-def str_to_year_month(value: str) -> datetime.datetime:
-    return datetime.datetime.strptime(value, "%Y%m")
+def str_to_year_month(value: str) -> datetime.date:
+    return datetime.datetime.strptime(value, "%Y%m").date()
 
 
 class HitasDuration(types.TypeDecorator):

--- a/backend/hitas/tests/apis/test_api_apartment_max_price.py
+++ b/backend/hitas/tests/apis/test_api_apartment_max_price.py
@@ -120,6 +120,11 @@ def test__api__apartment_max_price__construction_price_index(api_client: HitasAP
                 "max_price": 146070,
                 "valid_until": "2022-08-31",
                 "maximum": False,
+                "calculation_variables": {
+                    "calculation_date": "2022-07-05",
+                    "calculation_date_value": 4869.0,
+                    "surface_area": 30,
+                },
             },
         },
         "apartment": {
@@ -148,7 +153,7 @@ def test__api__apartment_max_price__construction_price_index(api_client: HitasAP
                 "end": a.share_number_end,
                 "total": 2383,
             },
-            "surface_area": a.surface_area,
+            "surface_area": 30,
         },
         "housing_company": {
             "archive_id": hc.id,
@@ -257,6 +262,11 @@ def test__api__apartment_max_price__market_price_index(api_client: HitasAPIClien
                 "max_price": 233712,
                 "valid_until": "2022-08-31",
                 "maximum": False,
+                "calculation_variables": {
+                    "calculation_date": "2022-07-05",
+                    "calculation_date_value": 4869.0,
+                    "surface_area": 48.0,
+                },
             },
         },
         "apartment": {
@@ -370,6 +380,11 @@ def test__api__apartment_max_price__surface_area_price_ceiling(api_client: Hitas
                 "max_price": 236292,
                 "valid_until": "2022-11-30",
                 "maximum": True,
+                "calculation_variables": {
+                    "calculation_date": "2022-09-29",
+                    "calculation_date_value": 4872.0,
+                    "surface_area": 48.5,
+                },
             },
         },
         "apartment": {

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3184,6 +3184,30 @@ components:
                 - maximum
                 - valid_until
               properties:
+                calculation_variables:
+                  description: Variables used for apartment's surface area price ceiling calculation
+                  type: object
+                  additionalProperties: false
+                  required:
+                    - calculation_date
+                    - calculation_date_value
+                    - surface_area
+                  properties:
+                    calculation_date:
+                      description: Maximum price calculation date.
+                      type: string
+                      format: date
+                      example: "2022-07-05"
+                    calculation_date_value:
+                      description: The value on the calculation date.
+                      type: number
+                      minimum: 0
+                      example: 129.29
+                    surface_area:
+                      description: Apartment's surface area
+                      type: number
+                      minimum: 0
+                      example: 30.0
                 max_price:
                   description: Maximum price for this index
                   type: integer

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -884,7 +884,9 @@ paths:
         - name: calculation_date
           required: false
           in: query
-          description: TBD
+          description: |-
+            Date which is used for calculating the maximum price. This cannot be in the future.
+            This mainly affects which indices are used and the validity period.
           schema:
             type: string
             format: date
@@ -892,7 +894,8 @@ paths:
         - name: apartment_share_housing_company_loans
           required: false
           in: query
-          description: TBD
+          description: |-
+            How much the apartment's share of the housing company loans are on the calculation date
           schema:
             type: integer
             minimum: 0
@@ -2241,7 +2244,7 @@ paths:
   /api/v1/indices/{index}/{month}:
     get:
       description: Read a single index by month
-      operationId: read-index-value
+      operationId: read-index
       tags:
         - Indices
       parameters:
@@ -2269,8 +2272,8 @@ paths:
           $ref: '#/components/responses/InternalServerError'
 
     put:
-      description: Update max value index by month
-      operationId: update-max-value-index
+      description: Update index by month
+      operationId: update-index
       tags:
         - Indices
       parameters:
@@ -2996,8 +2999,34 @@ components:
                       - 2.5
                       - 10
 
+    ApartmentMaxPriceCalculation:
+      description: Calculations for particular index
+      type: object
+      required:
+        - calculation_variables
+        - max_price
+        - maximum
+        - valid_until
+      properties:
+        calculation_variables:
+          $ref: '#/components/schemas/ApartmentMaxPriceCalculationVars'
+        max_price:
+          description: Maximum price for this index
+          type: integer
+          minimum: 0
+          example: 223558
+        valid_until:
+          description: The date until this maximum price calculation is valid.
+          type: string
+          format: date
+          example: 2022-10-05
+        maximum:
+          description: Is this calculated maximum price the highest maximum price.
+          type: boolean
+          example: true
+
     ApartmentMaxPriceCalculationVars:
-      description: TBD
+      description: Variables used for apartment's maximum price calculations
       type: object
       required:
         - acquisition_price
@@ -3015,67 +3044,81 @@ components:
         - calculation_date_index
       properties:
         acquisition_price:
-          description: TBD
+          description: Apartment's acquisition price
           type: integer
           minimum: 0
           example: 199500
         additional_work_during_construction:
-          description: TBD
+          description: Amount of apartment's additional work done during construction
           type: integer
           minimum: 0
           example: 0
         basic_price:
-          description: TBD
+          description: |-
+            Basic price is sum of the apartment's acquisition price and the apartment's
+            additional work during construction.
           type: integer
           minimum: 0
           example: 199500
         index_adjustment:
-          description: TBD
+          description: |-
+            Value increase of the apartment based on the index. Calculated by dividing the
+            calculation date index value with the apartment's completion date's index value
+            and multiplying the result with the apartment's basic price.
           type: integer
           minimum: 0
           example: 26401
         apartment_improvements:
-          description: TBD
+          description: |-
+            Total value of this apartment's improvements. Calculated by summing up all apartment
+            improvement's values together.
           type: integer
           minimum: 0
           example: 0
         housing_company_improvements:
-          description: TBD
+          description: |-
+            Total value of this apartment's housing company's improvements. Calculated by
+            summing up each improvement, first removing the excess and adjusting the improvement
+            by the improvement's completion date index for each improvement.
           type: integer
           minimum: 0
           example: 157
         debt_free_price:
-          description: TBD
+          description: |-
+            Sum of basic price, index adjustment, apartment improvements and housing company
+            improvements.
           type: integer
           minimum: 0
           example: 226058
         debt_free_price_m2:
-          description: TBD
+          description: |-
+            Debt free price divided by the apartment's surface area.
           type: integer
           minimum: 0
           example: 7535
         apartment_share_of_housing_company_loans:
-          description: TBD
+          description: |-
+            How much the apartment's share of the housing company loans are on the calculation date.
           type: integer
           minimum: 0
           example: 2500
         completion_date:
-          description: TBD
+          description: The date the apartment was completed.
           type: string
           format: date
           example: "2019-11-27"
         completion_date_index:
-          description: TBD
+          description: The index value on the apartment's completion date.
           type: number
           minimum: 0
           example: 129.29
         calculation_date:
-          description: TBD
+          description: Maximum price calculation date.
           type: string
           format: date
           example: "2022-07-05"
         calculation_date_index:
-          description: TBD
+          description: The index value on the calculation date.
           type: number
           minimum: 0
           example: 146.4
@@ -3092,26 +3135,36 @@ components:
         - calculations
       properties:
         max_price:
-          description: TBD
+          description: The maximum price for this apartment.
           type: integer
           minimum: 0
           example: 223558
         created:
-          description: TBD
+          description: The timestamp when this maximum price calculation was done.
           type: string
           format: date-time
           example: 2022-07-05T15:39:50.742380
         valid_until:
-          description: TBD
+          description: The date until this maximum price calculation is valid.
           type: string
           format: date
           example: 2022-10-05
         index:
-          description: TBD
+          description: |-
+            The index used for the maximum price calculation.
+
+            Can have the following values:
+            - construction_price_index
+            - market_price_index
+            - surface_area_price_ceiling
           type: string
           example: construction_price_index
+          x-extensible-enum:
+            - construction_price_index
+            - market_price_index
+            - surface_area_price_ceiling
         calculations:
-          description: TBD
+          description: Calculations for each index
           type: object
           required:
             - construction_price_index
@@ -3119,169 +3172,179 @@ components:
             - surface_area_price_ceiling
           properties:
             construction_price_index:
-              description: TBD
+              $ref: '#/components/schemas/ApartmentMaxPriceCalculation'
+            market_price_index:
+              $ref: '#/components/schemas/ApartmentMaxPriceCalculation'
+            surface_area_price_ceiling:
+              description: Calculations for particular index
               type: object
+              additionalProperties: false
               required:
-                - calculation_variables
                 - max_price
                 - maximum
                 - valid_until
               properties:
-                calculation_variables:
-                  $ref: '#/components/schemas/ApartmentMaxPriceCalculationVars'
                 max_price:
-                  description: TBD
+                  description: Maximum price for this index
                   type: integer
                   minimum: 0
                   example: 223558
                 valid_until:
-                  description: TBD
+                  description: The date until this maximum price calculation is valid.
                   type: string
                   format: date
                   example: 2022-10-05
                 maximum:
-                  description: TBD
+                  description: Is this calculated maximum price the highest maximum price.
                   type: boolean
                   example: true
-            market_price_index:
-              type: object
-              properties:
-                calculation_variables:
-                  $ref: '#/components/schemas/ApartmentMaxPriceCalculationVars'
-                max_price:
-                  description: TBD
-                  type: integer
-                  minimum: 0
-                  example: 222343
-                valid_until:
-                  description: TBD
-                  type: string
-                  format: date
-                  example: 2022-10-05
-                maximum:
-                  description: TBD
-                  type: boolean
-                  example: false
-            surface_area_price_ceiling:
-              type: object
-              properties:
-                max_price:
-                  description: TBD
-                  type: integer
-                  minimum: 0
-                  example: 146070
-                valid_until:
-                  description: TBD
-                  type: string
-                  format: date
-                  example: 2022-10-05
-                maximum:
-                  description: TBD
-                  type: boolean
-                  example: false
+
         apartment:
+          description: Share information
           type: object
+          additionalProperties: false
+          required:
+            - shares
+            - rooms
+            - apartment_type
+            - surface_area
+            - address
+            - ownership
           properties:
             shares:
+              description: Share information
               type: object
+              additionalProperties: false
+              nullable: true
+              required:
+                - start
+                - end
+                - total
               properties:
                 start:
-                  description: TBD
+                  description: First share number
                   type: integer
+                  nullable: true
                   minimum: 0
                   example: 18402
                 end:
-                  description: TBD
+                  description: Last share number
                   type: integer
+                  nullable: true
                   minimum: 0
                   example: 20784
                 total:
-                  description: TBD
+                  description: Total number of shares
                   type: integer
                   minimum: 0
+                  readOnly: true
                   example: 2382
             rooms:
-              description: TBD
+              description: Number of rooms for this apartment
               type: integer
               minimum: 0
               nullable: true
               example: 2
             apartment_type:
-              description: TBD
+              description: Apartment type
               type: string
               example: "h+k"
             surface_area:
-              description: TBD
+              description: Apartment's surface area
               type: number
               minimum: 0
               nullable: true
               example: 30.0
             address:
+              description: Apartment's address
               type: object
+              additionalProperties: false
+              required:
+                - street_address
+                - floor
+                - stair
+                - apartment_number
+                - postal_code
+                - city
               properties:
                 street_address:
-                  description: TBD
+                  description: Apartment's street address
                   type: string
                   example: Torikatu 18
                 floor:
-                  description: TBD
+                  description: Apartment's floor
                   type: string
                   example: "1"
                 stair:
-                  description: TBD
+                  description: Apartment's stair
                   type: string
                   example: B
                 apartment_number:
-                  description: TBD
+                  description: Apartment number
                   type: integer
                   minimum: 0
                   example: 18
                 postal_code:
-                  description: TBD
+                  description: Apartment's postal code
                   type: string
+                  example: "00100"
                 city:
-                  description: TBD
+                  description: Apartment's city
                   type: string
-                  example: "90500"
+                  example: Helsinki
             ownership:
-              description: TBD
+              description: Ownership information
               type: array
               items:
+                description: Single ownership
                 type: object
+                additionalProperties: false
+                required:
+                  - percentage
+                  - name
                 properties:
                   percentage:
-                    description: TBD
+                    description: Ownership percentage of this apartment
                     type: number
                     minimum: 0
                     maximum: 100
                     example: 100.0
                   name:
-                    description: TBD
+                    description: Owner name
                     type: string
                     example: Helsingin kaupunki
         housing_company:
-          description: TBD
+          description: Housing company information for this apartment
           type: object
+          additionalProperties: false
+          required:
+            - official_name
+            - archive_id
+            - property_manager
           properties:
             official_name:
-              description: TBD
+              description: Official name
               type: string
               example: As Oy Helmi
             archive_id:
-              description: TBD
+              description: Archive ID
               type: integer
               minimum: 0
               example: 792
             property_manager:
-              description: TBD
+              description: Property manager information
               type: object
+              additionalProperties: false
+              required:
+                - name
+                - street_address
               properties:
                 name:
-                  description: TBD
+                  description: Name of this property manager
                   type: string
                   example: Isännöinti Isät Oy
                 street_address:
-                  description: TBD
+                  description: Property manager's street address
                   type: string
                   example: Isätie 42
 
@@ -3913,6 +3976,8 @@ components:
           minimum: 0
           nullable: true
           example: 127.12
+        valid_until:
+          $ref: '#/components/schemas/YearMonth'
 
     HousingCompanyState:
       description: |-

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,6 +63,7 @@
     "react-scripts": "^5.0.1"
   },
   "resolutions": {
-    "@svgr/webpack": "^6.3.1"
+    "@svgr/webpack": "^6.3.1",
+    "**/recursive-readdir/minimatch": "^3.0.5"
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2258,9 +2258,9 @@
   integrity sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==
 
 "@types/node@^18.8.3":
-  version "18.11.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.6.tgz#4f91b0b30d405fdf76e0029b11ef5df6a0da4261"
-  integrity sha512-j3CEDa2vd96K0AXF8Wur7UucACvnjkk8hYyQAHhUNciabZLDl9nfAEVUSwmh245OOZV15bRA3Y590Gi5jUcDJg==
+  version "18.11.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.7.tgz#8ccef136f240770c1379d50100796a6952f01f94"
+  integrity sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -6680,17 +6680,17 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimatch@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.0.4:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
+  integrity sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==
   dependencies:
     brace-expansion "^1.1.7"
 


### PR DESCRIPTION
52ab7e0: frontend: bump minimatch version to 3.0.5
 - fixes https://github.com/City-of-Helsinki/hitas/security/dependabot/6

---

90b5e36: backend: hitasmigration: truncate all indices

---

dcf98c0: backend: hitasmigration: fix type hint

---

a1def2e: backend: hitasmigration: use date instead of datetime

---

c04c03a: backend: max price calculation: minor improvement

---

739e4ac: backend: OpenAPI: max price TBD's fixed

---

a287565: backend: add surface area price ceiling calculation variables
 - mainly the calculation date value is required

---
