### PR TITLE
Confirmed price refactor

### DIFF
--- a/backend/hitas/calculations/max_prices/__init__.py
+++ b/backend/hitas/calculations/max_prices/__init__.py
@@ -1,0 +1,1 @@
+from hitas.calculations.max_prices.max_price import create_max_price_calculation

--- a/backend/hitas/calculations/max_prices/rules.py
+++ b/backend/hitas/calculations/max_prices/rules.py
@@ -1,0 +1,115 @@
+import datetime
+from decimal import Decimal
+from typing import List
+
+from dateutil.relativedelta import relativedelta
+
+from hitas.calculations.improvement import ImprovementCalculationResult, ImprovementsResult
+from hitas.calculations.max_prices.types import (
+    IndexCalculation,
+    MaxPriceImprovements,
+    SurfaceAreaPriceCeilingCalculation,
+)
+from hitas.models import Apartment
+from hitas.types import Month
+
+
+class CalculatorRules:
+    def validate_indices(self, apartment: Apartment) -> None:
+        raise NotImplementedError()
+
+    def calculate_construction_price_index_max_price(
+        self,
+        apartment: Apartment,
+        total_surface_area: Decimal,
+        apartment_share_of_housing_company_loans: Decimal,
+        apartment_share_of_housing_company_loans_date: datetime.date,
+        apartment_improvements: List,
+        housing_company_improvements: List,
+        calculation_date: datetime.date,
+    ) -> IndexCalculation:
+        raise NotImplementedError()
+
+    def calculate_market_price_index_max_price(
+        self,
+        apartment: Apartment,
+        total_surface_area: Decimal,
+        apartment_share_of_housing_company_loans: Decimal,
+        apartment_share_of_housing_company_loans_date: datetime.date,
+        apartment_improvements: List,
+        housing_company_improvements: List,
+        calculation_date: datetime.date,
+    ) -> IndexCalculation:
+        raise NotImplementedError()
+
+    @staticmethod
+    def calculate_surface_area_price_ceiling(
+        apartment: Apartment, calculation_date: datetime.date
+    ) -> SurfaceAreaPriceCeilingCalculation:
+        return SurfaceAreaPriceCeilingCalculation(
+            maximum_price=apartment.surface_area_price_ceiling,
+            valid_until=surface_area_price_ceiling_validity(calculation_date),
+            calculation_variables=SurfaceAreaPriceCeilingCalculation.CalculationVars(
+                calculation_date=calculation_date,
+                calculation_date_value=apartment.surface_area_price_ceiling_m2,
+                surface_area=apartment.surface_area,
+            ),
+        )
+
+
+def improvement_to_obj(result: ImprovementCalculationResult) -> MaxPriceImprovements.Improvement:
+    return MaxPriceImprovements.Improvement(
+        name=result.name,
+        value=result.value,
+        completion_date=Month(result.completion_date),
+        value_added=result.value_added,
+        depreciation=MaxPriceImprovements.Improvement.Depreciation(
+            amount=result.depreciation.amount,
+            time=MaxPriceImprovements.Improvement.Depreciation.DepreciationTime(
+                years=int(result.depreciation.time_months / 12),
+                months=result.depreciation.time_months % 12,
+            ),
+        )
+        if result.depreciation
+        else None,
+        value_for_housing_company=result.improvement_value_for_housing_company,
+        value_for_apartment=result.improvement_value_for_apartment,
+    )
+
+
+def improvement_result_to_obj(result: ImprovementsResult) -> MaxPriceImprovements:
+    return MaxPriceImprovements(
+        items=list(map(improvement_to_obj, result.items)),
+        summary=MaxPriceImprovements.Summary(
+            value=result.summary.value,
+            value_added=result.summary.value_added,
+            excess=MaxPriceImprovements.Summary.Excess(
+                surface_area=result.summary.excess.surface_area,
+                value_per_square_meter=result.summary.excess.value_per_square_meter,
+                total=result.summary.excess.total,
+            ),
+            depreciation=result.summary.depreciation,
+            value_for_housing_company=result.summary.improvement_value_for_housing_company,
+            value_for_apartment=result.summary.improvement_value_for_apartment,
+        ),
+    )
+
+
+def surface_area_price_ceiling_validity(date: datetime.date) -> datetime.date:
+    """
+    1.2 - 30.4 -> end of May (31.5)
+    1.5 - 31.7 -> end of August (31.8)
+    1.8 - 31.10 -> end of November (30.11)
+    1.11 - 31.1 -> end of February (28/29.2)
+    """
+
+    if date.month == 1:
+        return date.replace(month=3, day=1) - relativedelta(days=1)
+    if 2 <= date.month <= 4:
+        return date.replace(month=5, day=31)
+    elif 5 <= date.month <= 7:
+        return date.replace(month=8, day=31)
+    elif 8 <= date.month <= 10:
+        return date.replace(month=11, day=30)
+    else:
+        return date.replace(year=date.year + 1, month=3, day=1) - relativedelta(days=1)

