### PR TITLE
Confirm calculation breakdown

### DIFF
--- a/frontend/src/common/models.ts
+++ b/frontend/src/common/models.ts
@@ -279,20 +279,25 @@ export interface IApartmentWritable {
 
 // //  Maximum Price Fields
 
-interface ICalculation {
+export interface ICalculation {
     maximum_price: number;
     valid_until: string;
     maximum: boolean;
 }
 
-interface IIndexCalculationVariables {
+export interface IIndexCalculationVariables {
     calculation_variables: {
         acquisition_price: number;
         additional_work_during_construction: number;
         basic_price: number;
         index_adjustment: number;
         apartment_improvements: number;
-        housing_company_improvements: number;
+        housing_company_improvements: {
+            summary: {
+                value: number;
+                value_for_apartment: number;
+            };
+        };
         debt_free_price: number;
         debt_free_price_m2: number;
         apartment_share_of_housing_company_loans: number;

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -284,18 +284,24 @@ const LoadedApartmentDetails = ({data}: {data: IApartmentDetails}): JSX.Element 
                         <Tabs.TabPanel>
                             <div className="company-details__tab basic-details">
                                 <div className="row">
-                                    <DetailField
-                                        label="Kauppakirjahinta"
-                                        value={formatMoney(data.prices.purchase_price)}
-                                    />
-                                    <DetailField
-                                        label="Hankinta-arvo"
-                                        value={formatMoney(data.prices.acquisition_price)}
-                                    />
-                                    <DetailField
-                                        label="Valmistumispäivä"
-                                        value={formatDate(data.completion_date)}
-                                    />
+                                    <div>
+                                        <DetailField
+                                            label="Kauppakirjahinta"
+                                            value={formatMoney(data.prices.purchase_price)}
+                                        />
+                                    </div>
+                                    <div>
+                                        <DetailField
+                                            label="Hankinta-arvo"
+                                            value={formatMoney(data.prices.acquisition_price)}
+                                        />
+                                    </div>
+                                    <div>
+                                        <DetailField
+                                            label="Valmistumispäivä"
+                                            value={formatDate(data.completion_date)}
+                                        />
+                                    </div>
                                 </div>
                                 <div className="columns">
                                     <div className="column">

--- a/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
+++ b/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
@@ -259,7 +259,7 @@ const MaximumPriceModalContent = ({
                 </Tabs>
                 <div className="valid-until">
                     <BreakdownValue
-                        label="Laskelman voimassaoloaika"
+                        label="Vahvistettavan laskelman voimassaoloaika"
                         value={calculation.valid_until}
                         unit=""
                     />

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -147,16 +147,18 @@
     .row
       border-bottom: 1px solid #CCC
       margin-bottom: 1rem
+      justify-content: space-between
+
+      > div
+        @include flexbox()
 
       .detail-field-
         &label
           padding-top: 0.25rem
-          margin-right: 0.5rem
+          margin-right: 1rem
 
         &value
           font-size: $fontsize-heading-m
-          margin-right: $spacing-layout-m
-          flex-grow: 1
           margin-bottom: 1rem
 
     .columns

--- a/frontend/src/styles/components/_ApartmentMaxPricePage.sass
+++ b/frontend/src/styles/components/_ApartmentMaxPricePage.sass
@@ -86,7 +86,7 @@
     @include flexbox()
     justify-content: space-between
     label
-      width: 300px
+      min-width: 300px
     p
       min-width: 100px
       margin: 0 0 $spacing-m

--- a/frontend/src/styles/components/_ApartmentMaxPricePage.sass
+++ b/frontend/src/styles/components/_ApartmentMaxPricePage.sass
@@ -15,49 +15,75 @@
 #maximum-price-confirmation-modal
   width: auto !important
 
-  .dialog-content
-    display: flex
+  [class*="Tabs-module_tabs"]
+    @include flexbox()
     gap: 50px
 
-.confirmation-modal__calculation-row
-  position: relative
-  left: calc(-1 * #{$spacing-xs})
-  height: calc(50px + #{$spacing-xs * 2})
-  padding: $spacing-xs
-  margin-bottom: $spacing-layout-s
-  cursor: pointer
-  background-color: var(--border-color)
-  --border-color: transparent
-  label
-    cursor: pointer
-  p
-    margin-top: $spacing-xs
-    margin-bottom: $spacing-m
-    font-size: $fontsize-body-l
-  &:before
-    display: block
-    content: ""
-    width: 0
-    height: 0
-    position: absolute
-    top: 0
-    right: -37px
-    border-top: calc(25px + #{$spacing-xs}) solid transparent
-    border-bottom: calc(25px + #{$spacing-xs}) solid transparent
-    border-left: calc(25px + #{$spacing-xs}) solid var(--border-color)
-  &:hover
-    --border-color: #{$color-engel-medium-light}
-  &--maximum
-    font-weight: bold
-    p
-      margin-top: 0.25rem
-      font-size: $fontsize-heading-l
+  [class*="Tabs-module_scrollButton"]
+    display: none
+
+  [class*="Tabs-module_tablist"]
+    overflow: visible
+    ul
+      @include flexbox()
+      flex-flow: column nowrap
+      width: auto !important
+      overflow: visible
+      li
+        position: relative
+        height: calc(50px + #{$spacing-xs * 2})
+        padding: $spacing-xs
+        margin-bottom: $spacing-layout-s
+        cursor: pointer
+        background-color: var(--border-color)
+        outline: 0 !important
+        --border-color: transparent
+        &:focus span:after
+          border: none !important
+        span
+          height: 50px
+          padding-left: 0
+          padding-right: 0
+          justify-content: flex-start
+          border-width: 0 !important
+          &:before
+            display: block
+            content: ""
+            width: 0
+            height: 0
+            position: absolute
+            top: -10px
+            right: -49px
+            background-color: transparent
+            border-top: calc(25px + #{$spacing-xs}) solid transparent
+            border-bottom: calc(25px + #{$spacing-xs}) solid transparent
+            border-left: calc(25px + #{$spacing-xs}) solid var(--border-color)
+        label
+          cursor: pointer
+        p
+          margin-top: $spacing-xs
+          margin-bottom: $spacing-m
+          font-size: $fontsize-body-l
+        &[class*="active"]
+          --border-color: #{$color-engel-medium-light}
+        &:not([class*="active"]):hover
+          --border-color: #{$color-engel-light}
+        .confirmation-modal__calculation-row
+          height: 50px
+          &--maximum
+            font-weight: bold
+            p
+              margin-top: 0.25rem
+              font-size: $fontsize-heading-l
+  .valid-until
+    margin-top: $spacing-layout-m
 
 .confirmation-modal__breakdown
   flex-grow: 1
   margin-top: $spacing-xs
+  min-height: 466px
   &-row
-    display: flex
+    @include flexbox()
     justify-content: space-between
     label
       width: 300px

--- a/frontend/src/styles/components/_ApartmentMaxPricePage.sass
+++ b/frontend/src/styles/components/_ApartmentMaxPricePage.sass
@@ -12,8 +12,57 @@
     > div
       flex-grow: 1
 
+#maximum-price-confirmation-modal
+  width: auto !important
+
+  .dialog-content
+    display: flex
+    gap: 50px
+
 .confirmation-modal__calculation-row
+  position: relative
+  left: calc(-1 * #{$spacing-xs})
+  height: calc(50px + #{$spacing-xs * 2})
+  padding: $spacing-xs
+  margin-bottom: $spacing-layout-s
+  cursor: pointer
+  background-color: var(--border-color)
+  --border-color: transparent
+  label
+    cursor: pointer
   p
     margin-top: $spacing-xs
     margin-bottom: $spacing-m
     font-size: $fontsize-body-l
+  &:before
+    display: block
+    content: ""
+    width: 0
+    height: 0
+    position: absolute
+    top: 0
+    right: -37px
+    border-top: calc(25px + #{$spacing-xs}) solid transparent
+    border-bottom: calc(25px + #{$spacing-xs}) solid transparent
+    border-left: calc(25px + #{$spacing-xs}) solid var(--border-color)
+  &:hover
+    --border-color: #{$color-engel-medium-light}
+  &--maximum
+    font-weight: bold
+    p
+      margin-top: 0.25rem
+      font-size: $fontsize-heading-l
+
+.confirmation-modal__breakdown
+  flex-grow: 1
+  margin-top: $spacing-xs
+  &-row
+    display: flex
+    justify-content: space-between
+    label
+      width: 300px
+    p
+      min-width: 100px
+      margin: 0 0 $spacing-m
+      text-align: right
+      font-weight: bold


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds a breakdown of the max price calculation to the confirmation dialog, which is shown when the user wants to save a calculation.

## Pull request checklist

- **Frontend**
    - [X] Changes have been tested

## Test plan

Navigate to any apartment max price page, and click on "Laske". The dialog window should show the indices on the left, with the max price one being initially selected, and with a bold font (even if you select another index). Check all of the different indices by clicking on them. Rajaneliöhinta should have different contents from the other two indices.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-217
