### PR TITLE
backend: allow filtering housing companies by completion date

### DIFF
--- a/backend/hitas/views/housing_company.py
+++ b/backend/hitas/views/housing_company.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 
 from django.db.models import F, Min, Prefetch, Sum
 from django.db.models.functions import Round
+from django_filters.rest_framework import BooleanFilter
 from enumfields.drf.serializers import EnumSupportSerializerMixin
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -46,10 +47,29 @@ class HousingCompanyFilterSet(HitasFilterSet):
     property_manager = HitasCharFilter(field_name="property_manager__name", lookup_expr="icontains")
     developer = HitasCharFilter(field_name="developer__value", lookup_expr="icontains")
     archive_id = HitasNumberFilter(field_name="id", min_value=1)
+    new_hitas = BooleanFilter(method="new_hitas_filter")
+
+    def new_hitas_filter(self, queryset, name, value):
+        if value is None:
+            return queryset
+
+        cutoff_date = datetime.date(2011, 1, 1)
+        if value:
+            return queryset.filter(date__gte=cutoff_date)
+        else:
+            return queryset.filter(date__lt=cutoff_date)
 
     class Meta:
         model = HousingCompany
-        fields = ["display_name", "street_address", "postal_code", "property_manager", "developer", "archive_id"]
+        fields = [
+            "display_name",
+            "street_address",
+            "postal_code",
+            "property_manager",
+            "developer",
+            "archive_id",
+            "new_hitas",
+        ]
 
 
 class HousingCompanyNameSerializer(serializers.Serializer):

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -61,6 +61,16 @@ paths:
             type: number
             minimum: 1
             example: 421
+        - name: new_hitas
+          description: |-
+            Search housing companies by completion date. When this parameter is given and is set
+            to `true` then only housing companies completed `2011-01-01` onwards are returned. When
+            this parameter is given and set to `false` then only housing companies completed before
+            `2011-01-01` are returned.
+          required: false
+          in: query
+          schema:
+            type: boolean
       responses:
         '200':
           description: Successfully fetched list of housing companies


### PR DESCRIPTION
# Hitas Pull Request

# Description

 - query parameter is named `new_hitas`.
   - When this is given and set to `true`, only housing companies completed `2011-01-01` onwards are returned.
   - When this parameter is give nand set to `false` only housing companyes completed before `2011-01-01` are returned

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [x] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan

Fetch `/api/v1/housing-companies` with `new_hitas=true`, `new_hitas=false` and without `new_hitas` and observe the results.

## Tickets

This pull request resolves all or part of the following ticket(s): n/a
