### PR TITLE
 backend: fix unconfirmed max price calculation

### DIFF
--- a/backend/hitas/oracle_migration/oracle_schema/company.py
+++ b/backend/hitas/oracle_migration/oracle_schema/company.py
@@ -3,7 +3,8 @@ from sqlalchemy import Column, Date, Float, ForeignKey, ForeignKeyConstraint, In
 from hitas.oracle_migration.oracle_schema.metadata import metadata_obj
 from hitas.oracle_migration.types import (
     HitasAnonymizedAddress,
-    HitasAnonymizedDate,
+    HitasAnonymizedDay,
+    HitasAnonymizedMonthAndDay,
     HitasAnonymizedName,
     HitasAnonymizedNameCommaSeparated,
     HitasAnonymizedPropertyIdentifier,
@@ -43,7 +44,7 @@ companies = Table(
     Column("N_RAKKORKO", Float, nullable=False),
     Column("N_VIIVKORKO1", Float, nullable=False),  # Always 0
     Column("N_VIIVKORKO2", Float, nullable=False),  # Always 0
-    Column("D_MHLVAHPVM", HitasAnonymizedDate, key="sales_price_catalogue_confirmation_date"),
+    Column("D_MHLVAHPVM", HitasAnonymizedMonthAndDay, key="sales_price_catalogue_confirmation_date"),
     Column("C_TALOKOODI", String(16), nullable=False),  # Always 'TALOTYYPPI'
     Column("C_TALOTYYP", String(12), key="building_type_code", nullable=False),
     Column("C_RAKEKOODI", String(16), nullable=False),  # Always 'RAKENTAJA'
@@ -59,7 +60,7 @@ companies = Table(
     Column("C_SAANNOSTELY", HitasBoolean, nullable=False),
     Column("C_HITVAPKOODI", String(16), key="state_codebook", nullable=False),  # Always 'HITVAPAUTUS'
     Column("C_HITVAPTYYP", String(12), key="state_code", nullable=False),
-    Column("D_HITVAPILMPVM", HitasAnonymizedDate, key="notification_date"),
+    Column("D_HITVAPILMPVM", HitasAnonymizedMonthAndDay, key="notification_date"),
     Column("N_MHINDKESKIHINTA", Integer, nullable=False),
     Column("N_RAKINDKESKIHINTA", Integer, nullable=False),
     Column("C_DIAARINRO", String(10)),
@@ -143,14 +144,14 @@ apartments = Table(
     Column("N_OSAKELKM1", Integer, key="share_number_start", nullable=False),
     Column("N_OSAKELKM2", Integer, key="share_number_end", nullable=False),
     Column("N_OSAKEYHT", Integer, nullable=False),
-    Column("D_VALMPVM", HitasAnonymizedDate, key="completion_date"),
+    Column("D_VALMPVM", HitasAnonymizedDay, key="completion_date"),
     Column("N_LUOVHINTA", Integer, key="debt_free_purchase_price", nullable=False),
     Column("N_KAUPHINTA", Integer, key="purchase_price", nullable=False),
     Column("N_ENSIJLAINA", Integer, key="primary_loan_amount", nullable=False),
     Column("N_HANKARVO", Integer, key="acquisition_price", nullable=False),
     Column("N_RAKKORKO", Integer, key="interest_during_construction", nullable=False),
-    Column("D_KAUPPVM1", HitasAnonymizedDate, key="first_purchase_date"),
-    Column("D_KAUPPVM2", HitasAnonymizedDate, key="latest_purchase_date"),
+    Column("D_KAUPPVM1", HitasAnonymizedMonthAndDay, key="first_purchase_date"),
+    Column("D_KAUPPVM2", HitasAnonymizedMonthAndDay, key="latest_purchase_date"),
     Column("N_RAKLAINA", Integer, key="loans_during_construction", nullable=False),
     Column("N_RALUOVHINTA", Integer, key="debt_free_purchase_price_during_construction", nullable=False),
     Column("C_LISATIET", HitasBoolean, nullable=False),

--- a/backend/hitas/oracle_migration/types.py
+++ b/backend/hitas/oracle_migration/types.py
@@ -2,6 +2,7 @@ import datetime
 import random
 
 import sqlalchemy.types as types
+from dateutil.relativedelta import relativedelta
 
 from hitas.oracle_migration.globals import faker, should_anonymize
 
@@ -156,11 +157,18 @@ class HitasAnonymizedText(HitasAnonymized):
         return faker().text(max_nb_chars=self.length)
 
 
-class HitasAnonymizedDate(HitasAnonymized):
+class HitasAnonymizedMonthAndDay(HitasAnonymized):
     def fake(self, value):
         beginning_of_year = value.replace(day=1, month=1)
         beginning_of_next_year = beginning_of_year.replace(year=beginning_of_year.year + 1)
         return faker().date_between_dates(beginning_of_year, beginning_of_next_year)
+
+
+class HitasAnonymizedDay(HitasAnonymized):
+    def fake(self, value):
+        beginning_of_month = value.replace(day=1)
+        beginning_of_next_month = value + relativedelta(months=1)
+        return faker().date_between_dates(beginning_of_month, beginning_of_next_month)
 
 
 class HitasAnonymizedEmail(HitasAnonymized):

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -210,7 +210,8 @@ def test__api__apartment__list(api_client: HitasAPIClient):
 def test__api__apartment__retrieve(api_client: HitasAPIClient):
     ap: Apartment = ApartmentFactory.create(
         completion_date=datetime.date(2011, 1, 1),
-        debt_free_purchase_price=100000,
+        debt_free_purchase_price=80000,
+        primary_loan_amount=20000,
         surface_area=50,
     )
     hc: HousingCompany = ap.housing_company
@@ -278,11 +279,11 @@ def test__api__apartment__retrieve(api_client: HitasAPIClient):
                     "pre_2011": None,
                     "onwards_2011": {
                         "construction_price_index": {
-                            "value": 150000,  # 100000 (debt_free_purchase_price) * 150/100
+                            "value": 150000,  # (80000 + 20000) * 150/100
                             "maximum": True,
                         },
                         "market_price_index": {
-                            "value": 125000,  # 100000 (debt_free_purchase_price) * 250/200
+                            "value": 125000,  # (80000 + 20000) * 250/200
                             "maximum": False,
                         },
                         "surface_area_price_ceiling": {
@@ -364,7 +365,8 @@ def _test_max_prices(
 
     ap: Apartment = ApartmentFactory.create(
         completion_date=completion_date,
-        debt_free_purchase_price=100000 if not null_values else None,
+        debt_free_purchase_price=80000 if not null_values else None,
+        primary_loan_amount=20000 if not null_values else None,
         surface_area=50 if not null_values else None,
     )
 

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -483,7 +483,9 @@ class ApartmentViewSet(HitasModelViewSet):
         return f"""
     SELECT
         ROUND(
-            a.debt_free_purchase_price * current_{table}.value / NULLIF(original_{table}.value, 0)
+            (
+                a.debt_free_purchase_price + a.primary_loan_amount
+            ) * current_{table}.value / NULLIF(original_{table}.value, 0)
         ) AS max_price_{table}
     FROM hitas_apartment AS a
     LEFT JOIN hitas_{table} AS original_{table} ON


### PR DESCRIPTION
777eda6: backend: fix unconfirmed max price calculation
 - also use `primary_loan_amount` in calculations, not just
   `debt_free_purchase_price` (in other words, use `acquisition_price`)

---

6fd917b: backend: oraclemigration: only change the date when anonymizing apartment completion date
 - copletion date's month affect the selected index so keep the month
   (and year as previously) but only randomize the day

---
