### PR TITLE
Fix confirmed date validity

### DIFF
--- a/frontend/src/common/components/formInputField/FormOwnershipInputField.tsx
+++ b/frontend/src/common/components/formInputField/FormOwnershipInputField.tsx
@@ -148,7 +148,7 @@ export default function FormOwnershipInputField({
             setIsAddingNew(false);
             closeModal();
         }
-    }, [createData, createError, isCreating]);
+    }, [createData, createError, isCreating, setFieldValue]);
 
     return (
         <div className={`input-field input-field--related-model${required ? " input-field--required" : ""}`}>

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -92,12 +92,20 @@ const UnconfirmedPriceRow = ({label, unconfirmedPrice}: UnconfirmedPriceRowProps
 
 const ConfirmedPriceDetails = ({confirmed}: {confirmed: IApartmentConfirmedMaximumPrice}) => {
     if (confirmed === null) return <p className="confirmed-price">-</p>;
-
     return (
         <>
-            <p className="confirmed-price">{formatMoney(confirmed.maximum_price)}</p>
-            <p>Vahvistettu: {formatDate(confirmed.confirmed_at.split("T")[0])}</p>
-            <p>Voimassa: {formatDate(confirmed.valid.valid_until)} asti</p>
+            <div className="confirmed-price">{formatMoney(confirmed.maximum_price)}</div>
+            <div className="confirmed-price__date">Vahvistettu: {formatDate(confirmed.confirmed_at.split("T")[0])}</div>
+            <div className="confirmed-price__date">
+                Voimassa:{" "}
+                {new Date() <= new Date(confirmed.valid.valid_until) ? (
+                    `${formatDate(confirmed.valid.valid_until)} asti`
+                ) : (
+                    <span>
+                        <span className="invalid">{formatDate(confirmed.valid.valid_until)} - ei voimassa</span>
+                    </span>
+                )}
+            </div>
         </>
     );
 };

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -110,6 +110,11 @@
       .confirmed-price
         font-size: $fontsize-heading-l
         font-weight: 900
+        margin: $spacing-2-xs 0 $spacing-s
+        &__date
+          margin-bottom: $spacing-s
+          .invalid
+            color: $color-black-40
 
       .button-confirm
         position: absolute


### PR DESCRIPTION
# Hitas Pull Request

# Description

The ApartmentDetailPage now has a check for the confirmed maximum price date to be valid. If today's date is bigger than the valid_until date, the date is shown in a dimmed color, with accompanying text. 

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [X] Changes have been tested

## Test plan

Navigate to any apartment details page with a confirmed maximum price. Check whether the calculation is still valid.

In `ApartmentDetailsPage.ts` (line 181), change the contents of the first `new Date()` object to change the date of "today" to see how the invalid price looks if it was valid to begin with - or the other way around.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-217
