### PR TITLE
backend: add housing company improvements to max price calculations

### DIFF
--- a/backend/hitas/calculations/__init__.py
+++ b/backend/hitas/calculations/__init__.py
@@ -1,1 +1,2 @@
+from hitas.calculations.improvement import calculate_housing_company_improvements_after_2010
 from hitas.calculations.max_price import calculate_max_price

--- a/backend/hitas/calculations/exceptions.py
+++ b/backend/hitas/calculations/exceptions.py
@@ -1,0 +1,6 @@
+class IndexMissingException(Exception):
+    pass
+
+
+class InvalidCalculationResultException(Exception):
+    pass

--- a/backend/hitas/calculations/helpers.py
+++ b/backend/hitas/calculations/helpers.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Optional, Union
+
+
+def roundup(v: Decimal, decimals=0) -> Optional[Union[int, float]]:
+    if v is None:
+        return None
+
+    exp = Decimal("1." + ("0" * decimals))
+    if decimals == 0:
+        return int(v.quantize(exp, ROUND_HALF_UP))
+    else:
+        return float(v.quantize(exp, ROUND_HALF_UP))
+
+
+class NoneSum:
+    def __init__(self, default_fn=int):
+        self.value = None
+        self.default_fn = default_fn
+
+    def __iadd__(self, other):
+        if other is None:
+            return self
+
+        if self.value is None:
+            self.value = self.default_fn()
+
+        self.value += other
+        return self
+
+
+def months_between_dates(first: datetime.date, second: datetime.date) -> int:
+    return (second.year - first.year) * 12 + (second.month - first.month)

