### PR TITLE
Apartment share loans date

### DIFF
--- a/frontend/src/common/components/formInputField/FormInputField.tsx
+++ b/frontend/src/common/components/formInputField/FormInputField.tsx
@@ -32,7 +32,11 @@ type FormInputFieldProps = {
     className?: string;
 } & (
     | {
-          inputType?: "text" | "textArea" | "postalCode" | "date";
+          inputType?: "text" | "textArea" | "postalCode";
+      }
+    | {
+          inputType?: "date";
+          maxDate?: Date;
       }
     | {
           inputType: "number";

--- a/frontend/src/common/models.ts
+++ b/frontend/src/common/models.ts
@@ -342,6 +342,7 @@ export interface IApartmentMaximumPrice {
 export interface IApartmentMaximumPriceWritable {
     calculation_date: string | null;
     apartment_share_of_housing_company_loans: number | null;
+    apartment_share_of_housing_company_loans_date: string | null;
 }
 
 // Indices

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -70,8 +70,8 @@ const ConfirmedPrice = ({confirmed}) => {
     return (
         <>
             <p className="confirmed-price">{formatMoney(confirmed.maximum_price)}</p>
-            <p>Vahvistettu: {confirmed.confirmed_at.split("T")[0]}</p>
-            <p>Voimassa: {confirmed.valid.valid_until} asti</p>
+            <p>Vahvistettu: {formatDate(confirmed.confirmed_at.split("T")[0])}</p>
+            <p>Voimassa: {formatDate(confirmed.valid.valid_until)} asti</p>
         </>
     );
 };

--- a/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
+++ b/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
@@ -193,6 +193,7 @@ const LoadedApartmentMaxPrice = ({apartment}: {apartment: IApartmentDetails}): J
                             formData={formData}
                             setFormData={setFormData}
                             error={error}
+                            maxDate={new Date()}
                         />
                         <FormInputField
                             inputType="date"
@@ -201,6 +202,7 @@ const LoadedApartmentMaxPrice = ({apartment}: {apartment: IApartmentDetails}): J
                             formData={formData}
                             setFormData={setFormData}
                             error={error}
+                            maxDate={new Date()}
                         />
                     </div>
                     <ImprovementsTable

--- a/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
+++ b/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
@@ -132,6 +132,7 @@ const LoadedApartmentMaxPrice = ({apartment}: {apartment: IApartmentDetails}): J
     const [formData, setFormData] = useImmer<IApartmentMaximumPriceWritable>({
         calculation_date: new Date().toISOString().split("T")[0], // Init with today's date in YYYY-MM format
         apartment_share_of_housing_company_loans: null,
+        apartment_share_of_housing_company_loans_date: null,
     });
     const {
         data: housingCompanyData,
@@ -188,8 +189,7 @@ const LoadedApartmentMaxPrice = ({apartment}: {apartment: IApartmentDetails}): J
                         <FormInputField
                             inputType="date"
                             label="Yhtiölainaosuuden päivämäärä"
-                            fieldPath="housing_company_loans_date"
-                            required
+                            fieldPath="apartment_share_of_housing_company_loans_date"
                             formData={formData}
                             setFormData={setFormData}
                             error={error}
@@ -198,7 +198,6 @@ const LoadedApartmentMaxPrice = ({apartment}: {apartment: IApartmentDetails}): J
                             inputType="date"
                             label="Laskentapäivämäärä"
                             fieldPath="calculation_date"
-                            required
                             formData={formData}
                             setFormData={setFormData}
                             error={error}


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Use correct field name on confirmed maximum price page for the field 'Yhtiölainaosuuden päivämäärä' in frontend.
- Format confirmed price dates 

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [x] Changes have been tested

## Test plan

Set a date and verify that the field is correctly filled in the json on the pdf when downloading confirmed max price pdf

## Tickets

This pull request resolves all or part of the following ticket(s): HT-318