--- a/backend/hitas/calculations/max_prices/rules_2011_onwards.py
+++ b/backend/hitas/calculations/max_prices/rules_2011_onwards.py
@@ -1,0 +1,132 @@
+import datetime
+from decimal import Decimal
+from typing import List
+
+from dateutil.relativedelta import relativedelta
+
+from hitas.calculations.exceptions import IndexMissingException, InvalidCalculationResultException
+from hitas.calculations.improvement import ImprovementData, calculate_housing_company_improvements_after_2010
+from hitas.calculations.max_prices.rules import CalculatorRules, improvement_result_to_obj
+from hitas.calculations.max_prices.types import IndexCalculation
+from hitas.models import Apartment
+
+
+class Rules2011Onwards(CalculatorRules):
+    def validate_indices(self, apartment: Apartment) -> None:
+        if (
+            apartment.calculation_date_cpi_2005eq100 is None
+            or apartment.completion_date_cpi_2005eq100 is None
+            or apartment.calculation_date_mpi_2005eq100 is None
+            or apartment.completion_date_mpi_2005eq100 is None
+            or apartment.surface_area_price_ceiling is None
+        ):
+            raise IndexMissingException()
+
+    def calculate_construction_price_index_max_price(
+        self,
+        apartment: Apartment,
+        total_surface_area: Decimal,
+        apartment_share_of_housing_company_loans: Decimal,
+        apartment_share_of_housing_company_loans_date: datetime.date,
+        apartment_improvements: List,
+        housing_company_improvements: List,
+        calculation_date: datetime.date,
+    ) -> IndexCalculation:
+        return self._calculate_max_price(
+            apartment,
+            apartment.calculation_date_cpi_2005eq100,
+            apartment.completion_date_cpi_2005eq100,
+            total_surface_area,
+            apartment_share_of_housing_company_loans,
+            apartment_share_of_housing_company_loans_date,
+            housing_company_improvements,
+            calculation_date,
+        )
+
+    def calculate_market_price_index_max_price(
+        self,
+        apartment: Apartment,
+        total_surface_area: Decimal,
+        apartment_share_of_housing_company_loans: Decimal,
+        apartment_share_of_housing_company_loans_date: datetime.date,
+        apartment_improvements: List,
+        housing_company_improvements: List,
+        calculation_date: datetime.date,
+    ) -> IndexCalculation:
+        return self._calculate_max_price(
+            apartment,
+            apartment.calculation_date_mpi_2005eq100,
+            apartment.completion_date_mpi_2005eq100,
+            total_surface_area,
+            apartment_share_of_housing_company_loans,
+            apartment_share_of_housing_company_loans_date,
+            housing_company_improvements,
+            calculation_date,
+        )
+
+    @staticmethod
+    def _calculate_max_price(
+        apartment: Apartment,
+        calculation_date_index: Decimal,
+        completion_date_index: Decimal,
+        total_surface_area: Decimal,
+        apartment_share_of_housing_company_loans: Decimal,
+        apartment_share_of_housing_company_loans_date: datetime.date,
+        housing_company_improvements: List,
+        calculation_date: datetime.date,
+    ) -> IndexCalculation:
+        # Start calculations
+
+        # basic price
+        basic_price = apartment.acquisition_price + apartment.additional_work_during_construction
+
+        # index adjustment
+        index_adjustment = ((calculation_date_index / completion_date_index) * basic_price) - basic_price
+
+        # housing company improvements
+        hc_improvements_result = calculate_housing_company_improvements_after_2010(
+            [
+                ImprovementData(
+                    name=i.name,
+                    value=i.value,
+                    completion_date=i.completion_date,
+                    completion_date_index=i.completion_date_index,
+                )
+                for i in housing_company_improvements
+            ],
+            calculation_date_index=calculation_date_index,
+            total_surface_area=total_surface_area,
+            apartment_surface_area=apartment.surface_area,
+        )
+
+        # debt free shares price
+        debt_free_shares_price = (
+            basic_price + index_adjustment + hc_improvements_result.summary.improvement_value_for_apartment
+        )
+
+        # maximum price
+        max_price = debt_free_shares_price - apartment_share_of_housing_company_loans
+
+        if max_price <= 0:
+            raise InvalidCalculationResultException()
+
+        return IndexCalculation(
+            maximum_price=max_price,
+            valid_until=calculation_date + relativedelta(months=3),
+            calculation_variables=IndexCalculation.CalculationVars(
+                acquisition_price=apartment.acquisition_price,
+                additional_work_during_construction=apartment.additional_work_during_construction,
+                basic_price=basic_price,
+                index_adjustment=index_adjustment,
+                apartment_improvements=None,
+                housing_company_improvements=improvement_result_to_obj(hc_improvements_result),
+                debt_free_price=debt_free_shares_price,
+                debt_free_price_m2=debt_free_shares_price / apartment.surface_area,
+                apartment_share_of_housing_company_loans=apartment_share_of_housing_company_loans,
+                apartment_share_of_housing_company_loans_date=apartment_share_of_housing_company_loans_date,
+                completion_date=apartment.completion_date,
+                completion_date_index=completion_date_index,
+                calculation_date=calculation_date,
+                calculation_date_index=calculation_date_index,
+            ),
+        )

