### PR TITLE
Fixed height listings

### DIFF
--- a/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
@@ -233,7 +233,7 @@ const HousingCompanyDetailsPage = () => {
     const {data, error, isLoading} = useGetHousingCompanyDetailQuery(params.housingCompanyId);
 
     return (
-        <div className="view--company-details">
+        <div className="view--housing-company-details">
             <QueryStateHandler
                 data={data}
                 error={error}

--- a/frontend/src/features/housingCompany/HousingCompanyListPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyListPage.tsx
@@ -118,7 +118,7 @@ const HousingCompanyListPage = (): JSX.Element => {
     const [filterParams, setFilterParams] = useState({string: ""});
 
     return (
-        <div className="view--companies-listing">
+        <div className="view--housing-company-list">
             <h1 className="main-heading">
                 <span>Kaikki kohteet</span>
                 <Link to="create">

--- a/frontend/src/styles/components/_ApartmentList.sass
+++ b/frontend/src/styles/components/_ApartmentList.sass
@@ -1,18 +1,24 @@
 @use '../imports' as *
 
 .view--apartments-listing
+
   .results-list
     height: 1009px
     background: #eee
     overflow: hidden
+
   .results-list__item
     height: 100px
     background: white
+
   .results-list > a:last-child
     border-bottom: 1px solid #ccc
+
   .listing >  .search [class^="Icon-module"]
     top: 0
+
   .list-header
+
     &.apartment
       width: 11%
 
@@ -24,26 +30,3 @@
 
     &.state
       width: 5%
-
-.view--company-details
-  .list-amount
-    display: none
-
-  .results
-    grid-column-start: 1
-    grid-column-end: 3
-
-  .list-header
-    &.apartment
-      width: 8%
-
-    &.area
-      width: 42%
-
-    &.address
-      width: 36%
-
-    &.state
-      width: 13%
-
-

--- a/frontend/src/styles/components/_ApartmentList.sass
+++ b/frontend/src/styles/components/_ApartmentList.sass
@@ -1,6 +1,15 @@
 @use '../imports' as *
 
 .view--apartments-listing
+  .results-list
+    height: 1009px
+    background: #eee
+    overflow: hidden
+  .results-list__item
+    height: 100px
+    background: white
+  .results-list > a:last-child
+    border-bottom: 1px solid #ccc
   .listing >  .search [class^="Icon-module"]
     top: 0
   .list-header

--- a/frontend/src/styles/components/_HousingCompanyList.sass
+++ b/frontend/src/styles/components/_HousingCompanyList.sass
@@ -1,0 +1,14 @@
+@use '../imports' as *
+
+.view--housing-company-list
+  .results-list
+    height: 859px
+    overflow: hidden
+    background: #eee
+
+  .results-list__item
+    height: 85px
+    background: white
+
+  .results-list > a:last-child
+    border-bottom: 1px solid #ccc

--- a/frontend/src/styles/components/_HousingCompanyPage.sass
+++ b/frontend/src/styles/components/_HousingCompanyPage.sass
@@ -1,0 +1,75 @@
+@use '../imports' as *
+
+.view--housing-company-details
+
+  .company-status
+    margin-bottom: 16px
+
+  .company-details
+    > *
+      margin-bottom: 75px
+
+    .tab-area
+      background: $color-black-5
+      padding-bottom: 0.1px
+
+    .tab-list
+      background-color: white
+
+    &__tab
+      background: white
+      margin: $spacing-layout-s
+      padding: $spacing-layout-s
+      @include flexbox()
+      @include flex-flow(row nowrap)
+
+      .column
+        width: 50%
+        border-left: 1px solid #ccc
+        padding-left: $spacing-layout-xs
+
+        &:not(:first-child)
+          margin-left: $spacing-layout-s
+
+      .detail-field-label
+        display: block
+        font-size: $fontsize-body-m
+        margin-bottom: $spacing-3-xs
+        letter-spacing: 1px
+        color: $color-black-50
+
+      .detail-field-value
+        font-size: $fontsize-body-xl
+        font-weight: 600
+
+        span
+          color: $color-black-50
+          font-weight: 400
+
+        &:not(:last-child)
+          margin-bottom: $spacing-layout-s
+
+      textarea
+        font-size: $fontsize-body-m
+        width: 100%
+        height: 200px
+
+  .list-amount
+    display: none
+
+  .results
+    grid-column-start: 1
+    grid-column-end: 3
+
+  .list-header
+    &.apartment
+      width: 8%
+
+    &.area
+      width: 42%
+
+    &.address
+      width: 36%
+
+    &.state
+      width: 13%

--- a/frontend/src/styles/components/index.sass
+++ b/frontend/src/styles/components/index.sass
@@ -2,6 +2,7 @@
 @forward "CreatePage"
 @forward "DialogModule"
 @forward "HousingCompanyList"
+@forward "HousingCompanyPage"
 @forward "ApartmentDetails"
 @forward "ApartmentMaxPricePage"
 @forward "Codes"

--- a/frontend/src/styles/components/index.sass
+++ b/frontend/src/styles/components/index.sass
@@ -1,6 +1,7 @@
 @forward "ApartmentList"
 @forward "CreatePage"
 @forward "DialogModule"
+@forward "HousingCompanyList"
 @forward "ApartmentDetails"
 @forward "ApartmentMaxPricePage"
 @forward "Codes"

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -249,10 +249,6 @@
       width: 100%
       height: 200px
 
-.company-page
-  .company-status
-    margin-bottom: 16px
-
 .list-wrapper--real-estates, .list-wrapper--buildings
   width: 50%
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

Makes the housing company and apartment listings height fixed, so the pagination element doesn't jump around even if the page doesn't contain ten list items. Also makes the list item heights fixed to the largest size encountered so far, despite the contents (necessary to be able to calculate the height for the entire list).
Also adds HousingCompanyPage.sass as a separate style sheet, and gathers relevant style rules there - as they were a bit all over the place before.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [X] Changes have been tested
- **Backend**
    - [ ] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan
Navigate to the housing company list and/or the apartments list, and check the last page. Click on the previous page and/or next page buttons and see that the list height stays the same (i.e. maxed out) no matter what the contents are.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-308