--- a/backend/hitas/calculations/improvement.py
+++ b/backend/hitas/calculations/improvement.py
@@ -1,0 +1,288 @@
+import datetime
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import Enum
+from typing import List, Optional
+
+from hitas.calculations.exceptions import IndexMissingException
+from hitas.calculations.helpers import NoneSum, months_between_dates
+
+
+@dataclass
+class ImprovementData:
+    # Name of the improvement
+    name: str
+    # Original value of the improvement
+    value: int
+    # Completion date of the improvement
+    completion_date: datetime.date
+    # Completion date index for this improvement. Not needed for all the calculations.
+    completion_date_index: Optional[Decimal] = None
+    # Depreciation percentage for this improvement. Not needed for all the calculations.
+    deprecation_percentage: Optional[Decimal] = None
+
+
+class Excess(Enum):
+    AFTER_2010_HOUSING_COMPANY = 30
+    BEFORE_2010_HOUSING_COMPANY = 150
+    BEFORE_2010_APARTMENT = 100
+
+
+@dataclass
+class ImprovementCalculationResult:
+    @dataclass
+    class Depreciation:
+        # How many months depreciation has occurred
+        time_months: int
+        # The total depreciation amount
+        amount: Decimal
+        # Percentage
+        percentage: Optional[Decimal]
+
+    # Name for the improvement
+    name: str
+    # Original value for the improvement
+    value: int
+    # When the improvement was completed
+    completion_date: datetime.date
+    # Calculated excess for the improvement or None when excess is not used in the calculation
+    excess: Optional[Decimal]
+    # Calculated value added by the improvement (original value - the excess)
+    value_added: Decimal
+    # Deprecation information or None when depreciation is not used in the calculation
+    depreciation: Optional[Depreciation]
+    # Improvement value for the whole housing company when the improvement is housing company improvement.
+    # None when the improvement is an apartment improvement.
+    improvement_value_for_housing_company: Optional[Decimal]
+    # Improvement share of a housing company's improvement value OR the whole value when the improvement
+    # is an apartment improvement.
+    improvement_value_for_apartment: Decimal
+
+
+@dataclass
+class ImprovementCalculationSummary:
+    @dataclass
+    class ExcessSummary:
+        surface_area: Decimal
+        value_per_square_meter: int
+
+        @property
+        def total(self) -> Decimal:
+            return self.surface_area * self.value_per_square_meter
+
+    # Sum of all improvement values
+    value: int
+    # Sum of all improvement added values (value - excess)
+    value_added: Decimal
+    # Excess information (if part of the calculations)
+    excess: Optional[ExcessSummary]
+    # Sum of all depreciation (if part of the calculations)
+    depreciation: Optional[Decimal]
+    # Sum of all improvement values for the whole housing company when the improvements are housing company
+    # improvements. None when the improvements are apartment improvements.
+    improvement_value_for_housing_company: Optional[Decimal]
+    # Sum of all improvement share of a housing company's improvements values OR the whole value when the improvements
+    # are apartment improvements.
+    improvement_value_for_apartment: Decimal
+
+
+@dataclass
+class ImprovementsResult:
+    items: List[ImprovementCalculationResult]
+    summary: ImprovementCalculationSummary
+
+
+@dataclass
+class ExcessCalc:
+    excess_per_square_meter: Excess
+    square_meters: Decimal
+
+
+@dataclass
+class IndexCalc:
+    calculation_date_index: Decimal
+    completion_date_index: Decimal
+
+
+@dataclass
+class DepreciationCalc:
+    total_months: Optional[int]
+    calculation_date: datetime.date
+    percentage: Optional[Decimal]
+
+
+@dataclass
+class ApartmentShare:
+    total_surface_area: Decimal
+    apartment_surface_area: Decimal
+
+
+def calculate_housing_company_improvements_after_2010(
+    improvements: List[ImprovementData],
+    calculation_date_index: Decimal,
+    total_surface_area: Decimal,
+    apartment_surface_area: Decimal,
+) -> ImprovementsResult:
+    def calc_fn(improvement):
+        return calculate_single_housing_company_improvement_after_2010(
+            improvement,
+            calculation_date_index=calculation_date_index,
+            total_surface_area=total_surface_area,
+            apartment_surface_area=apartment_surface_area,
+        )
+
+    return calculate_multiple_improvements(
+        improvements, calc_fn, total_surface_area, excess_per_square_meter=Excess.AFTER_2010_HOUSING_COMPANY
+    )
+
+
+def calculate_single_housing_company_improvement_after_2010(
+    improvement: ImprovementData,
+    calculation_date_index: Decimal,
+    total_surface_area: Decimal,
+    apartment_surface_area: Decimal,
+) -> ImprovementCalculationResult:
+    return calculate_improvement(
+        improvement,
+        excess=ExcessCalc(excess_per_square_meter=Excess.AFTER_2010_HOUSING_COMPANY, square_meters=total_surface_area),
+        depreciation=None,
+        index_check=IndexCalc(
+            calculation_date_index=calculation_date_index, completion_date_index=improvement.completion_date_index
+        ),
+        apartment_share=ApartmentShare(
+            total_surface_area=total_surface_area, apartment_surface_area=apartment_surface_area
+        ),
+    )
+
+
+def calculate_improvement(
+    improvement: ImprovementData,
+    excess: Optional[ExcessCalc],
+    depreciation: Optional[DepreciationCalc],
+    index_check: Optional[IndexCalc],
+    apartment_share: Optional[ApartmentShare],
+) -> ImprovementCalculationResult:
+    deprecation_result = None
+
+    if index_check and (index_check.completion_date_index is None or index_check.calculation_date_index is None):
+        raise IndexMissingException()
+
+    #
+    # Calculate the excess
+    #
+    if excess:
+        # Calculate value addition by calculating the excess ('omavastuu') first and then reducing that from the
+        # improvement's value. Value addition must be always >= 0.
+        excess_amount = excess.excess_per_square_meter.value * excess.square_meters
+        value_addition = max(improvement.value - excess_amount, Decimal(0))
+    else:
+        # Value addition always equals to improvement's value when excess is not calculated
+        excess_amount = None
+        value_addition = improvement.value
+
+    #
+    # Calculate the depreciation ('poistot')
+    #
+    if depreciation and depreciation.total_months is not None:
+        # Check how many months has elapsed since the completion of the improvement
+        depreciation_time_months = months_between_dates(improvement.completion_date, depreciation.calculation_date)
+
+        if depreciation_time_months > depreciation.total_months:
+            # Time has passed more than the total depreciation time so the full value is depreciated
+            depreciation_amount = value_addition
+        else:
+            # Calculate the depreciation amount
+            depreciation_amount = Decimal(value_addition) / depreciation.total_months * depreciation_time_months
+
+        deprecation_result = ImprovementCalculationResult.Depreciation(
+            time_months=depreciation_time_months, amount=depreciation_amount, percentage=None
+        )
+    else:
+        # set depreciation amount to 0 to help with the next calculations
+        depreciation_amount = 0
+
+    #
+    # Calculate the accepted value ('hyväksytty') for this improvement
+    #
+    accepted = value_addition - depreciation_amount
+
+    if index_check:
+        # Adjust the accepted value with the index check
+        accepted *= index_check.calculation_date_index / index_check.completion_date_index
+
+    if depreciation and improvement.deprecation_percentage:
+        depreciation_time_months = months_between_dates(improvement.completion_date, depreciation.calculation_date)
+        depreciation_amount = min(accepted * depreciation.percentage * depreciation_time_months, accepted)
+
+        deprecation_result = ImprovementCalculationResult.Depreciation(
+            time_months=depreciation_time_months, amount=depreciation_amount, percentage=depreciation.percentage
+        )
+
+    #
+    # Calculate the housing company's and apartment's share
+    #
+    if apartment_share:
+        # This is a housing company improvement so set the accepted value only for the housing company
+        # and calculate the apartment's share
+        improvement_share_for_housing_company = accepted
+        improvement_share_for_apartment = (
+            improvement_share_for_housing_company
+            / apartment_share.total_surface_area
+            * apartment_share.apartment_surface_area
+        )
+    else:
+        # This is an apartment improvement so set the accepted value only for the apartment
+        improvement_share_for_housing_company = None
+        improvement_share_for_apartment = accepted
+
+    #
+    # Return the result
+    #
+    return ImprovementCalculationResult(
+        name=improvement.name,
+        value=improvement.value,
+        completion_date=improvement.completion_date,
+        excess=excess_amount,
+        value_added=value_addition,
+        depreciation=deprecation_result,
+        improvement_value_for_housing_company=improvement_share_for_housing_company,
+        improvement_value_for_apartment=improvement_share_for_apartment,
+    )
+
+
+def calculate_multiple_improvements(improvements, calc_fn, total_surface_area, excess_per_square_meter):
+    results: List[ImprovementCalculationResult] = []
+
+    summary_value = 0
+    summary_value_added = Decimal(0)
+    summary_value_for_housing_company = NoneSum(Decimal)
+    summary_value_for_apartment = Decimal(0)
+    summary_depreciation = NoneSum(Decimal)
+
+    # Calculate result for each improvement and calculate the summary
+    for improvement in improvements:
+        result = calc_fn(improvement)
+
+        # Summary calculation
+        summary_value += result.value
+        summary_value_added += result.value_added
+        summary_value_for_housing_company += result.improvement_value_for_housing_company
+        summary_value_for_apartment += result.improvement_value_for_apartment
+        summary_depreciation += result.depreciation.amount if result.depreciation else None
+
+        results.append(result)
+
+    # Generate summary report
+    summary = ImprovementCalculationSummary(
+        value=summary_value,
+        value_added=summary_value_added,
+        depreciation=summary_depreciation.value,
+        excess=ImprovementCalculationSummary.ExcessSummary(
+            surface_area=total_surface_area,
+            value_per_square_meter=excess_per_square_meter.value,
+        ),
+        improvement_value_for_housing_company=summary_value_for_housing_company.value,
+        improvement_value_for_apartment=summary_value_for_apartment,
+    )
+
+    return ImprovementsResult(items=results, summary=summary)