--- a/backend/hitas/calculations/max_prices/rules_pre_2011.py
+++ b/backend/hitas/calculations/max_prices/rules_pre_2011.py
@@ -1,0 +1,36 @@
+import datetime
+from decimal import Decimal
+from typing import List
+
+from hitas.calculations.max_prices.rules import CalculatorRules
+from hitas.calculations.max_prices.types import IndexCalculation
+from hitas.models import Apartment
+
+
+class RulesPre2011(CalculatorRules):
+    def validate_indices(self, apartment: Apartment) -> None:
+        raise NotImplementedError()
+
+    def calculate_construction_price_index_max_price(
+        self,
+        apartment: Apartment,
+        total_surface_area: Decimal,
+        apartment_share_of_housing_company_loans: Decimal,
+        apartment_share_of_housing_company_loans_date: datetime.date,
+        apartment_improvements: List,
+        housing_company_improvements: List,
+        calculation_date: datetime.date,
+    ) -> IndexCalculation:
+        raise NotImplementedError()
+
+    def calculate_market_price_index_max_price(
+        self,
+        apartment: Apartment,
+        total_surface_area: Decimal,
+        apartment_share_of_housing_company_loans: Decimal,
+        apartment_share_of_housing_company_loans_date: datetime.date,
+        apartment_improvements: List,
+        housing_company_improvements: List,
+        calculation_date: datetime.date,
+    ) -> IndexCalculation:
+        raise NotImplementedError()

