### PR TITLE
backend: allow filter indices by year

### DIFF
--- a/backend/hitas/views/postal_code.py
+++ b/backend/hitas/views/postal_code.py
@@ -29,5 +29,6 @@ class HitasPostalCodeViewSet(HitasModelViewSet):
     def get_queryset(self):
         return HitasPostalCode.objects.all().order_by("value")
 
-    def get_filterset_class(self):
+    @staticmethod
+    def get_filterset_class():
         return HitasPostalCodeFilterSet

--- a/backend/hitas/views/utils/__init__.py
+++ b/backend/hitas/views/utils/__init__.py
@@ -10,6 +10,7 @@ from hitas.views.utils.filters import (
     HitasCharFilter,
     HitasFilterBackend,
     HitasFilterSet,
+    HitasIntegerFilter,
     HitasNumberFilter,
     HitasPostalCodeFilter,
     HitasSSNFilter,

--- a/backend/hitas/views/utils/filters.py
+++ b/backend/hitas/views/utils/filters.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from uuid import UUID
 
+from django import forms
 from django.core.validators import RegexValidator
 from django_filters import CharFilter
 from django_filters.constants import EMPTY_VALUES
@@ -34,6 +35,15 @@ class HitasPostalCodeFilter(filters.CharFilter):
 
 
 class HitasNumberFilter(filters.NumberFilter):
+    def __init__(self, *args, **kwargs):
+        if not kwargs.get("min_value"):
+            kwargs["min_value"] = 0
+        super().__init__(*args, **kwargs)
+
+
+class HitasIntegerFilter(filters.NumberFilter):
+    field_class = forms.IntegerField
+
     def __init__(self, *args, **kwargs):
         if not kwargs.get("min_value"):
             kwargs["min_value"] = 0

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2418,6 +2418,16 @@ paths:
         - $ref: '#/components/parameters/IndexNameParameter'
         - $ref: '#/components/parameters/PagingLimitParameter'
         - $ref: '#/components/parameters/PagingPageParameter'
+        - name: year
+          required: false
+          in: query
+          description: Fetch indices by year
+          schema:
+            description: Year
+            type: integer
+            minimum: 1970
+            maximum: 2099
+            example: 2022-01
       responses:
         '200':
           description: Successfully fetched list of indices
@@ -2438,6 +2448,8 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Index'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '406':


### PR DESCRIPTION
# Hitas Pull Request

# Description

 `GET /api/v1/indices/{index}` has a new filter parameter `year`. It can be used to fetch only indices from the given year

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [x] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan

Try `GET /api/v1/indices/{index}` with different values and check the returned values :)

## Tickets

This pull request resolves all or part of the following ticket(s): HT-325
