### PR TITLE
Clear apartment share numbers

### DIFF
--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -963,11 +963,17 @@ def test__api__apartment__update(api_client: HitasAPIClient, minimal_data: bool)
         ),
         (
             {"shares": {"start": None, "end": 100}},
-            [{"field": "shares", "message": "Both 'shares.start' and 'shares.end' must be given or be 'null'."}],
+            [
+                {
+                    "field": "shares.start",
+                    "message": "Both 'shares.start' and 'shares.end' must be given or be 'null'.",
+                },
+                {"field": "shares.end", "message": "Both 'shares.start' and 'shares.end' must be given or be 'null'."},
+            ],
         ),
         (
             {"shares": {"start": 100, "end": 50}},
-            [{"field": "shares", "message": "'shares.start' must not be greater than 'shares.end'."}],
+            [{"field": "shares.start", "message": "'shares.start' must not be greater than 'shares.end'."}],
         ),
         (
             {"shares": {"start": 0, "end": 0}},

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -127,9 +127,10 @@ class SharesSerializer(serializers.Serializer):
         if start is None and end is None:
             return data
         if start is None or end is None:
-            raise ValidationError("Both 'shares.start' and 'shares.end' must be given or be 'null'.")
+            err_msg = "Both 'shares.start' and 'shares.end' must be given or be 'null'."
+            raise ValidationError({"start": err_msg, "end": err_msg})
         if start > end:
-            raise ValidationError("'shares.start' must not be greater than 'shares.end'.")
+            raise ValidationError({"start": "'shares.start' must not be greater than 'shares.end'."})
 
         return data
 

--- a/frontend/src/features/apartment/ApartmentCreatePage.tsx
+++ b/frontend/src/features/apartment/ApartmentCreatePage.tsx
@@ -139,6 +139,12 @@ const ApartmentCreatePage = () => {
 
             // Clean away ownership items that don't have an owner selected
             ownerships: formOwnershipsList.filter((o) => o.owner.id),
+
+            // Clean share fields
+            shares: {
+                start: formData.shares.start || null,
+                end: formData.shares.end || null,
+            },
         };
 
         setFormData(() => formDataWithOwnerships);


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Allow clearing apartment share numbers
- Improve error messaging for share fields

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [x] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added

## Test plan

- Have an apartment with share prices already set, go to edit it and clear the fields and save, check that the values are actually cleared

## Tickets

This pull request resolves all or part of the following ticket(s): HT-305
