### PR TITLE
Styles for apartment max price view, along with some small restructuring

### DIFF
--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -65,8 +65,8 @@ const ConfirmedPrice = ({confirmed}) => {
     return (
         <>
             <p className="confirmed-price">{formatMoney(confirmed.maximum_price)}</p>
-            <p>Voimassa {confirmed.valid.valid_until} saakka</p>
-            <p>Vahvistettu {confirmed.confirmed_at.split("T")[0]}</p>
+            <p>Vahvistettu: {confirmed.confirmed_at.split("T")[0]}</p>
+            <p>Voimassa: {confirmed.valid.valid_until} asti</p>
         </>
     );
 };

--- a/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
+++ b/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
@@ -28,9 +28,12 @@ import {formatMoney, hitasToast} from "../../common/utils";
 const CalculationRowPrice = ({label, calculation}) => {
     const maximumBoldedStyle = calculation.maximum ? {fontWeight: 700} : {};
     return (
-        <div>
-            <p style={maximumBoldedStyle}>{label}</p>
-            <p style={maximumBoldedStyle}>{formatMoney(calculation.maximum_price)}</p>
+        <div
+            className="confirmation-modal__calculation-row"
+            style={maximumBoldedStyle}
+        >
+            <label>{label}</label>
+            <p>{formatMoney(calculation.maximum_price)}</p>
         </div>
     );
 };