--- a/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
@@ -4,7 +4,12 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from hitas.models import Apartment, Ownership
+from hitas.models import (
+    Apartment,
+    HousingCompanyConstructionPriceImprovement,
+    HousingCompanyMarketPriceImprovement,
+    Ownership,
+)
 from hitas.tests.apis.apartment_max_price.utils import assert_created, assert_id
 from hitas.tests.apis.helpers import HitasAPIClient
 from hitas.tests.factories import (
@@ -34,10 +39,12 @@ def test__api__apartment_max_price__construction_price_index(api_client: HitasAP
     # Create another apartment with rest of the surface area
     ApartmentFactory.create(building__real_estate__housing_company=a.housing_company, surface_area=4302)
 
-    HousingCompanyConstructionPriceImprovementFactory.create(
-        housing_company=a.housing_company, value=150000, completion_date=datetime.date(2020, 5, 21)
+    cpi_improvement: HousingCompanyConstructionPriceImprovement = (
+        HousingCompanyConstructionPriceImprovementFactory.create(
+            housing_company=a.housing_company, value=150000, completion_date=datetime.date(2020, 5, 21)
+        )
     )
-    HousingCompanyMarketPriceImprovementFactory.create(
+    mpi_improvement: HousingCompanyMarketPriceImprovement = HousingCompanyMarketPriceImprovementFactory.create(
         housing_company=a.housing_company, value=150000, completion_date=datetime.date(2020, 5, 21)
     )
     o1: Ownership = OwnershipFactory.create(apartment=a, percentage=75.2)
@@ -87,8 +94,32 @@ def test__api__apartment_max_price__construction_price_index(api_client: HitasAP
                     "additional_work_during_construction": 0,
                     "basic_price": 199500,
                     "index_adjustment": 26401,
-                    "apartment_improvements": 0,
-                    "housing_company_improvements": 157,
+                    "apartment_improvements": None,
+                    "housing_company_improvements": {
+                        "items": [
+                            {
+                                "name": cpi_improvement.name,
+                                "value": 150_000,
+                                "completion_date": "2020-05",
+                                "value_added": 20040,
+                                "depreciation": None,
+                                "value_for_housing_company": 22707.86,
+                                "value_for_apartment": 157.26,
+                            }
+                        ],
+                        "summary": {
+                            "value": 150_000,
+                            "value_added": 20040,
+                            "excess": {
+                                "surface_area": 4332.0,
+                                "value_per_square_meter": 30,
+                                "total": 129960,
+                            },
+                            "depreciation": None,
+                            "value_for_housing_company": 22707.86,
+                            "value_for_apartment": 157,
+                        },
+                    },
                     "debt_free_price": 226058,
                     "debt_free_price_m2": 7535,
                     "apartment_share_of_housing_company_loans": 2500,
@@ -108,8 +139,32 @@ def test__api__apartment_max_price__construction_price_index(api_client: HitasAP
                     "additional_work_during_construction": 0,
                     "basic_price": 199500,
                     "index_adjustment": 25190,
-                    "apartment_improvements": 0,
-                    "housing_company_improvements": 153,
+                    "apartment_improvements": None,
+                    "housing_company_improvements": {
+                        "items": [
+                            {
+                                "name": mpi_improvement.name,
+                                "value": 150_000,
+                                "completion_date": "2020-05",
+                                "value_added": 20040,
+                                "depreciation": None,
+                                "value_for_housing_company": 22161.19,
+                                "value_for_apartment": 153.47,
+                            }
+                        ],
+                        "summary": {
+                            "value": 150_000,
+                            "value_added": 20040,
+                            "excess": {
+                                "surface_area": 4332.0,
+                                "value_per_square_meter": 30,
+                                "total": 129960,
+                            },
+                            "depreciation": None,
+                            "value_for_housing_company": 22161.19,
+                            "value_for_apartment": 153,
+                        },
+                    },
                     "debt_free_price": 224843,
                     "debt_free_price_m2": 7495,
                     "apartment_share_of_housing_company_loans": 2500,
@@ -195,10 +250,12 @@ def test__api__apartment_max_price__market_price_index(api_client: HitasAPIClien
     # Create another apartment with rest of the surface area
     ApartmentFactory.create(building__real_estate__housing_company=a.housing_company, surface_area=2655)
 
-    HousingCompanyConstructionPriceImprovementFactory.create(
-        housing_company=a.housing_company, value=150000, completion_date=datetime.date(2020, 5, 21)
+    cpi_improvement: HousingCompanyConstructionPriceImprovement = (
+        HousingCompanyConstructionPriceImprovementFactory.create(
+            housing_company=a.housing_company, value=150000, completion_date=datetime.date(2020, 5, 21)
+        )
     )
-    HousingCompanyMarketPriceImprovementFactory.create(
+    mpi_improvement: HousingCompanyMarketPriceImprovement = HousingCompanyMarketPriceImprovementFactory.create(
         housing_company=a.housing_company, value=150000, completion_date=datetime.date(2020, 5, 21)
     )
     o1: Ownership = OwnershipFactory.create(apartment=a, percentage=100.0)
@@ -244,8 +301,32 @@ def test__api__apartment_max_price__market_price_index(api_client: HitasAPIClien
                     "additional_work_during_construction": 0,
                     "basic_price": 220661,
                     "index_adjustment": 40916,
-                    "apartment_improvements": 0,
-                    "housing_company_improvements": 1387,
+                    "apartment_improvements": None,
+                    "housing_company_improvements": {
+                        "items": [
+                            {
+                                "name": cpi_improvement.name,
+                                "value": 150_000,
+                                "completion_date": "2020-05",
+                                "value_added": 68910,
+                                "depreciation": None,
+                                "value_for_housing_company": 78083.78,
+                                "value_for_apartment": 1386.62,
+                            }
+                        ],
+                        "summary": {
+                            "value": 150_000,
+                            "value_added": 68910.0,
+                            "excess": {
+                                "surface_area": 2703.0,
+                                "value_per_square_meter": 30,
+                                "total": 81090,
+                            },
+                            "depreciation": None,
+                            "value_for_housing_company": 78083.78,
+                            "value_for_apartment": 1387,
+                        },
+                    },
                     "debt_free_price": 262964,
                     "debt_free_price_m2": 5478,
                     "apartment_share_of_housing_company_loans": 2500,
@@ -265,8 +346,32 @@ def test__api__apartment_max_price__market_price_index(api_client: HitasAPIClien
                     "additional_work_during_construction": 0,
                     "basic_price": 220661,
                     "index_adjustment": 56411,
-                    "apartment_improvements": 0,
-                    "housing_company_improvements": 1353,
+                    "apartment_improvements": None,
+                    "housing_company_improvements": {
+                        "items": [
+                            {
+                                "name": mpi_improvement.name,
+                                "value": 150_000,
+                                "completion_date": "2020-05",
+                                "value_added": 68910,
+                                "depreciation": None,
+                                "value_for_housing_company": 76203.98,
+                                "value_for_apartment": 1353.23,
+                            }
+                        ],
+                        "summary": {
+                            "value": 150_000,
+                            "value_added": 68910.0,
+                            "excess": {
+                                "surface_area": 2703.0,
+                                "value_per_square_meter": 30,
+                                "total": 81090,
+                            },
+                            "depreciation": None,
+                            "value_for_housing_company": 76203.98,
+                            "value_for_apartment": 1353,
+                        },
+                    },
                     "debt_free_price": 278425,
                     "debt_free_price_m2": 5801,
                     "apartment_share_of_housing_company_loans": 2500,
@@ -369,8 +474,22 @@ def test__api__apartment_max_price__surface_area_price_ceiling(api_client: Hitas
                     "additional_work_during_construction": 0,
                     "basic_price": 169583,
                     "index_adjustment": 48578,
-                    "apartment_improvements": 0,
-                    "housing_company_improvements": 0,
+                    "apartment_improvements": None,
+                    "housing_company_improvements": {
+                        "items": [],
+                        "summary": {
+                            "value": 0,
+                            "value_added": 0,
+                            "excess": {
+                                "surface_area": 2703.5,
+                                "value_per_square_meter": 30,
+                                "total": 81105,
+                            },
+                            "depreciation": None,
+                            "value_for_housing_company": None,
+                            "value_for_apartment": 0.00,
+                        },
+                    },
                     "debt_free_price": 218161,
                     "debt_free_price_m2": 4498,
                     "apartment_share_of_housing_company_loans": 0,
@@ -390,8 +509,22 @@ def test__api__apartment_max_price__surface_area_price_ceiling(api_client: Hitas
                     "additional_work_during_construction": 0,
                     "basic_price": 169583,
                     "index_adjustment": 62627,
-                    "apartment_improvements": 0,
-                    "housing_company_improvements": 0,
+                    "apartment_improvements": None,
+                    "housing_company_improvements": {
+                        "items": [],
+                        "summary": {
+                            "value": 0,
+                            "value_added": 0,
+                            "excess": {
+                                "surface_area": 2703.5,
+                                "value_per_square_meter": 30,
+                                "total": 81105,
+                            },
+                            "depreciation": None,
+                            "value_for_housing_company": None,
+                            "value_for_apartment": 0.00,
+                        },
+                    },
                     "debt_free_price": 232210,
                     "debt_free_price_m2": 4788,
                     "apartment_share_of_housing_company_loans": 0,

--- a/backend/hitas/tests/factories/apartment.py
+++ b/backend/hitas/tests/factories/apartment.py
@@ -8,6 +8,7 @@ from factory.fuzzy import FuzzyDecimal
 from rest_framework.utils import json
 from rest_framework.utils.encoders import JSONEncoder
 
+from hitas.calculations.max_price import roundup
 from hitas.models import (
     Apartment,
     ApartmentConstructionPriceImprovement,
@@ -85,8 +86,32 @@ def create_apartment_max_price_calculation(**kwargs) -> ApartmentMaximumPriceCal
                     "additional_work_during_construction": random.randint(0, 50_000),
                     "basic_price": random.randint(100_000, 300_000),
                     "index_adjustment": random.randint(10_000, 50_000),
-                    "apartment_improvements": random.randint(0, 10_000),
-                    "housing_company_improvements": random.randint(0, 10_000),
+                    "apartment_improvements": None,
+                    "housing_company_improvements": {
+                        "items": [
+                            {
+                                "name": factory.Faker("sentence").evaluate(None, None, {"locale": None}),
+                                "value": random.randint(100_000, 200_000),
+                                "value_added": random.randint(100_00, 200_00),
+                                "completion_date": fuzzy.FuzzyDate(date(2010, 1, 1)).fuzz().strftime("%Y-%m"),
+                                "depreciation": None,
+                                "value_for_housing_company": random.randint(20_000, 30_000),
+                                "value_for_apartment": random.randint(100, 1000),
+                            },
+                        ],
+                        "summary": {
+                            "value": random.randint(100_000, 200_000),
+                            "value_added": random.randint(100_00, 200_00),
+                            "excess": {
+                                "surface_area": mpc.apartment.surface_area,
+                                "value_per_square_meter": 30,
+                                "total": roundup(30 * mpc.apartment.surface_area, 0),
+                            },
+                            "depreciation": 0,
+                            "value_for_housing_company": random.randint(20_000, 30_000),
+                            "value_for_apartment": random.randint(100, 1000),
+                        },
+                    },
                     "debt_free_price": random.randint(100_000, 300_000),
                     "debt_free_price_m2": random.randint(1_000, 10_000),
                     "apartment_share_of_housing_company_loans": random.randint(0, 50_000),
@@ -106,8 +131,32 @@ def create_apartment_max_price_calculation(**kwargs) -> ApartmentMaximumPriceCal
                     "additional_work_during_construction": random.randint(0, 50_000),
                     "basic_price": random.randint(100_000, 300_000),
                     "index_adjustment": random.randint(10_000, 50_000),
-                    "apartment_improvements": random.randint(0, 10_000),
-                    "housing_company_improvements": random.randint(0, 10_000),
+                    "apartment_improvements": None,
+                    "housing_company_improvements": {
+                        "items": [
+                            {
+                                "name": factory.Faker("sentence").evaluate(None, None, {"locale": None}),
+                                "value": random.randint(100_000, 200_000),
+                                "value_added": random.randint(100_00, 200_00),
+                                "completion_date": fuzzy.FuzzyDate(date(2010, 1, 1)).fuzz().strftime("%Y-%m"),
+                                "depreciation": None,
+                                "value_for_housing_company": random.randint(20_000, 30_000),
+                                "value_for_apartment": random.randint(100, 1000),
+                            },
+                        ],
+                        "summary": {
+                            "value": random.randint(100_000, 200_000),
+                            "value_added": random.randint(100_00, 200_00),
+                            "excess": {
+                                "surface_area": mpc.apartment.surface_area,
+                                "value_per_square_meter": 30,
+                                "total": roundup(30 * mpc.apartment.surface_area, 0),
+                            },
+                            "depreciation": 0,
+                            "value_for_housing_company": random.randint(20_000, 30_000),
+                            "value_for_apartment": random.randint(100, 1000),
+                        },
+                    },
                     "debt_free_price": random.randint(100_000, 300_000),
                     "debt_free_price_m2": random.randint(1_000, 10_000),
                     "apartment_share_of_housing_company_loans": random.randint(0, 50_000),

--- a/backend/hitas/tests/test_improvements.py
+++ b/backend/hitas/tests/test_improvements.py
@@ -1,0 +1,68 @@
+import datetime
+from dataclasses import dataclass
+from decimal import Decimal
+
+from hitas.calculations.improvement import (
+    ImprovementData,
+    calculate_housing_company_improvements_after_2010,
+    calculate_single_housing_company_improvement_after_2010,
+)
+from hitas.calculations.max_price import roundup
+
+
+@dataclass
+class ImprovementCalculationRequest:
+    value: int
+    completion_date_index: Decimal
+    completion_date: datetime.date
+
+
+def test_calculate_single_housing_company_improvement_after_2010():
+    result = calculate_single_housing_company_improvement_after_2010(
+        ImprovementData(
+            name="Testi",
+            value=150_000,
+            completion_date=datetime.date(2020, 5, 1),
+            completion_date_index=Decimal(129.2),
+        ),
+        calculation_date_index=Decimal(146.4),
+        total_surface_area=Decimal(4332),
+        apartment_surface_area=Decimal(30),
+    )
+    assert result is not None
+    assert result.value == 150_000
+    assert result.completion_date == datetime.date(2020, 5, 1)
+    assert result.value_added == 20_040
+    assert result.depreciation is None
+    assert roundup(result.improvement_value_for_housing_company, 2) == Decimal(22_707.86)
+    assert roundup(result.improvement_value_for_apartment, 2) == Decimal(157.26)
+
+
+def test_calculate_housing_company_improvements_after_2010():
+    result = calculate_housing_company_improvements_after_2010(
+        improvements=[
+            ImprovementData(
+                name="Testi",
+                value=150_000,
+                completion_date=datetime.date(2020, 5, 1),
+                completion_date_index=Decimal(129.2),
+            )
+        ],
+        calculation_date_index=Decimal(146.4),
+        total_surface_area=Decimal(4332),
+        apartment_surface_area=Decimal(30),
+    )
+    assert result is not None
+    assert len(result.items) == 1
+
+    # Verify summary
+    assert result.summary is not None
+    assert result.summary.value == 150_000
+    assert result.summary.value_added == 20_040
+    assert result.summary.excess is not None
+    assert result.summary.excess.total == 129960
+    assert result.summary.excess.value_per_square_meter == 30
+    assert result.summary.excess.surface_area == 4332
+    assert result.summary.depreciation is None
+    assert roundup(result.summary.improvement_value_for_housing_company, 2) == Decimal(22_707.86)
+    assert roundup(result.summary.improvement_value_for_apartment, 2) == Decimal(157.26)

--- a/backend/hitas/views/apartment_max_price.py
+++ b/backend/hitas/views/apartment_max_price.py
@@ -13,7 +13,7 @@ from rest_framework.serializers import Serializer
 from rest_framework.viewsets import ViewSet
 
 from hitas.calculations import calculate_max_price
-from hitas.calculations.max_price import IndexMissingException, InvalidCalculationResult
+from hitas.calculations.exceptions import IndexMissingException, InvalidCalculationResultException
 from hitas.exceptions import HitasModelNotFound
 from hitas.models import Apartment, HousingCompany
 from hitas.models.apartment import ApartmentMaximumPriceCalculation
@@ -43,7 +43,7 @@ class ApartmentMaximumPriceViewSet(CreateModelMixin, RetrieveModelMixin, ViewSet
                 apartment_share_of_housing_company_loans_date=apartment_share_of_housing_company_loans_date,
             )
             return Response(max_prices)
-        except InvalidCalculationResult:
+        except InvalidCalculationResultException:
             return Response(
                 {
                     "error": "invalid_calculation_result",

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2834,14 +2834,11 @@ components:
                     example: Hissisaneeraus
                   value:
                     description: Original value of this improvement
-                    type: number
+                    type: integer
                     minimum: 0
                     example: 78284
                   completion_date:
-                    description: When this improvement was completed
-                    type: string
-                    pattern: \d{4}-\d{2}
-                    example: 2005-08
+                    $ref: '#/components/schemas/YearMonth'
             construction_price_index:
               description: List of improvements for construction price index
               type: array
@@ -2860,14 +2857,11 @@ components:
                     example: Liittyminen HTV-verkkoon
                   value:
                     description: Original value of this improvement
-                    type: number
+                    type: integer
                     minimum: 0
                     example: 13359
                   completion_date:
-                    description: When this improvement was completed
-                    type: string
-                    pattern: \d{4}-\d{2}
-                    example: 2004-03
+                    $ref: '#/components/schemas/YearMonth'
 
     RealEstate:
       description: Single real estate
@@ -3112,14 +3106,11 @@ components:
                     example: Hissisaneeraus
                   value:
                     description: Original value of this improvement
-                    type: number
+                    type: integer
                     minimum: 0
                     example: 78284
                   completion_date:
-                    description: When this improvement was completed
-                    type: string
-                    pattern: \d{4}-\d{2}
-                    example: 2005-08
+                    $ref: '#/components/schemas/YearMonth'
             construction_price_index:
               description: List of improvements for construction price index
               type: array
@@ -3139,14 +3130,11 @@ components:
                     example: Liittyminen HTV-verkkoon
                   value:
                     description: Original value of this improvement
-                    type: number
+                    type: integer
                     minimum: 0
                     example: 13359
                   completion_date:
-                    description: When this improvement was completed
-                    type: string
-                    pattern: \d{4}-\d{2}
-                    example: 2004-03
+                    $ref: '#/components/schemas/YearMonth'
                   depreciation_percentage:
                     description: |-
                       Depreciation percentage.
@@ -3165,6 +3153,7 @@ components:
     ApartmentMaximumPriceCalculation:
       description: Calculations for particular index
       type: object
+      additionalProperties: false
       required:
         - calculation_variables
         - maximum_price
@@ -3233,20 +3222,10 @@ components:
           minimum: 0
           example: 26401
         apartment_improvements:
-          description: |-
-            Total value of this apartment's improvements. Calculated by summing up all apartment
-            improvement's values together.
-          type: integer
-          minimum: 0
-          example: 0
+          nullable: true
+          $ref: '#/components/schemas/ApartmentMaximumPriceImprovements'
         housing_company_improvements:
-          description: |-
-            Total value of this apartment's housing company's improvements. Calculated by
-            summing up each improvement, first removing the excess and adjusting the improvement
-            by the improvement's completion date index for each improvement.
-          type: integer
-          minimum: 0
-          example: 157
+          $ref: '#/components/schemas/ApartmentMaximumPriceImprovements'
         debt_free_price:
           description: |-
             Sum of basic price, index adjustment, apartment improvements and housing company
@@ -3291,6 +3270,140 @@ components:
           type: number
           minimum: 0
           example: 146.4
+
+    ApartmentMaximumPriceImprovements:
+      description: Improvement information used in the calculation
+      type: object
+      additionalProperties: false
+      nullable: true
+      required:
+        - items
+        - summary
+      properties:
+        items:
+          description: List of improvements
+          type: array
+          items:
+            description: Single improvement
+            type: object
+            additionalProperties: false
+            required:
+              - name
+              - value
+              - completion_date
+              - depreciation
+              - value_for_housing_company
+              - value_for_apartment
+            properties:
+              name:
+                description: Name of this improvement
+                type: string
+                example: Liittyminen HTV-verkkoon
+              value:
+                description: Original value of this improvement
+                type: integer
+                minimum: 0
+                example: 13359
+              completion_date:
+                $ref: '#/components/schemas/YearMonth'
+              value_added:
+                description: Improvement value minus the excess
+                type: number
+                minimum: 0
+                example: 20040.00
+              depreciation:
+                description: Improvement depreciation
+                type: object
+                additionalProperties: false
+                nullable: true
+                required:
+                  - amount
+                  - time_months
+                properties:
+                  amount:
+                    description: Amount the value has reduced based on the depreciation calculation.
+                    type: number
+                    minimum: 0
+                    example: 3965.69
+                  time_months:
+                    description: Amount of time in months the improvement has depreciated
+                    type: integer
+                    minimum: 0
+                    example: 13
+              value_for_housing_company:
+                description: Housing company's share of the improvement's value (adjusted to index)
+                type: number
+                nullable: true
+                minimum: 0
+                example: 22707.86
+              value_for_apartment:
+                description: Apartment share of the improvement's value (adjusted to index)
+                type: number
+                minimum: 0
+                example: 157.26
+        summary:
+          description: Summary data across all improvements
+          type: object
+          additionalProperties: false
+          required:
+            - value
+            - value_added
+            - excess
+            - depreciation
+            - value_for_housing_company
+            - value_for_apartment
+          properties:
+            value:
+              description: Sum of improvement values
+              type: integer
+              minimum: 0
+              example: 13359
+            value_added:
+              description: Sum of improvement value added
+              type: number
+              minimum: 0
+              example: 13359.00
+            excess:
+              description: Excess information
+              type: object
+              additionalProperties: false
+              required:
+                - surface_area
+                - value_per_square_meter
+                - total
+              properties:
+                surface_area:
+                  description: Apartment's surface area
+                  type: number
+                  minimum: 0
+                  example: 4332.0
+                value_per_square_meter:
+                  description: Excess value per square meter
+                  type: integer
+                  minimum: 0
+                  example: 30
+                total:
+                  description: Excess value per square meter multiplied by apartment's surface area
+                  type: number
+                  minimum: 0
+                  example: 129960.0
+            depreciation:
+              description: Sum of improvement value minus the excess
+              type: number
+              nullable: true
+              minimum: 0
+              example: 0.0
+            value_for_housing_company:
+              description: Sum of housing company's share of the improvement's value (adjusted to index)
+              type: number
+              nullable: true
+              minimum: 0
+              example: 22707.86
+            value_for_apartment:
+              description: Sum of apartment share of the improvement's value (adjusted to index)
+              type: number
+              minimum: 0
+              example: 157.0
 
     ApartmentMaximumPrice:
       description: Single apartment's maximum price calculations


### PR DESCRIPTION
# Hitas Pull Request

# Description

 - 2011 after constructed apartment's do not have any apartment improvements do not try to calculate them
 - move improvement calculation logic to own file. this is helpful in the future as we will have more complex improvement calculations for apartments constructed before 2011
 - response contains now a lot of information about the improvements
   - `calculations.construction_price_index.calculation_variables` now has `housing_company_improvements` as an object instead of a single number. the object has two elements, `items` and `summary`. `items` contains a list of improvements and `summary` contains a summary values across all improvements (such as total value, total accepted values etc)
  - `apartment_improvements` has changed to be an object too but will always be `null` for now.
  - same is true for `calculations.market_price_index.calculation_variables`

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [x] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan

- Create a maximum price calculations (with improvements) and see the resulted calculation variables are sane :)

## Tickets

This pull request resolves all or part of the following ticket(s): HT-79
