### PR TITLE
frontend: removes decimals from displayed unconfirmed max prices

### DIFF
--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -84,7 +84,7 @@ const UnconfirmedPriceRow = ({label, unconfirmedPrice}: UnconfirmedPriceRowProps
         <div className={`price${unconfirmedPrice.maximum ? " price--current-top" : ""}`}>
             <span className="basis">{label}</span>
             <span className="amount">
-                <span className="value">{formatMoney(unconfirmedPrice.value)}</span>
+                <span className="value">{formatMoney(Math.floor(unconfirmedPrice.value))}</span>
             </span>
         </div>
     );


### PR DESCRIPTION
# Hitas Pull Request

# Description

Removes the decimals from the displayed values for unconfirmed maximum prices in the apartment details view.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [X] Changes have been tested

## Test plan

Check out the apartment detail page. The different index maximum prices shown on the top left should not have any decimals.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-217 (comment from Saila)
