### PR TITLE
backend: implement market price calculations before 2011

### DIFF
--- a/backend/hitas/calculations/max_prices/rules_2011_onwards.py
+++ b/backend/hitas/calculations/max_prices/rules_2011_onwards.py
@@ -90,7 +90,7 @@ class Rules2011Onwards(CalculatorRules):
                     name=i.name,
                     value=i.value,
                     completion_date=i.completion_date,
-                    completion_date_index=i.completion_date_index,
+                    completion_date_index=i.completion_date_index_2005eq100,
                 )
                 for i in housing_company_improvements
             ],
@@ -116,6 +116,7 @@ class Rules2011Onwards(CalculatorRules):
             calculation_variables=IndexCalculation.CalculationVars(
                 acquisition_price=apartment.acquisition_price,
                 additional_work_during_construction=apartment.additional_work_during_construction,
+                interest_during_construction=None,
                 basic_price=basic_price,
                 index_adjustment=index_adjustment,
                 apartment_improvements=None,

--- a/backend/hitas/calculations/max_prices/rules_pre_2011.py
+++ b/backend/hitas/calculations/max_prices/rules_pre_2011.py
@@ -2,14 +2,29 @@ import datetime
 from decimal import Decimal
 from typing import List
 
-from hitas.calculations.max_prices.rules import CalculatorRules
-from hitas.calculations.max_prices.types import IndexCalculation
+from dateutil.relativedelta import relativedelta
+
+from hitas.calculations.exceptions import IndexMissingException, InvalidCalculationResultException
+from hitas.calculations.improvement import (
+    ImprovementData,
+    calculate_apartment_improvements_pre_2011,
+    calculate_housing_company_improvements_pre_2011,
+)
+from hitas.calculations.max_prices.rules import CalculatorRules, improvement_result_to_obj
+from hitas.calculations.max_prices.types import IndexCalculation, MaxPriceImprovements
 from hitas.models import Apartment
 
 
 class RulesPre2011(CalculatorRules):
     def validate_indices(self, apartment: Apartment) -> None:
-        raise NotImplementedError()
+        if (
+            apartment.calculation_date_cpi is None
+            or apartment.completion_date_cpi is None
+            or apartment.calculation_date_mpi is None
+            or apartment.completion_date_mpi is None
+            or apartment.surface_area_price_ceiling is None
+        ):
+            raise IndexMissingException()
 
     def calculate_construction_price_index_max_price(
         self,
@@ -21,7 +36,42 @@ class RulesPre2011(CalculatorRules):
         housing_company_improvements: List,
         calculation_date: datetime.date,
     ) -> IndexCalculation:
-        raise NotImplementedError()
+        # FIXME: implement
+        return IndexCalculation(
+            maximum_price=Decimal(0),
+            valid_until=calculation_date + relativedelta(months=3),
+            calculation_variables=IndexCalculation.CalculationVars(
+                acquisition_price=apartment.acquisition_price,
+                additional_work_during_construction=None,
+                interest_during_construction=apartment.interest_during_construction,
+                basic_price=Decimal(0),
+                index_adjustment=Decimal(0),
+                apartment_improvements=None,
+                housing_company_improvements=MaxPriceImprovements(
+                    items=[],
+                    summary=MaxPriceImprovements.Summary(
+                        depreciation=Decimal(0),
+                        excess=MaxPriceImprovements.Summary.Excess(
+                            surface_area=apartment.surface_area,
+                            value_per_square_meter=Decimal(0),
+                            total=Decimal(0),
+                        ),
+                        value=Decimal(0),
+                        value_added=Decimal(0),
+                        value_for_apartment=Decimal(0),
+                        value_for_housing_company=Decimal(0),
+                    ),
+                ),
+                debt_free_price=Decimal(0),
+                debt_free_price_m2=Decimal(0),
+                apartment_share_of_housing_company_loans=Decimal(0),
+                apartment_share_of_housing_company_loans_date=apartment_share_of_housing_company_loans_date,
+                completion_date=apartment.completion_date,
+                completion_date_index=apartment.completion_date_cpi,
+                calculation_date=calculation_date,
+                calculation_date_index=apartment.calculation_date_cpi,
+            ),
+        )
 
     def calculate_market_price_index_max_price(
         self,
@@ -33,4 +83,93 @@ class RulesPre2011(CalculatorRules):
         housing_company_improvements: List,
         calculation_date: datetime.date,
     ) -> IndexCalculation:
-        raise NotImplementedError()
+        # Start calculations
+
+        # Basic price
+        basic_price = apartment.acquisition_price + apartment.interest_during_construction
+
+        # Index adjustment
+        index_adjustment = (apartment.calculation_date_mpi / apartment.completion_date_mpi) * basic_price - basic_price
+
+        # Apartment improvements
+        apartment_improvements_list = [
+            ImprovementData(
+                name=i.name,
+                value=i.value,
+                completion_date=i.completion_date,
+                completion_date_index=i.completion_date_index,
+            )
+            for i in apartment_improvements
+        ]
+        if apartment.additional_work_during_construction:
+            # Add `additional_work_during_construction` as an improvement as it's treated as an improvement
+            # with pre 2011 rules
+            apartment_improvements_list.append(
+                ImprovementData(
+                    name="Rakennusaikaiset muutos- ja lisätyöt",
+                    value=apartment.additional_work_during_construction,
+                    completion_date=apartment.completion_date,
+                    completion_date_index=apartment.completion_date_mpi,
+                    treat_as_additional_work=True,
+                )
+            )
+        apartment_improvements_result = calculate_apartment_improvements_pre_2011(
+            apartment_improvements_list,
+            calculation_date=calculation_date,
+            calculation_date_index=apartment.calculation_date_mpi,
+            total_surface_area=total_surface_area,
+            apartment_surface_area=apartment.surface_area,
+        )
+
+        # Housing company improvements
+        hc_improvements_result = calculate_housing_company_improvements_pre_2011(
+            [
+                ImprovementData(
+                    name=i.name,
+                    value=i.value,
+                    completion_date=i.completion_date,
+                    completion_date_index=i.completion_date_index,
+                )
+                for i in housing_company_improvements
+            ],
+            calculation_date=calculation_date,
+            calculation_date_index=apartment.calculation_date_mpi,
+            total_surface_area=total_surface_area,
+            apartment_surface_area=apartment.surface_area,
+        )
+
+        # Debt free shares price
+        debt_free_shares_price = (
+            basic_price
+            + index_adjustment
+            + apartment_improvements_result.summary.improvement_value_for_apartment
+            + hc_improvements_result.summary.improvement_value_for_apartment
+        )
+
+        # Final maximum price
+        max_price = debt_free_shares_price - apartment_share_of_housing_company_loans
+
+        if max_price <= 0:
+            raise InvalidCalculationResultException()
+
+        return IndexCalculation(
+            maximum_price=max_price,
+            valid_until=calculation_date + relativedelta(months=3),
+            calculation_variables=IndexCalculation.CalculationVars(
+                acquisition_price=apartment.acquisition_price,
+                additional_work_during_construction=None,
+                interest_during_construction=apartment.interest_during_construction,
+                basic_price=basic_price,
+                index_adjustment=index_adjustment,
+                apartment_improvements=improvement_result_to_obj(apartment_improvements_result),
+                housing_company_improvements=improvement_result_to_obj(hc_improvements_result),
+                debt_free_price=debt_free_shares_price,
+                debt_free_price_m2=debt_free_shares_price / apartment.surface_area,
+                apartment_share_of_housing_company_loans=apartment_share_of_housing_company_loans,
+                apartment_share_of_housing_company_loans_date=apartment_share_of_housing_company_loans_date,
+                completion_date=apartment.completion_date,
+                completion_date_index=apartment.completion_date_mpi,
+                calculation_date=calculation_date,
+                calculation_date_index=apartment.calculation_date_mpi,
+            ),
+        )

--- a/backend/hitas/calculations/max_prices/types.py
+++ b/backend/hitas/calculations/max_prices/types.py
@@ -52,7 +52,8 @@ class IndexCalculation:
     @dataclass
     class CalculationVars:
         acquisition_price: Decimal
-        additional_work_during_construction: Decimal
+        additional_work_during_construction: Optional[Decimal]
+        interest_during_construction: Optional[Decimal]
         basic_price: Decimal
         index_adjustment: Decimal
         apartment_improvements: Optional[MaxPriceImprovements]

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3263,6 +3263,7 @@ components:
         - acquisition_price
         - additional_work_during_construction
         - basic_price
+        - interest_during_construction
         - index_adjustment
         - apartment_improvements
         - housing_company_improvements
@@ -3283,6 +3284,7 @@ components:
         additional_work_during_construction:
           description: Amount of apartment's additional work done during construction
           type: number
+          nullable: true
           minimum: 0
           example: 0.0
         basic_price:
@@ -3292,6 +3294,13 @@ components:
           type: number
           minimum: 0
           example: 199500.21
+        interest_during_construction:
+          description: |-
+            TBD
+          type: number
+          nullable: true
+          minimum: 0
+          example: 1802.88
         index_adjustment:
           description: |-
             Value increase of the apartment based on the index. Calculated by dividing the
@@ -3397,18 +3406,32 @@ components:
                 nullable: true
                 required:
                   - amount
-                  - time_months
+                  - time
                 properties:
                   amount:
                     description: Amount the value has reduced based on the depreciation calculation.
                     type: number
                     minimum: 0
                     example: 3965.69
-                  time_months:
+                  time:
                     description: Amount of time in months the improvement has depreciated
-                    type: integer
-                    minimum: 0
-                    example: 13
+                    type: object
+                    additionalProperties: false
+                    required:
+                      - years
+                      - months
+                    properties:
+                      years:
+                        description: How many years (in addition to months) this improvement has depreciated
+                        type: integer
+                        minimum: 0
+                        example: 13
+                      months:
+                        description: How many months (in addition to years) this improvement has depreciated
+                        type: integer
+                        minimum: 0
+                        maximum: 11
+                        example: 7
               value_for_housing_company:
                 description: Housing company's share of the improvement's value (adjusted to index)
                 type: number


### PR DESCRIPTION
# Hitas Pull Request

# Description

    backend: implement market price calculations before 2011
    
     - it's now possible to calculate maximum prices for apartments
       constructed before 2011. construction price index is not yet
       implemented and returns a zero value.


## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [x] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [x] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan

Test maximum price confirmation with apartments constructed before 2011

## Tickets

This pull request resolves all or part of the following ticket(s): HT-37