--- a/backend/hitas/calculations/max_prices/types.py
+++ b/backend/hitas/calculations/max_prices/types.py
@@ -1,0 +1,86 @@
+import datetime
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import List, Optional
+
+from hitas.types import Month
+
+
+@dataclass
+class MaxPriceImprovements:
+    @dataclass
+    class Improvement:
+        @dataclass
+        class Depreciation:
+            @dataclass
+            class DepreciationTime:
+                years: int
+                months: int
+
+            amount: Decimal
+            time: DepreciationTime
+
+        name: str
+        value: Decimal
+        completion_date: Month
+        value_added: Decimal
+        depreciation: Optional[Depreciation]
+        value_for_housing_company: Decimal
+        value_for_apartment: Decimal
+
+    @dataclass
+    class Summary:
+        @dataclass
+        class Excess:
+            surface_area: Decimal
+            value_per_square_meter: Decimal
+            total: Decimal
+
+        value: Decimal
+        value_added: Decimal
+        excess: Excess
+        depreciation: Decimal
+        value_for_housing_company: Decimal
+        value_for_apartment: Decimal
+
+    items: List[Improvement]
+    summary: Summary
+
+
+@dataclass
+class IndexCalculation:
+    @dataclass
+    class CalculationVars:
+        acquisition_price: Decimal
+        additional_work_during_construction: Decimal
+        basic_price: Decimal
+        index_adjustment: Decimal
+        apartment_improvements: Optional[MaxPriceImprovements]
+        housing_company_improvements: MaxPriceImprovements
+        debt_free_price: Decimal
+        debt_free_price_m2: Decimal
+        apartment_share_of_housing_company_loans: Decimal
+        apartment_share_of_housing_company_loans_date: datetime.date
+        completion_date: datetime.date
+        completion_date_index: Decimal
+        calculation_date: datetime.date
+        calculation_date_index: Decimal
+
+    maximum_price: Decimal
+    valid_until: datetime.date
+    calculation_variables: CalculationVars
+    maximum: bool = False
+
+
+@dataclass
+class SurfaceAreaPriceCeilingCalculation:
+    @dataclass
+    class CalculationVars:
+        calculation_date: datetime.date
+        calculation_date_value: Decimal
+        surface_area: Decimal
+
+    maximum_price: Decimal
+    valid_until: datetime.date
+    calculation_variables: CalculationVars
+    maximum: bool = False

--- a/backend/hitas/tests/factories/apartment.py
+++ b/backend/hitas/tests/factories/apartment.py
@@ -5,7 +5,7 @@ from factory import fuzzy
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyDate, FuzzyDecimal
 
-from hitas.calculations.max_price import calculate_max_price, fetch_apartment
+from hitas.calculations.max_prices.max_price import calculate_max_price, fetch_apartment
 from hitas.models import (
     Apartment,
     ApartmentConstructionPriceImprovement,

--- a/backend/hitas/tests/test_max_price.py
+++ b/backend/hitas/tests/test_max_price.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from hitas.calculations.max_price import surface_area_price_ceiling_validity
+from hitas.calculations.max_prices.rules import surface_area_price_ceiling_validity
 
 
 @pytest.mark.parametrize(

--- a/backend/hitas/views/apartment_max_price.py
+++ b/backend/hitas/views/apartment_max_price.py
@@ -12,7 +12,7 @@ from rest_framework.serializers import Serializer
 from rest_framework.viewsets import ViewSet
 
 from hitas.calculations.exceptions import IndexMissingException, InvalidCalculationResultException
-from hitas.calculations.max_price import create_max_price_calculation
+from hitas.calculations.max_prices import create_max_price_calculation
 from hitas.exceptions import HitasModelNotFound
 from hitas.models import Apartment, HousingCompany
 from hitas.models.apartment import ApartmentMaximumPriceCalculation


### PR DESCRIPTION
# Hitas Pull Request

# Description

    backend: implement max price calculator refactoring
    
     - this commit splits `old `max_prices.py` into multiple files
       to support new calculations for housing companies constructed
       before 2011.
    
     - calculator is splitted into three parts:
      - `rules.py` contains common methods for max price calculators
      - `rules_2011_onwards.py` contains the calculator rules for housing
        companies completed 2011 onwards
      - `rules_pre_2011.py` contains the calculator rules for housing
        companies completed before 2011. This is still unimplemented.
    
     - there's now a `max_prices/types.py` to describe the output
       objects that calculators return


## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan

no visible changes should have happened

## Tickets

This pull request resolves all or part of the following ticket(s): n/a