@@ -162,16 +165,16 @@ const LoadedApartmentMaxPrice = ({apartment}: {apartment: IApartmentDetails}): J
     };
 
     return (
-        <div className="view--create view--set-apartment">
+        <div className="view--set-apartment">
             <h1 className="main-heading">
-                {apartment.address.street_address} - {apartment.address.stair}
-                {apartment.address.apartment_number} ({apartment.links.housing_company.display_name})
+                <div>
+                    {apartment.address.street_address} - {apartment.address.stair}
+                    {apartment.address.apartment_number} ({apartment.links.housing_company.display_name})
+                </div>
             </h1>
             <div className="field-sets">
                 <Fieldset heading="">
-                    <div className="row">
-                        <h2 className="detail-list__heading">Laskentaan vaikuttavat asunnon tiedot</h2>
-                    </div>
+                    <h2 className="detail-list__heading">Laskentaan vaikuttavat asunnon tiedot</h2>
                     <div className="row">
                         <FormInputField
                             inputType="number"
@@ -182,26 +185,15 @@ const LoadedApartmentMaxPrice = ({apartment}: {apartment: IApartmentDetails}): J
                             setFormData={setFormData}
                             error={error}
                         />
-                    </div>
-                    <div className="row">
-                        <ImprovementsTable
-                            data={apartment}
-                            title="Laskentaan vaikuttavat yhtiön parannukset"
+                        <FormInputField
+                            inputType="date"
+                            label="Yhtiölainaosuuden päivämäärä"
+                            fieldPath="housing_company_loans_date"
+                            required
+                            formData={formData}
+                            setFormData={setFormData}
+                            error={error}
                         />
-                    </div>
-                    <div className="row">
-                        <QueryStateHandler
-                            data={housingCompanyData}
-                            error={housingCompanyError}
-                            isLoading={isHousingCompanyLoading}
-                        >
-                            <ImprovementsTable
-                                data={housingCompanyData as IHousingCompanyDetails}
-                                title="Yhtiökohtaiset parannukset"
-                            />
-                        </QueryStateHandler>
-                    </div>
-                    <div className="row">
                         <FormInputField
                             inputType="date"
                             label="Laskentapäivämäärä"
@@ -212,22 +204,32 @@ const LoadedApartmentMaxPrice = ({apartment}: {apartment: IApartmentDetails}): J
                             error={error}
                         />
                     </div>
+                    <ImprovementsTable
+                        data={apartment}
+                        title="Laskentaan vaikuttavat asunnon parannukset"
+                    />
+                    <QueryStateHandler
+                        data={housingCompanyData}
+                        error={housingCompanyError}
+                        isLoading={isHousingCompanyLoading}
+                    >
+                        <ImprovementsTable
+                            data={housingCompanyData as IHousingCompanyDetails}
+                            title="Yhtiökohtaiset parannukset"
+                        />
+                    </QueryStateHandler>
+                    <div className="row">
+                        <NavigateBackButton />
+                        <Button
+                            theme="black"
+                            onClick={handleCalculateButton}
+                            iconLeft={<IconCheck />}
+                        >
+                            Laske
+                        </Button>
+                    </div>
                 </Fieldset>
             </div>
-            <div
-                className="align-content-right"
-                style={{marginTop: "10px"}}
-            >
-                <NavigateBackButton />
-                <Button
-                    theme="black"
-                    onClick={handleCalculateButton}
-                    iconLeft={<IconCheck />}
-                >
-                    Laske
-                </Button>
-            </div>
-
             <Dialog
                 id="maximum-price-confirmation-modal"
                 closeButtonLabelText=""
@@ -270,7 +272,7 @@ const ApartmentMaxPricePage = (): JSX.Element => {
     });
 
     return (
-        <div className="view--apartment-details">
+        <div className="view--apartment view--apartment-details">
             <QueryStateHandler
                 data={data}
                 error={error}

--- a/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
+++ b/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
@@ -218,7 +218,7 @@ const LoadedApartmentMaxPrice = ({apartment}: {apartment: IApartmentDetails}): J
                             title="Yhtiökohtaiset parannukset"
                         />
                     </QueryStateHandler>
-                    <div className="row">
+                    <div className="row row--buttons">
                         <NavigateBackButton />
                         <Button
                             theme="black"

--- a/frontend/src/styles/base/_general.sass
+++ b/frontend/src/styles/base/_general.sass
@@ -14,6 +14,16 @@ ul, ol
   list-style-type: none
   padding-left: 0
 
+.row
+  @include flexbox()
+  @include flex-flow(row nowrap)
+  &--buttons
+    align-items: center
+    justify-content: space-between
+    >*:only-child
+      margin-left: auto
+      margin-right: auto
+
 .pull-right
   float: right
   align-content: center

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -140,8 +140,6 @@
     padding-bottom: 4rem
 
     .row
-      @include flexbox()
-      flex-flow: row nowrap
       border-bottom: 1px solid #CCC
       margin-bottom: 1rem
 

--- a/frontend/src/styles/components/_ApartmentMaxPricePage.sass
+++ b/frontend/src/styles/components/_ApartmentMaxPricePage.sass
@@ -7,15 +7,10 @@
       height: 30px
 
   .row
-    @include flexbox()
-    @include flex-flow(row)
-    align-items: flex-end
+    justify-content: space-between
     gap: $spacing-layout-s
     > div
       flex-grow: 1
-    > button
-      display: inline-flex
-      height: 56px
 
 .confirmation-modal__calculation-row
   p

--- a/frontend/src/styles/components/_ApartmentMaxPricePage.sass
+++ b/frontend/src/styles/components/_ApartmentMaxPricePage.sass
@@ -1,0 +1,24 @@
+@use '../imports' as *
+
+.view--set-apartment
+  .main-heading
+    align-items: center
+    div
+      height: 30px
+
+  .row
+    @include flexbox()
+    @include flex-flow(row)
+    align-items: flex-end
+    gap: $spacing-layout-s
+    > div
+      flex-grow: 1
+    > button
+      display: inline-flex
+      height: 56px
+
+.confirmation-modal__calculation-row
+  p
+    margin-top: $spacing-xs
+    margin-bottom: $spacing-m
+    font-size: $fontsize-body-l

--- a/frontend/src/styles/components/index.sass
+++ b/frontend/src/styles/components/index.sass
@@ -2,4 +2,5 @@
 @forward "CreatePage"
 @forward "DialogModule"
 @forward "ApartmentDetails"
+@forward "ApartmentMaxPricePage"
 @forward "Codes"


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds styles to the maximum price view, along with the confirmation dialog within it. There's also some small restructuring mainly focusing on stilistic elements. I also added the field for the date of the loan, as requested in the demo review - but it's not functional.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

  - **Frontend**
    - [X] Changes have been tested
  - **Backend**
    - [ ] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan

Navigate to the apartment view, and click on "Vahvista", which takes you to the styled view. Fill in a number in "Yhtiölainaosuus" and click on "Laske", which will bring out the confirmation dialog modal.
