### PR TITLE
Confirmed price PDF

### DIFF
--- a/backend/hitas/calculations/improvement.py
+++ b/backend/hitas/calculations/improvement.py
@@ -66,7 +66,7 @@ class ImprovementCalculationResult:
 @dataclass
 class ImprovementCalculationSummary:
     @dataclass
-    class ExcessSummary:
+    class ExcessSummary:  # 'Omavastuu'
         surface_area: Decimal
         value_per_square_meter: Decimal
 

--- a/backend/hitas/templates/components/apartment_info.jinja
+++ b/backend/hitas/templates/components/apartment_info.jinja
@@ -1,0 +1,26 @@
+{% macro apartment_info(apartment) %}
+    <table>
+        <tr>
+            <td class="first-column"><b>Huoneisto:</b></td>
+            <td>{{ apartment.street_address }} {{ apartment.stair }} {{ apartment.apartment_number }}, {{ apartment.postal_code }} {{ apartment.city|upper }}</td>
+        </tr>
+        <tr>
+            <td class="first-column"><b>Taloyhtiö:</b></td>
+            <td>{{ apartment.housing_company.id }} - {{ apartment.housing_company.official_name }}</td>
+        </tr>
+        <tr>
+            <td class="first-column"><b>Isännöitsijä:</b></td>
+            <td>{{ apartment.housing_company.property_manager.name }}, {{ apartment.housing_company.property_manager.street_address }}</td>
+        </tr>
+    </table>
+    <table>
+        {% for ownership in apartment.ownerships.all() %}
+            <tr>
+                <td class="first-column">{% if loop.index == 1 %}<b>Omistaja ja omistusosuus (%):</b>{% endif %}</td>
+                <td>{{ ownership.owner.name }}</td>
+                <td>{{ ownership.percentage }}</td>
+            </tr>
+        {% endfor %}
+    </table>
+    <br>
+{% endmacro %}

--- a/backend/hitas/templates/components/base.jinja
+++ b/backend/hitas/templates/components/base.jinja
@@ -14,28 +14,11 @@
                 -pdf-frame-content: header_content_2;
                 left: 325pt; width: 225pt; top: 50pt; height: 40pt;
             }
-            @frame content_frame {
-                left: 50pt; width: 512pt; top: 90pt; height: 632pt;
-            }
-            @frame footer_frame_1 {
-                -pdf-frame-content: footer_content_1;
-                left: 50pt; width: 125pt; top: 770pt; height: 50pt;
-            }
-            @frame footer_frame_2 {
-                -pdf-frame-content: footer_content_2;
-                left: 175pt; width: 125pt; top: 770pt; height: 50pt;
-            }
-            @frame footer_frame_3 {
-                -pdf-frame-content: footer_content_3;
-                left: 300pt; width: 125pt; top: 770pt; height: 50pt;
-            }
-            @frame footer_frame_4 {
-                -pdf-frame-content: footer_content_4;
-                left: 425pt; width: 125pt; top: 770pt; height: 50pt;
-            }
+            @frame content_frame {left: 50pt; width: 512pt; top: 90pt; height: 632pt;}
+            @frame footer {-pdf-frame-content: footer; left: 50pt; width: 500pt; top: 770pt; height: 50pt;}
         }
-        body {font-size: 10.5pt;}
-        .static-footer {font-size: 8pt;}
+        body {font-size: 9.5pt;}
+        .static-footer {font-size: 7pt; width: 500px;}
     </style>
 </head>
 
@@ -54,26 +37,32 @@
 
 
 {% block footer %}
-    <div class="static-footer">
-        <div id="footer_content_1">
-            <b>Postiosoite</b><br>
-            Asuntopalvelut<br>
-            PL 58231<br>
-            00099 HELSINGIN KAUPUNKI<br>
-        </div>
-        <div id="footer_content_2">
-            <b>Käyntiosoite</b><br>
-            Työpajankatu 8<br>
-            00580 Helsinki<br>
-        </div>
-        <div id="footer_content_3">
-            <b>Puh.</b><br>
-            <b>Email</b> hitas@hel.fi<br>
-            <b>Url</b> <a href="http://www.hel.fi/hitas" style="color: black;">http://www.hel.fi/hitas</a><br>
-        </div>
-        <div id="footer_content_4">
-        </div>
-    </div>
+        <table id="footer" class="static-footer">
+            <tr>
+                <td><b>Postiosoite</b></td>
+                <td><b>Käyntiosoite</b></td>
+                <td><b>Puh.</b> (09) 310 13033</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>Asuntopalvelut</td>
+                <td>Työpajankatu 8</td>
+                <td><b>Email</b> hitas@hel.fi</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>PL 58231</td>
+                <td>00580 Helsinki</td>
+                <td><b>Url</b> <a href="http://www.hel.fi/hitas" style="color: black; text-decoration: none;">http://www.hel.fi/hitas</a></td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>00099 HELSINGIN KAUPUNKI</td>
+                <td></td>
+                <td></td>
+                <td></td>
+            </tr>
+        </table>
 {% endblock %}
 
 </body>

--- a/backend/hitas/templates/components/base.jinja
+++ b/backend/hitas/templates/components/base.jinja
@@ -6,19 +6,28 @@
     <style>
         @page {
             size: A4 portrait;
-            @frame header_frame_1 {
-                -pdf-frame-content: header_content_1;
-                left: 50pt; width: 225pt; top: 50pt; height: 40pt;
-            }
-            @frame header_frame_2 {
-                -pdf-frame-content: header_content_2;
-                left: 325pt; width: 225pt; top: 50pt; height: 40pt;
-            }
+            @frame h_date {-pdf-frame-content: header_date; left: 325pt; width: 100pt; top: 50pt; height: 40pt;}
+            @frame content_frame {left: 50pt; width: 512pt; top: 90pt; height: 632pt;}
+            @frame footer {-pdf-frame-content: footer; left: 50pt; width: 500pt; top: 770pt; height: 50pt;}
+        }
+        @page template_attachment_1 {
+            size: A4 portrait;
+            @frame h_page_1 {-pdf-frame-content: header_page_1; left: 450pt; width: 100pt; top: 50pt; height: 40pt;}
+            @frame h_date {-pdf-frame-content: header_date; left: 325pt; width: 100pt; top: 50pt; height: 40pt;}
+            @frame content_frame {left: 50pt; width: 512pt; top: 90pt; height: 632pt;}
+            @frame footer {-pdf-frame-content: footer; left: 50pt; width: 500pt; top: 770pt; height: 50pt;}
+        }
+        @page template_attachment_2 {
+            size: A4 portrait;
+            @frame h_page_2 {-pdf-frame-content: header_page_2; left: 450pt; width: 100pt; top: 50pt; height: 40pt;}
+            @frame h_date {-pdf-frame-content: header_date; left: 325pt; width: 100pt; top: 50pt; height: 40pt;}
             @frame content_frame {left: 50pt; width: 512pt; top: 90pt; height: 632pt;}
             @frame footer {-pdf-frame-content: footer; left: 50pt; width: 500pt; top: 770pt; height: 50pt;}
         }
         body {font-size: 9.5pt;}
         .static-footer {font-size: 7pt; width: 500px;}
+        #header_page_1 {text-align: right;}
+        #header_page_2 {text-align: right;}
     </style>
     {% block style %}
     {% endblock %}
@@ -27,10 +36,9 @@
 <body>
 
 {% block header %}
-    <div id="header_content_1"></div>
-    <div id="header_content_2">
-        {{ date_today }}
-    </div>
+    <div id="header_date">{{ date_today }}</div>
+    <div id="header_page_1">Liite 1</div>
+    <div id="header_page_2">Liite 2</div>
 {% endblock %}
 
 

--- a/backend/hitas/templates/components/base.jinja
+++ b/backend/hitas/templates/components/base.jinja
@@ -20,6 +20,8 @@
         body {font-size: 9.5pt;}
         .static-footer {font-size: 7pt; width: 500px;}
     </style>
+    {% block style %}
+    {% endblock %}
 </head>
 
 <body>

--- a/backend/hitas/templates/components/calculation_details_table.jinja
+++ b/backend/hitas/templates/components/calculation_details_table.jinja
@@ -1,0 +1,62 @@
+{# refs. https://www.hel.fi/static/kanslia/Julkaisut/2021/Hitas/Liite_Hitas-j%C3%A4rjestelm%C3%A4n_tavoitteiden_toteutumista_koskeva_selvitys.pdf last page#}
+
+{% macro calculation_details_table(apartment, maximum_price_calculation, index_calculation, index_name_short, sapc_calculation) %}
+    {% set is_pre_2011 = apartment.completion_date|is_date_pre_2011 %}
+    {% set vars = index_calculation.calculation_variables %}
+
+    {% set table_left = [
+        ["Huoneluku:", apartment.rooms~" "~apartment.apartment_type.value],
+        ["Pinta-ala m²:", maximum_price_calculation.json.apartment.surface_area|intcomma],
+        ["Osakenumerot:", maximum_price_calculation.json.apartment.shares.start~" - "~maximum_price_calculation.json.apartment.shares.end],
+        ["Osakelkm:", maximum_price_calculation.json.apartment.shares.total],
+        ["Valmistumispäivä:", vars.completion_date|format_date],
+        ["ja sen "~index_name_short~":", vars.completion_date_index|intcomma],
+        ["Jälleenlaskentapäivä:", vars.calculation_date|format_date],
+        ["ja sen "~index_name_short~":", vars.calculation_date_index|intcomma],
+    ] %}
+
+    {% if not sapc_calculation %}
+        {% set table_right = [
+            ["Hankinta-arvo", vars.acquisition_price|intcomma],
+        ] %}
+
+        {% if vars.additional_work_during_construction is not none %} {% set table_right = table_right + [
+            ["+ Rakennusaik. lisä- ja muutostyöt", vars.additional_work_during_construction|intcomma],
+        ] %} {% endif %}
+
+        {% if is_pre_2011 %} {% set table_right = table_right + [
+            ["+ Rakennusaikaiset korot (TODO %)", vars.interest_during_construction|intcomma],
+        ] %} {% endif %}
+
+        {% set table_right = table_right + [
+            ["= Perushinta", vars.basic_price|intcomma],
+            ["+ Indeksin muutos", vars.index_adjustment|intcomma],
+        ] %}
+
+        {% if is_pre_2011 %} {% set table_right = table_right + [
+            [ "+ Huoneistokohtaiset parannukset", vars.apartment_improvements.summary.value_for_apartment|intcomma ],
+        ] %} {% endif %}
+
+        {% set table_right = table_right + [
+            ["+ Osuus yhtiön parannuksista", vars.housing_company_improvements.summary.value_for_apartment|intcomma],
+            ["= Osakkeiden velaton hinta", vars.debt_free_price|intcomma],
+            ["- osuus yhtiön lainoista "~vars.apartment_share_of_housing_company_loans_date|format_date, vars.apartment_share_of_housing_company_loans|intcomma],
+            ["= Enimmäismyyntihinta", index_calculation.maximum_price|intcomma],
+            ["Velaton hinta euroa/m² (*)", vars.debt_free_price_m2|intcomma],
+            ["* Lasketaan osakkeiden velattomasta hinnasta", ""],
+        ] %}
+    {% endif %}
+
+    <table>
+    {% for row in zip_lists(table_left, table_right) %}
+        <tr>
+            <td style="width: 180px;"><b>{{ row[0][0]|value_or_blank }}</b></td>
+            <td style="width: 150px;">{{ row[0][1]|value_or_blank }}</td>
+            {% if not sapc_calculation %}
+                <td style="width: 300px;"><b>{{ row[1][0]|value_or_blank }}</b></td>
+                <td style="width: 80px;" class="text-right">{{ row[1][1]|value_or_blank }}</td>
+            {% endif %}
+        </tr>
+    {% endfor %}
+    </table>
+{% endmacro %}

--- a/backend/hitas/templates/components/improvements_table.jinja
+++ b/backend/hitas/templates/components/improvements_table.jinja
@@ -52,14 +52,12 @@
     <h3 class="bordered-header">HUONEISTON OSUUS YHTIÖN PARANNUKSISTA</h3>
     <table class="improvements-table">
         <tr style="border-bottom: 1px solid black;">
-            <td class="improvement-cell" style="width: 172px;"><b>Parannus</b></td>
-            <td class="improvement-cell improvement-column" style="width: 60px;"><b>Arvo</b></td>
-            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Valmistunut</b></td>
-            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Arvoa korot-<br>tava osuus</b></td>
-            <td class="improvement-cell improvement-column" style="width: 70px;"><b>Poistoaika</b></td>
-            <td class="improvement-cell improvement-column" style="width: 60px;"><b>Poiston määrä</b></td>
-            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty yhtiö</b></td>
-            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty huoneisto</b></td>
+            <td class="improvement-cell" style="width: 252px;"><b>Parannus</b></td>
+            <td class="improvement-cell improvement-column" style="width: 70px;"><b>Arvo</b></td>
+            <td class="improvement-cell improvement-column" style="width: 90px;"><b>Valmistunut</b></td>
+            <td class="improvement-cell improvement-column" style="width: 90px;"><b>Arvoa korot-<br>tava osuus</b></td>
+            <td class="improvement-cell improvement-column" style="width: 90px;"><b>Hyväksytty<br>yhtiö</b></td>
+            <td class="improvement-cell improvement-column" style="width: 90px;"><b>Hyväksytty<br>huoneisto</b></td>
         </tr>
         {% set improvements = index_calculation.calculation_variables.housing_company_improvements %}
         {% for improvement in improvements["items"] %}
@@ -68,8 +66,6 @@
                 <td class="improvement-cell text-right">{{ improvement.value|intcomma }}</td>
                 <td class="improvement-cell text-right">{{ improvement.completion_date }}</td>
                 <td class="improvement-cell text-right">{{ improvement.value_added|intcomma }}</td>
-                <td class="improvement-cell text-right">TODO</td>
-                <td class="improvement-cell text-right">{{ improvement.depreciation }}</td>
                 <td class="improvement-cell text-right">{{ improvement.value_for_housing_company|intcomma }}</td>
                 <td class="improvement-cell text-right">{{ improvement.value_for_apartment|intcomma }}</td>
             </tr>
@@ -79,8 +75,6 @@
             <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.value|intcomma }}</b></td>
             <td></td>
             <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.value_added|intcomma }}</b></td>
-            <td></td>
-            <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.depreciation }}</b></td>
             <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.value_for_housing_company|intcomma }}</b></td>
             <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.value_for_apartment|intcomma }}</b></td>
         </tr>

--- a/backend/hitas/templates/components/improvements_table.jinja
+++ b/backend/hitas/templates/components/improvements_table.jinja
@@ -1,0 +1,141 @@
+{# Table max width is 682px #}
+
+{% macro apartment_improvements_table(index_calculation) %}
+    <h3 class="bordered-header">HUONEISTOKOHTAISET PARANNUKSET</h3>
+    <table class="improvements-table">
+        <tr style="border-bottom: 1px solid black;">
+            <td class="improvement-cell" style="width: 152px;"><b>Parannus</b></td>
+            <td class="improvement-cell improvement-column" style="width: 70px;"><b>Valmistunut</b></td>
+            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Indeksit</b></td>
+            <td class="improvement-cell improvement-column" style="width: 60px;"><b>Poisto %</b></td>
+            <td class="improvement-cell improvement-column" style="width: 65px;"><b>Poisto aika</b></td>
+            <td class="improvement-cell improvement-column" style="width: 65px;"><b>Alkup. arvo</b></td>
+            <td class="improvement-cell improvement-column" style="width: 65px;"><b>Ind. tark. arvo</b></td>
+            <td class="improvement-cell improvement-column" style="width: 60px;"><b>Poisto</b></td>
+            <td class="improvement-cell improvement-column" style="width: 65px;"><b>Hyv. arvo</b></td>
+        </tr>
+        {% set improvements = index_calculation.calculation_variables.apartment_improvements %}
+        {% for improvement in improvements["items"] %}
+            <tr>
+                <td class="improvement-cell">{{ improvement.name }}</td>
+                <td class="improvement-cell text-right">{{ improvement.completion_date }}</td>
+                <td class="improvement-cell text-right">*TODO*/{{ index_calculation.calculation_variables.calculation_date_index|intcomma }}</td>
+                <td class="improvement-cell text-right">*TODO*</td>
+                <td class="improvement-cell text-right"> {% if improvement.depreciation is not none %}{{ improvement.depreciation.time.years }} v {{ improvement.depreciation.time.months }} kk{% else %}-{% endif %}</td>
+                <td class="improvement-cell text-right">{{ improvement.value|intcomma }}</td>
+                <td class="improvement-cell text-right">*TODO*</td>
+                <td class="improvement-cell text-right"> {% if improvement.depreciation is not none %}{{ improvement.depreciation.amount|intcomma }}{% else %}-{% endif %}</td>
+                <td class="improvement-cell text-right">{{ improvement.value_for_apartment|intcomma }}</td>
+            </tr>
+        {% endfor %}
+        <tr style="border-top: 1px solid gray; padding-top: 2px;">
+            <td class="improvement-cell"><b>Parannukset yhteensä</b></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td class="improvement-cell text-right"><b>{{ improvements.summary.value|intcomma }}</b></td>
+            <td class="improvement-cell text-right">*TODO*</td>
+            <td class="improvement-cell text-right"><b>{{ improvements.summary.depreciation|intcomma }}</b></td>
+            <td class="improvement-cell text-right"><b>{{ improvements.summary.value_for_apartment|intcomma }}</b></td>
+        </tr>
+    </table>
+
+    {% set excess = improvements.summary.excess %}
+    {% if excess %}
+        <p>Parannuksen omavastuu on {{ excess.surface_area|intcomma }} m² x {{ excess.value_per_square_meter|intcomma }} euroa/m² = {{ excess.total|intcomma }} euroa. Arvoa korottavaan osuuteen tehdään indeksitarkistus ilman poistoja.</p>
+    {% endif %}
+{% endmacro %}
+
+
+{% macro housing_company_improvements_table_post_2011(index_calculation) %}
+    <h3 class="bordered-header">HUONEISTON OSUUS YHTIÖN PARANNUKSISTA</h3>
+    <table class="improvements-table">
+        <tr style="border-bottom: 1px solid black;">
+            <td class="improvement-cell" style="width: 172px;"><b>Parannus</b></td>
+            <td class="improvement-cell improvement-column" style="width: 60px;"><b>Arvo</b></td>
+            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Valmistunut</b></td>
+            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Arvoa korot-<br>tava osuus</b></td>
+            <td class="improvement-cell improvement-column" style="width: 70px;"><b>Poistoaika</b></td>
+            <td class="improvement-cell improvement-column" style="width: 60px;"><b>Poiston määrä</b></td>
+            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty yhtiö</b></td>
+            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty huoneisto</b></td>
+        </tr>
+        {% set improvements = index_calculation.calculation_variables.housing_company_improvements %}
+        {% for improvement in improvements["items"] %}
+            <tr style="padding-top: 2px;">
+                <td class="improvement-cell">{{ improvement.name }}</td>
+                <td class="improvement-cell text-right">{{ improvement.value|intcomma }}</td>
+                <td class="improvement-cell text-right">{{ improvement.completion_date }}</td>
+                <td class="improvement-cell text-right">{{ improvement.value_added|intcomma }}</td>
+                <td class="improvement-cell text-right">TODO</td>
+                <td class="improvement-cell text-right">{{ improvement.depreciation }}</td>
+                <td class="improvement-cell text-right">{{ improvement.value_for_housing_company|intcomma }}</td>
+                <td class="improvement-cell text-right">{{ improvement.value_for_apartment|intcomma }}</td>
+            </tr>
+        {% endfor %}
+        <tr style="border-top: 1px solid gray; padding-top: 2px;">
+            <td class="improvement-cell"><b>Parannukset yhteensä</b></td>
+            <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.value|intcomma }}</b></td>
+            <td></td>
+            <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.value_added|intcomma }}</b></td>
+            <td></td>
+            <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.depreciation }}</b></td>
+            <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.value_for_housing_company|intcomma }}</b></td>
+            <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.value_for_apartment|intcomma }}</b></td>
+        </tr>
+    </table>
+    {% set excess = improvements.summary.excess %}
+    {% if excess %}
+        <p>Parannuksen omavastuu on {{ excess.surface_area|intcomma }} m² x {{ excess.value_per_square_meter|intcomma }} euroa/m² = {{ excess.total|intcomma }} euroa. Arvoa korottavaan osuuteen tehdään indeksitarkistus ilman poistoja.</p>
+    {% endif %}
+
+{% endmacro %}
+
+
+
+{% macro housing_company_improvements_table_pre_2011(index_calculation) %}
+    <h3 class="bordered-header">HUONEISTON OSUUS YHTIÖN PARANNUKSISTA</h3>
+    <table class="improvements-table">
+        <tr style="border-bottom: 1px solid black;">
+            <td class="improvement-cell" style="width: 172px;"><b>Parannus</b></td>
+            <td class="improvement-cell improvement-column" style="width: 60px;"><b>Arvo</b></td>
+            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Valmistunut</b></td>
+            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Arvoa korot-<br>tava osuus</b></td>
+            <td class="improvement-cell improvement-column" style="width: 70px;"><b>Poistoaika</b></td>
+            <td class="improvement-cell improvement-column" style="width: 60px;"><b>Poiston määrä</b></td>
+            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty yhtiö</b></td>
+            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty huoneisto</b></td>
+        </tr>
+        {% set improvements = index_calculation.calculation_variables.housing_company_improvements %}
+        {% for improvement in improvements["items"] %}
+            <tr style="padding-top: 2px;">
+                <td class="improvement-cell">{{ improvement.name }}</td>
+                <td class="improvement-cell text-right">{{ improvement.value|intcomma }}</td>
+                <td class="improvement-cell text-right">{{ improvement.completion_date }}</td>
+                <td class="improvement-cell text-right">{{ improvement.value_added|intcomma }}</td>
+                <td class="improvement-cell text-right">*TODO*</td>
+                <td class="improvement-cell text-right">*TODO*</td>
+                <td class="improvement-cell text-right">{{ improvement.value_for_housing_company|intcomma }}</td>
+                <td class="improvement-cell text-right">{{ improvement.value_for_apartment|intcomma }}</td>
+            </tr>
+        {% endfor %}
+        <tr style="border-top: 1px solid gray; padding-top: 2px;">
+            <td class="improvement-cell"><b>Parannukset yhteensä</b></td>
+            <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.value|intcomma }}</b></td>
+            <td></td>
+            <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.value_added|intcomma }}</b></td>
+            <td></td>
+            <td class="improvement-cell text-right"><b>*TODO*</b></td>
+            <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.value_for_housing_company|intcomma }}</b></td>
+            <td class="improvement-cell text-right"><b>{{ index_calculation.calculation_variables.housing_company_improvements.summary.value_for_apartment|intcomma }}</b></td>
+        </tr>
+    </table>
+    {% set excess = improvements.summary.excess %}
+    {% if excess %}
+        <p>
+            * Jokaisen parannuksen omavastuu on {{ excess.surface_area|intcomma }} m² x {{ excess.value_per_square_meter|intcomma }} euroa/m² = {{ excess.total|intcomma }} euroa<br>
+            * Parannusten poistoaika on 10 vuotta ja poisto lasketaan arvoa korottavasta osuudesta
+        </p>
+    {% endif %}
+{% endmacro %}

--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -6,25 +6,47 @@
             width: 210px;
         }
 
-        p {
+        .plain-text {
             margin-left: 150px;
         }
 
         .bordered-header {
+            border-style: solid;
+            border-color: black;
             border-left: 2px;
             border-top: 2px;
             border-right: 4px;
             border-bottom: 4px;
-            border-style: solid;
-            border-color: black;
+        }
+        h2.bordered-header {
             text-align: center;
             padding-top: 10px;
             padding-bottom: -5px;
+            margin-left: 125px;
+            margin-right: 125px;
+            margin-bottom: 50px
+        }
+        h3.bordered-header {
+            text-align: left;
+            padding-left: 5px;
+            padding-top: 5px;
+            padding-bottom: -5px;
+            margin-right: 250px;
+            margin-bottom: 30px
         }
 
         .text-right {
             text-align: right;
             vertical-align: top;
+        }
+
+        .improvement-cell {
+            padding-right: 2px;
+            padding-top: 3px;
+        }
+        .improvement-column {
+            text-align: center;
+            vertical-align: bottom;
         }
     </style>
 {% endblock %}
@@ -33,6 +55,7 @@
 
 {% block content %}
     {% set apartment = maximum_price_calculation.apartment %}
+    {% set is_pre_2011 = apartment.completion_date|is_date_pre_2011 %}
 
     <h3>Helsingin kaupunki</h3>
     <h3>
@@ -69,20 +92,16 @@
 
     <br>
 
-    <p>
+    <p class="plain-text">
         Huoneiston vahvistettu enimmäismyyntihinta on
         {{ maximum_price_calculation.maximum_price|wordify }} ({{ maximum_price_calculation.maximum_price|intcomma }})
         euroa. Enimmäismyyntihinta on voimassa kolme kuukautta laskelman päiväyksestä.
     </p>
-    <p>Jos huoneiston osuus yhtiön lainoista on muuttunut ilmoitetusta määrästä, tulee kaupantekohetkellä huoneistolle
-       kuuluva osuus ottaa huomioon siten, ettei enimmäishintalaskelmassa (liite 1) mainittu osakkeiden velaton hinta
-       ylity.</p>
-    <p>Enimmäishintalaskelman uudistuksen voi tilata puhelimitse. Rajahinta tarkistetaan ja markkinahintaindeksi
-       julkaistaan neljännesvuosittain 1.2., 1.5., 1.8. ja 1. 11.</p>
-    <p>Kaupungilla on yhtiöjärjestykseen perustuva oikeus lunastaa huoneiston hallintaan oikeuttavat osakkeet kaupan
-       tapahduttua. Hitas-asunto voidaan myydä vain luonnolliselle henkilölle (ei yritykselle).</p>
-    <p>Enimmäishintalaskelma on tulostettu Hitas-rekisteristä ja perustuu huoneiston ja yhtiön tietoihin.</p>
-    <p>Lisätiedot: Maija Meikäläinen, suunnittelija, puhelin 310 00000</p>
+    <p class="plain-text">Jos huoneiston osuus yhtiön lainoista on muuttunut ilmoitetusta määrästä, tulee kaupantekohetkellä huoneistolle kuuluva osuus ottaa huomioon siten, ettei enimmäishintalaskelmassa (liite 1) mainittu osakkeiden velaton hinta ylity.</p>
+    <p class="plain-text">Enimmäishintalaskelman uudistuksen voi tilata puhelimitse. Rajahinta tarkistetaan ja markkinahintaindeksi julkaistaan neljännesvuosittain 1.2., 1.5., 1.8. ja 1. 11.</p>
+    <p class="plain-text">Kaupungilla on yhtiöjärjestykseen perustuva oikeus lunastaa huoneiston hallintaan oikeuttavat osakkeet kaupan tapahduttua. Hitas-asunto voidaan myydä vain luonnolliselle henkilölle (ei yritykselle).</p>
+    <p class="plain-text">Enimmäishintalaskelma on tulostettu Hitas-rekisteristä ja perustuu huoneiston ja yhtiön tietoihin.</p>
+    <p class="plain-text">Lisätiedot: Maija Meikäläinen, suunnittelija, puhelin 310 00000</p>
 
     <br>
     <br>
@@ -103,9 +122,11 @@
     {% if maximum_price_calculation.json.calculations.market_price_index.maximum_price > maximum_price_calculation.json.calculations.construction_price_index.maximum_price %}
         {% set calculation = maximum_price_calculation.json.calculations.market_price_index %}
         {% set index_name = "MARKKINAHINTAINDEKSILLÄ" %}
+        {% set show_improvements = true %}
     {% else %}
         {% set calculation = maximum_price_calculation.json.calculations.construction_price_index %}
         {% set index_name = "RAKENNUSKUSTANNUSINDEKSILLÄ" %}
+        {% set show_improvements = false %}
     {% endif %}
 
 
@@ -199,5 +220,57 @@
             <td class="text-right">{{ calculation.calculation_variables.debt_free_price_m2|intcomma }}</td>
         </tr>
     </table>
+
+    {% if is_pre_2011 %}
+        <pdf:nexttemplate name="template_attachment_2" />
+        <pdf:nextpage />
+
+        <h2 class="bordered-header">ENIMMÄISHINTALASKELMA<br>{{ index_name }}</h2>
+        <h3 class="bordered-header">HUONEISTON OSUUS YHTIÖN PARANNUKSISTA</h3>
+
+        {# Table max width is 682px #}
+        <table style="font-size: 8pt">
+            <tr style="border-bottom: 1px solid black;">
+                <td class="improvement-cell" style="width: 172px;"><b>Parannus</b></td>
+                <td class="improvement-cell improvement-column" style="width: 60px;"><b>Arvo</b></td>
+                <td class="improvement-cell improvement-column" style="width: 80px;"><b>Valmistunut</b></td>
+                <td class="improvement-cell improvement-column" style="width: 80px;"><b>Arvoa korot-<br>tava osuus</b></td>
+                <td class="improvement-cell improvement-column" style="width: 70px;"><b>Poistoaika</b></td>
+                <td class="improvement-cell improvement-column" style="width: 60px;"><b>Poiston määrä</b></td>
+                <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty yhtiö</b></td>
+                <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty huoneisto</b></td>
+            </tr>
+            {% for improvement in calculation.calculation_variables.housing_company_improvements["items"] %}
+                <tr style="border-bottom: 1px solid black; padding-top: 2px;">
+                    <td class="improvement-cell">{{ improvement.name }}</td>
+                    <td class="improvement-cell text-right">{{ improvement.value|intcomma }}</td>
+                    <td class="improvement-cell text-right">{{ improvement.completion_date }}</td>
+                    <td class="improvement-cell text-right">{{ improvement.value_added|intcomma }}</td>
+                    <td class="improvement-cell text-right">TODO</td>
+                    <td class="improvement-cell text-right">{{ improvement.depreciation|intcomma }}</td>
+                    <td class="improvement-cell text-right">{{ improvement.value_for_housing_company|intcomma }}</td>
+                    <td class="improvement-cell text-right">{{ improvement.value_for_apartment|intcomma }}</td>
+                </tr>
+            {% endfor %}
+            <tr style="padding-top: 2px;">
+                <td class="improvement-cell"><b>Parannukset yhteensä</b></td>
+                <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value|intcomma }}</b></td>
+                <td></td>
+                <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value_added|intcomma }}</b></td>
+                <td></td>
+                <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.depreciation|intcomma }}</b></td>
+                <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value_for_housing_company|intcomma }}</b></td>
+                <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value_for_apartment|intcomma }}</b></td>
+            </tr>
+        </table>
+
+        <br>
+
+        <p>
+        {% set excess = calculation.calculation_variables.housing_company_improvements.summary.excess %}
+        Parannuksen omavastuu on {{ excess.surface_area|intcomma }} m² x {{ excess.value_per_square_meter|intcomma }} euroa/m² = {{ excess.total|intcomma }} euroa. Arvoa korottavaan osuuteen tehdään indeksitarkistus ilman poistoja.
+        </p>
+
+    {% endif %}
 
 {% endblock %}

--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -126,9 +126,11 @@
     {% if maximum_price_calculation.json.calculations.market_price_index.maximum_price > maximum_price_calculation.json.calculations.construction_price_index.maximum_price %}
         {% set calculation = maximum_price_calculation.json.calculations.market_price_index %}
         {% set index_name = "MARKKINAHINTAINDEKSILLÄ" %}
+        {% set index_name_short = "mark.hintaindeksi" %}
     {% else %}
         {% set calculation = maximum_price_calculation.json.calculations.construction_price_index %}
         {% set index_name = "RAKENNUSKUSTANNUSINDEKSILLÄ" %}
+        {% set index_name_short = "rak.kust.indeksi" %}
     {% endif %}
 
     <h2 class="bordered-header">ENIMMÄISHINTALASKELMA<br>{{ index_name }}</h2>
@@ -183,7 +185,7 @@
             <td class="text-right">{{ calculation.calculation_variables.apartment_improvements }}</td>
         </tr>
         <tr>
-            <td><b>ja sen rak.kust.indeksi:</b></td>
+            <td><b>ja sen {{ index_name_short }}:</b></td>
             <td>{{ calculation.calculation_variables.completion_date_index|intcomma }}</td>
             <td><b>+ Osuus yhtiön parannuksista</b></td>
             <td class="text-right">{{ calculation.calculation_variables.housing_company_improvements.summary.value_for_apartment|intcomma }}</td>
@@ -195,7 +197,7 @@
             <td class="text-right">{{ calculation.calculation_variables.debt_free_price|intcomma }}</td>
         </tr>
         <tr>
-            <td><b>ja sen rak.kust.indeksi:</b></td>
+            <td><b>ja sen {{ index_name_short }}:</b></td>
             <td>{{ calculation.calculation_variables.completion_date_index|intcomma }}</td>
             <td><b>- osuus yhtiön lainoista {{ calculation.calculation_variables.apartment_share_of_housing_company_loans_date|format_date }}</b></td>
             <td class="text-right">{{ calculation.calculation_variables.apartment_share_of_housing_company_loans|intcomma }}</td>

--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -1,9 +1,200 @@
 {% extends "components/base.jinja" %}
 
+{% block style %}
+    <style>
+        .first-column {
+            width: 210px;
+        }
+
+        p {
+            margin-left: 150px;
+        }
+
+        .bordered-header {
+            border-left: 2px;
+            border-top: 2px;
+            border-right: 4px;
+            border-bottom: 4px;
+            border-style: solid;
+            border-color: black;
+            text-align: center;
+            padding-top: 10px;
+            padding-bottom: -5px;
+        }
+
+        .text-right {
+            text-align: right;
+            vertical-align: top;
+        }
+    </style>
+{% endblock %}
+
 {% block title %}{{ title }}{% endblock %}
 
 {% block content %}
+    {% set apartment = maximum_price_calculation.apartment %}
 
-<code>{{ maximum_price_calculation.json }}</code>
+    <h3>Helsingin kaupunki</h3>
+    <h3>
+        {{ apartment.street_address }} {{ apartment.stair }} {{ apartment.apartment_number }}
+        <br>{{ apartment.postal_code }} {{ apartment.city|upper }}
+    </h3>
+
+    <br>
+
+    <h3>HITAS-HUONEISTON ENIMMÄISHINTALASKELMA</h3>
+    <table>
+        <tr>
+            <td class="first-column"><b>Asunto-osakeyhtiö</b></td>
+            <td>{{ apartment.housing_company.official_name }}</td>
+        </tr>
+        <tr>
+            <td class="first-column"><b>Huoneiston osoite</b></td>
+            <td>{{ apartment.street_address }} {{ apartment.stair }} {{ apartment.apartment_number }}, {{ apartment.postal_code }} {{ apartment.city|upper }}</td>
+        </tr>
+        <tr>
+            <td class="first-column"><b>Osakenumerot</b></td>
+            <td>{{ apartment.share_number_start }} - {{ apartment.share_number_end }}</td>
+        </tr>
+    </table>
+    <table>
+        {% for ownership in apartment.ownerships.all() %}
+            <tr>
+                <td class="first-column">{% if loop.index == 1 %}<b>Omistaja ja omistusosuus (%)</b>{% endif %}</td>
+                <td>{{ ownership.owner.name }}</td>
+                <td>{{ ownership.percentage }}</td>
+            </tr>
+        {% endfor %}
+    </table>
+
+    <br>
+
+    <p>
+        Huoneiston vahvistettu enimmäismyyntihinta on
+        {{ maximum_price_calculation.maximum_price|wordify }} ({{ maximum_price_calculation.maximum_price|intcomma }})
+        euroa. Enimmäismyyntihinta on voimassa kolme kuukautta laskelman päiväyksestä.
+    </p>
+    <p>Jos huoneiston osuus yhtiön lainoista on muuttunut ilmoitetusta määrästä, tulee kaupantekohetkellä huoneistolle
+       kuuluva osuus ottaa huomioon siten, ettei enimmäishintalaskelmassa (liite 1) mainittu osakkeiden velaton hinta
+       ylity.</p>
+    <p>Enimmäishintalaskelman uudistuksen voi tilata puhelimitse. Rajahinta tarkistetaan ja markkinahintaindeksi
+       julkaistaan neljännesvuosittain 1.2., 1.5., 1.8. ja 1. 11.</p>
+    <p>Kaupungilla on yhtiöjärjestykseen perustuva oikeus lunastaa huoneiston hallintaan oikeuttavat osakkeet kaupan
+       tapahduttua. Hitas-asunto voidaan myydä vain luonnolliselle henkilölle (ei yritykselle).</p>
+    <p>Enimmäishintalaskelma on tulostettu Hitas-rekisteristä ja perustuu huoneiston ja yhtiön tietoihin.</p>
+    <p>Lisätiedot: Maija Meikäläinen, suunnittelija, puhelin 310 00000</p>
+
+    <br>
+    <br>
+    <br>
+    <br>
+
+    <table>
+        <tr>
+            <td style="width: 150px; vertical-align: top;">TIEDOKSI</td>
+            <td>{{ apartment.housing_company.official_name }}<br>{{ apartment.housing_company.property_manager.name }}
+            </td>
+        </tr>
+    </table>
+
+    {% if maximum_price_calculation.json.calculations.market_price_index.maximum_price > maximum_price_calculation.json.calculations.construction_price_index.maximum_price %}
+        {% set calculation = maximum_price_calculation.json.calculations.market_price_index %}
+        {% set index_name = "MARKKINAHINTAINDEKSILLÄ" %}
+    {% else %}
+        {% set calculation = maximum_price_calculation.json.calculations.construction_price_index %}
+        {% set index_name = "RAKENNUSKUSTANNUSINDEKSILLÄ" %}
+    {% endif %}
+
+
+    <h2 class="bordered-header">ENIMMÄISHINTALASKELMA<br>{{ index_name }}</h2>
+
+    <table>
+        <tr>
+            <td class="first-column"><b>HUONEISTO</b></td>
+            <td>{{ apartment.street_address }} {{ apartment.stair }} {{ apartment.apartment_number }}, {{ apartment.postal_code }} {{ apartment.city|upper }}</td>
+        </tr>
+        <tr>
+            <td class="first-column"><b>Taloyhtiö</b></td>
+            <td>{{ apartment.housing_company.id }} - {{ apartment.housing_company.official_name }}</td>
+        </tr>
+        <tr>
+            <td class="first-column"><b>Isännöitsijä</b></td>
+            <td>{{ apartment.housing_company.property_manager.name }}, {{ apartment.housing_company.property_manager.street_address }}</td>
+        </tr>
+    </table>
+    <table>
+        {% for ownership in apartment.ownerships.all() %}
+            <tr>
+                <td class="first-column">{% if loop.index == 1 %}<b>Omistaja ja omistusosuus (%)</b>{% endif %}</td>
+                <td>{{ ownership.owner.name }}</td>
+                <td>{{ ownership.percentage }}</td>
+            </tr>
+        {% endfor %}
+    </table>
+
+    <br>
+
+    <table>
+        <tr>
+            <td style="width: 200px"><b>Huoneluku:</b></td>
+            <td style="width: 150px">{{ apartment.rooms }} {{ apartment.apartment_type.value }}</td>
+            <td style="width: 350px"><b>Hankinta-arvo</b></td>
+            <td style="width: 100px" class="text-right">{{ calculation.calculation_variables.acquisition_price|intcomma }}</td>
+        </tr>
+        <tr>
+            <td><b>Pinta-ala m²:</b></td>
+            <td>{{ maximum_price_calculation.json.apartment.surface_area|intcomma }}</td>
+            <td><b>+ Rakennusaik. lisä- ja muutostyöt</b></td>
+            <td class="text-right">{{ calculation.calculation_variables.additional_work_during_construction|intcomma }}</td>
+        </tr>
+        <tr>
+            <td><b>Osakenumerot:</b></td>
+            <td>{{ maximum_price_calculation.json.apartment.shares.start }} - {{ maximum_price_calculation.json.apartment.shares.end }}</td>
+            <td><b>= Perushinta</b></td>
+            <td class="text-right">{{ calculation.calculation_variables.basic_price|intcomma }}</td>
+        </tr>
+        <tr>
+            <td><b>Osakelkm:</b></td>
+            <td>{{ maximum_price_calculation.json.apartment.shares.total }}</td>
+            <td><b>+ Indeksin muutos</b></td>
+            <td class="text-right">{{ calculation.calculation_variables.index_adjustment|intcomma }}</td>
+        </tr>
+        <tr>
+            <td><b>Valmistumispäivä:</b></td>
+            <td>{{ calculation.calculation_variables.completion_date|format_date }}</td>
+            <td><b>+ Huoneistokohtaiset parannukset</b></td>
+            <td class="text-right">{{ calculation.calculation_variables.apartment_improvements|intcomma }}</td>
+        </tr>
+        <tr>
+            <td><b>ja sen rak.kust.indeksi:</b></td>
+            <td>{{ calculation.calculation_variables.completion_date_index|intcomma }}</td>
+            <td><b>+ Osuus yhtiön parannuksista</b></td>
+            <td class="text-right">{{ calculation.calculation_variables.housing_company_improvements.summary.value_for_apartment|intcomma }}</td>
+        </tr>
+        <tr>
+            <td><b>Jälleenlaskentapäivä:</b></td>
+            <td>{{ calculation.calculation_variables.calculation_date|format_date }}</td>
+            <td><b>= Osakkeiden velaton hinta</b></td>
+            <td class="text-right">{{ calculation.calculation_variables.debt_free_price|intcomma }}</td>
+        </tr>
+        <tr>
+            <td><b>ja sen rak.kust.indeksi:</b></td>
+            <td>{{ calculation.calculation_variables.completion_date_index|intcomma }}</td>
+            <td><b>- osuus yhtiön lainoista {{ calculation.calculation_variables.apartment_share_of_housing_company_loans_date|format_date }}</b></td>
+            <td class="text-right">{{ calculation.calculation_variables.apartment_share_of_housing_company_loans|intcomma }}</td>
+        </tr>
+        <tr>
+            <td></td>
+            <td></td>
+            <td><b>= Enimmäismyyntihinta</b></td>
+            <td class="text-right">{{ calculation.maximum_price|intcomma }}</td>
+        </tr>
+        <tr>
+            <td></td>
+            <td></td>
+            <td><b>Velaton hinta euroa/m² (*)<br>* Lasketaan osakkeiden velattomasta hinnasta</b></td>
+            <td class="text-right">{{ calculation.calculation_variables.debt_free_price_m2|intcomma }}</td>
+        </tr>
+    </table>
 
 {% endblock %}

--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -60,7 +60,7 @@
         }
 
         .improvement-column {
-            text-align: center;
+            text-align: right;
             vertical-align: bottom;
         }
 

--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -1,4 +1,5 @@
 {% extends "components/base.jinja" %}
+{% from "components/apartment_info.jinja" import apartment_info %}
 
 {% block style %}
     <style>
@@ -18,21 +19,23 @@
             border-right: 4px;
             border-bottom: 4px;
         }
+
         h2.bordered-header {
             text-align: center;
             padding-top: 10px;
             padding-bottom: -5px;
             margin-left: 125px;
             margin-right: 125px;
-            margin-bottom: 50px
+            margin-bottom: 50px;
         }
+
         h3.bordered-header {
             text-align: left;
             padding-left: 5px;
             padding-top: 5px;
             padding-bottom: -5px;
             margin-right: 250px;
-            margin-bottom: 30px
+            margin-bottom: 30px;
         }
 
         .text-right {
@@ -44,6 +47,7 @@
             padding-right: 2px;
             padding-top: 3px;
         }
+
         .improvement-column {
             text-align: center;
             vertical-align: bottom;
@@ -122,42 +126,31 @@
     {% if maximum_price_calculation.json.calculations.market_price_index.maximum_price > maximum_price_calculation.json.calculations.construction_price_index.maximum_price %}
         {% set calculation = maximum_price_calculation.json.calculations.market_price_index %}
         {% set index_name = "MARKKINAHINTAINDEKSILLÄ" %}
-        {% set show_improvements = true %}
     {% else %}
         {% set calculation = maximum_price_calculation.json.calculations.construction_price_index %}
         {% set index_name = "RAKENNUSKUSTANNUSINDEKSILLÄ" %}
-        {% set show_improvements = false %}
     {% endif %}
-
 
     <h2 class="bordered-header">ENIMMÄISHINTALASKELMA<br>{{ index_name }}</h2>
 
-    <table>
-        <tr>
-            <td class="first-column"><b>HUONEISTO</b></td>
-            <td>{{ apartment.street_address }} {{ apartment.stair }} {{ apartment.apartment_number }}, {{ apartment.postal_code }} {{ apartment.city|upper }}</td>
-        </tr>
-        <tr>
-            <td class="first-column"><b>Taloyhtiö</b></td>
-            <td>{{ apartment.housing_company.id }} - {{ apartment.housing_company.official_name }}</td>
-        </tr>
-        <tr>
-            <td class="first-column"><b>Isännöitsijä</b></td>
-            <td>{{ apartment.housing_company.property_manager.name }}, {{ apartment.housing_company.property_manager.street_address }}</td>
-        </tr>
-    </table>
-    <table>
-        {% for ownership in apartment.ownerships.all() %}
-            <tr>
-                <td class="first-column">{% if loop.index == 1 %}<b>Omistaja ja omistusosuus (%)</b>{% endif %}</td>
-                <td>{{ ownership.owner.name }}</td>
-                <td>{{ ownership.percentage }}</td>
-            </tr>
-        {% endfor %}
-    </table>
+    {{ apartment_info(apartment) }}
+    {{ calculation_details_table(apartment, maximum_price_calculation, calculation) }}
 
-    <br>
 
+    {% if is_pre_2011 %}
+        <pdf:nexttemplate name="template_attachment_2" />
+        <pdf:nextpage />
+
+        <h2 class="bordered-header">ENIMMÄISHINTALASKELMA<br>{{ index_name }}</h2>
+        <h3 class="bordered-header">HUONEISTON OSUUS YHTIÖN PARANNUKSISTA</h3>
+
+        {{ improvements_table(calculation) }}
+    {% endif %}
+
+{% endblock %}
+
+
+{% macro calculation_details_table(apartment, maximum_price_calculation, calculation) %}
     <table>
         <tr>
             <td style="width: 200px"><b>Huoneluku:</b></td>
@@ -220,57 +213,49 @@
             <td class="text-right">{{ calculation.calculation_variables.debt_free_price_m2|intcomma }}</td>
         </tr>
     </table>
+{% endmacro %}
 
-    {% if is_pre_2011 %}
-        <pdf:nexttemplate name="template_attachment_2" />
-        <pdf:nextpage />
-
-        <h2 class="bordered-header">ENIMMÄISHINTALASKELMA<br>{{ index_name }}</h2>
-        <h3 class="bordered-header">HUONEISTON OSUUS YHTIÖN PARANNUKSISTA</h3>
-
-        {# Table max width is 682px #}
-        <table style="font-size: 8pt">
-            <tr style="border-bottom: 1px solid black;">
-                <td class="improvement-cell" style="width: 172px;"><b>Parannus</b></td>
-                <td class="improvement-cell improvement-column" style="width: 60px;"><b>Arvo</b></td>
-                <td class="improvement-cell improvement-column" style="width: 80px;"><b>Valmistunut</b></td>
-                <td class="improvement-cell improvement-column" style="width: 80px;"><b>Arvoa korot-<br>tava osuus</b></td>
-                <td class="improvement-cell improvement-column" style="width: 70px;"><b>Poistoaika</b></td>
-                <td class="improvement-cell improvement-column" style="width: 60px;"><b>Poiston määrä</b></td>
-                <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty yhtiö</b></td>
-                <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty huoneisto</b></td>
+{% macro improvements_table(calculation) %}
+    {# Table max width is 682px #}
+    <table style="font-size: 8pt">
+        <tr style="border-bottom: 1px solid black;">
+            <td class="improvement-cell" style="width: 172px;"><b>Parannus</b></td>
+            <td class="improvement-cell improvement-column" style="width: 60px;"><b>Arvo</b></td>
+            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Valmistunut</b></td>
+            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Arvoa korot-<br>tava osuus</b></td>
+            <td class="improvement-cell improvement-column" style="width: 70px;"><b>Poistoaika</b></td>
+            <td class="improvement-cell improvement-column" style="width: 60px;"><b>Poiston määrä</b></td>
+            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty yhtiö</b></td>
+            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty huoneisto</b></td>
+        </tr>
+        {% for improvement in calculation.calculation_variables.housing_company_improvements["items"] %}
+            <tr style="border-bottom: 1px solid black; padding-top: 2px;">
+                <td class="improvement-cell">{{ improvement.name }}</td>
+                <td class="improvement-cell text-right">{{ improvement.value|intcomma }}</td>
+                <td class="improvement-cell text-right">{{ improvement.completion_date }}</td>
+                <td class="improvement-cell text-right">{{ improvement.value_added|intcomma }}</td>
+                <td class="improvement-cell text-right">TODO</td>
+                <td class="improvement-cell text-right">{{ improvement.depreciation|intcomma }}</td>
+                <td class="improvement-cell text-right">{{ improvement.value_for_housing_company|intcomma }}</td>
+                <td class="improvement-cell text-right">{{ improvement.value_for_apartment|intcomma }}</td>
             </tr>
-            {% for improvement in calculation.calculation_variables.housing_company_improvements["items"] %}
-                <tr style="border-bottom: 1px solid black; padding-top: 2px;">
-                    <td class="improvement-cell">{{ improvement.name }}</td>
-                    <td class="improvement-cell text-right">{{ improvement.value|intcomma }}</td>
-                    <td class="improvement-cell text-right">{{ improvement.completion_date }}</td>
-                    <td class="improvement-cell text-right">{{ improvement.value_added|intcomma }}</td>
-                    <td class="improvement-cell text-right">TODO</td>
-                    <td class="improvement-cell text-right">{{ improvement.depreciation|intcomma }}</td>
-                    <td class="improvement-cell text-right">{{ improvement.value_for_housing_company|intcomma }}</td>
-                    <td class="improvement-cell text-right">{{ improvement.value_for_apartment|intcomma }}</td>
-                </tr>
-            {% endfor %}
-            <tr style="padding-top: 2px;">
-                <td class="improvement-cell"><b>Parannukset yhteensä</b></td>
-                <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value|intcomma }}</b></td>
-                <td></td>
-                <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value_added|intcomma }}</b></td>
-                <td></td>
-                <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.depreciation|intcomma }}</b></td>
-                <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value_for_housing_company|intcomma }}</b></td>
-                <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value_for_apartment|intcomma }}</b></td>
-            </tr>
-        </table>
+        {% endfor %}
+        <tr style="padding-top: 2px;">
+            <td class="improvement-cell"><b>Parannukset yhteensä</b></td>
+            <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value|intcomma }}</b></td>
+            <td></td>
+            <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value_added|intcomma }}</b></td>
+            <td></td>
+            <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.depreciation|intcomma }}</b></td>
+            <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value_for_housing_company|intcomma }}</b></td>
+            <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value_for_apartment|intcomma }}</b></td>
+        </tr>
+    </table>
 
-        <br>
+    <br>
 
-        <p>
+    <p>
         {% set excess = calculation.calculation_variables.housing_company_improvements.summary.excess %}
         Parannuksen omavastuu on {{ excess.surface_area|intcomma }} m² x {{ excess.value_per_square_meter|intcomma }} euroa/m² = {{ excess.total|intcomma }} euroa. Arvoa korottavaan osuuteen tehdään indeksitarkistus ilman poistoja.
-        </p>
-
-    {% endif %}
-
-{% endblock %}
+    </p>
+{% endmacro %}

--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -1,6 +1,7 @@
 {% extends "components/base.jinja" %}
 {% from "components/apartment_info.jinja" import apartment_info %}
 {% from "components/calculation_details_table.jinja" import calculation_details_table %}
+{% from "components/improvements_table.jinja" import apartment_improvements_table, housing_company_improvements_table_pre_2011, housing_company_improvements_table_post_2011 %}
 
 {% block style %}
     <style>
@@ -60,6 +61,13 @@
 
         .improvement-column {
             text-align: center;
+            vertical-align: bottom;
+        }
+
+        .improvements-table {
+            font-size: 8pt;
+        }
+        table.improvements-table tr td:first-child {
             vertical-align: bottom;
         }
     </style>
@@ -183,16 +191,25 @@
     {% endif %}
 
     {# Parannukset #}
-    {% if is_pre_2011 %}
+    {% if index_calculation.calculation_variables.housing_company_improvements or index_calculation.calculation_variables.apartment_improvements %}
         <pdf:nexttemplate name="template_attachment_2" />
         <pdf:nextpage />
 
         <h2 class="bordered-header">ENIMMÄISHINTALASKELMA<br>{{ index_name }}</h2>
-        <h3 class="bordered-header">HUONEISTON OSUUS YHTIÖN PARANNUKSISTA</h3>
 
-        {{ improvements_table(index_calculation) }}
+        {% if index_calculation.calculation_variables.apartment_improvements %}
+            {{ apartment_improvements_table(index_calculation) }}
+            <br>
+        {% endif %}
+
+        {% if index_calculation.calculation_variables.housing_company_improvements %}
+            {% if is_pre_2011 %}
+                {{ housing_company_improvements_table_pre_2011(index_calculation) }}
+            {% else %}
+                {{ housing_company_improvements_table_post_2011(index_calculation) }}
+            {% endif %}
+        {% endif %}
     {% endif %}
-
 {% endblock %}
 
 
@@ -223,50 +240,4 @@
             <td class="text-right">{{ sapc_calculation.maximum_price|intcomma }} euroa</td>
         </tr>
     </table>
-{% endmacro %}
-
-
-{% macro improvements_table(calculation) %}
-    {# Table max width is 682px #}
-    <table style="font-size: 8pt">
-        <tr style="border-bottom: 1px solid black;">
-            <td class="improvement-cell" style="width: 172px;"><b>Parannus</b></td>
-            <td class="improvement-cell improvement-column" style="width: 60px;"><b>Arvo</b></td>
-            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Valmistunut</b></td>
-            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Arvoa korot-<br>tava osuus</b></td>
-            <td class="improvement-cell improvement-column" style="width: 70px;"><b>Poistoaika</b></td>
-            <td class="improvement-cell improvement-column" style="width: 60px;"><b>Poiston määrä</b></td>
-            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty yhtiö</b></td>
-            <td class="improvement-cell improvement-column" style="width: 80px;"><b>Hyväksytty huoneisto</b></td>
-        </tr>
-        {% for improvement in calculation.calculation_variables.housing_company_improvements["items"] %}
-            <tr style="border-bottom: 1px solid black; padding-top: 2px;">
-                <td class="improvement-cell">{{ improvement.name }}</td>
-                <td class="improvement-cell text-right">{{ improvement.value|intcomma }}</td>
-                <td class="improvement-cell text-right">{{ improvement.completion_date }}</td>
-                <td class="improvement-cell text-right">{{ improvement.value_added|intcomma }}</td>
-                <td class="improvement-cell text-right">TODO</td>
-                <td class="improvement-cell text-right">{{ improvement.depreciation|intcomma }}</td>
-                <td class="improvement-cell text-right">{{ improvement.value_for_housing_company|intcomma }}</td>
-                <td class="improvement-cell text-right">{{ improvement.value_for_apartment|intcomma }}</td>
-            </tr>
-        {% endfor %}
-        <tr style="padding-top: 2px;">
-            <td class="improvement-cell"><b>Parannukset yhteensä</b></td>
-            <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value|intcomma }}</b></td>
-            <td></td>
-            <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value_added|intcomma }}</b></td>
-            <td></td>
-            <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.depreciation|intcomma }}</b></td>
-            <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value_for_housing_company|intcomma }}</b></td>
-            <td class="improvement-cell text-right"><b>{{ calculation.calculation_variables.housing_company_improvements.summary.value_for_apartment|intcomma }}</b></td>
-        </tr>
-    </table>
-
-    <br>
-
-    <p>
-        {% set excess = calculation.calculation_variables.housing_company_improvements.summary.excess %}
-        Parannuksen omavastuu on {{ excess.surface_area|intcomma }} m² x {{ excess.value_per_square_meter|intcomma }} euroa/m² = {{ excess.total|intcomma }} euroa. Arvoa korottavaan osuuteen tehdään indeksitarkistus ilman poistoja.
-    </p>
 {% endmacro %}

--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -97,6 +97,9 @@
         </tr>
     </table>
 
+    <pdf:nexttemplate name="template_attachment_1" />
+    <pdf:nextpage />
+
     {% if maximum_price_calculation.json.calculations.market_price_index.maximum_price > maximum_price_calculation.json.calculations.construction_price_index.maximum_price %}
         {% set calculation = maximum_price_calculation.json.calculations.market_price_index %}
         {% set index_name = "MARKKINAHINTAINDEKSILLÄ" %}

--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -166,7 +166,7 @@
             <td><b>Valmistumispäivä:</b></td>
             <td>{{ calculation.calculation_variables.completion_date|format_date }}</td>
             <td><b>+ Huoneistokohtaiset parannukset</b></td>
-            <td class="text-right">{{ calculation.calculation_variables.apartment_improvements|intcomma }}</td>
+            <td class="text-right">{{ calculation.calculation_variables.apartment_improvements }}</td>
         </tr>
         <tr>
             <td><b>ja sen rak.kust.indeksi:</b></td>

--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -1,5 +1,6 @@
 {% extends "components/base.jinja" %}
 {% from "components/apartment_info.jinja" import apartment_info %}
+{% from "components/calculation_details_table.jinja" import calculation_details_table %}
 
 {% block style %}
     <style>
@@ -221,90 +222,6 @@
             <td></td>
             <td class="text-right">{{ sapc_calculation.maximum_price|intcomma }} euroa</td>
         </tr>
-    </table>
-{% endmacro %}
-
-
-{% macro calculation_details_table(apartment, maximum_price_calculation, index_calculation, index_name_short, sapc_calculation) %}
-    <table>
-        <tr>
-            <td style="width: 180px;"><b>Huoneluku:</b></td>
-            <td style="width: 150px;">{{ apartment.rooms }} {{ apartment.apartment_type.value }}</td>
-            {% if not sapc_calculation %}
-                <td style="width: 300px;"><b>Hankinta-arvo</b></td>
-                <td style="width: 80px;" class="text-right">{{ index_calculation.calculation_variables.acquisition_price|intcomma }}</td>
-            {% endif %}
-        </tr>
-        <tr>
-            <td><b>Pinta-ala m²:</b></td>
-            <td>{{ maximum_price_calculation.json.apartment.surface_area|intcomma }}</td>
-            {% if not sapc_calculation %}
-                <td><b>+ Rakennusaik. lisä- ja muutostyöt</b></td>
-                <td class="text-right">{{ index_calculation.calculation_variables.additional_work_during_construction|intcomma }}</td>
-            {% endif %}
-        </tr>
-        <tr>
-            <td><b>Osakenumerot:</b></td>
-            <td>{{ maximum_price_calculation.json.apartment.shares.start }} - {{ maximum_price_calculation.json.apartment.shares.end }}</td>
-            {% if not sapc_calculation %}
-                <td><b>= Perushinta</b></td>
-                <td class="text-right">{{ index_calculation.calculation_variables.basic_price|intcomma }}</td>
-            {% endif %}
-        </tr>
-        <tr>
-            <td><b>Osakelkm:</b></td>
-            <td>{{ maximum_price_calculation.json.apartment.shares.total }}</td>
-            {% if not sapc_calculation %}
-                <td><b>+ Indeksin muutos</b></td>
-                <td class="text-right">{{ index_calculation.calculation_variables.index_adjustment|intcomma }}</td>
-            {% endif %}
-        </tr>
-        <tr>
-            <td><b>Valmistumispäivä:</b></td>
-            <td>{{ index_calculation.calculation_variables.completion_date|format_date }}</td>
-            {% if not sapc_calculation %}
-                <td><b>+ Huoneistokohtaiset parannukset</b></td>
-                <td class="text-right">{{ index_calculation.calculation_variables.apartment_improvements|intcomma }}</td>
-            {% endif %}
-        </tr>
-        <tr>
-            <td><b>ja sen {{ index_name_short }}:</b></td>
-            <td>{{ index_calculation.calculation_variables.completion_date_index|intcomma }}</td>
-            {% if not sapc_calculation %}
-                <td><b>+ Osuus yhtiön parannuksista</b></td>
-                <td class="text-right">{{ index_calculation.calculation_variables.housing_company_improvements.summary.value_for_apartment|intcomma }}</td>
-            {% endif %}
-        </tr>
-        <tr>
-            <td><b>Jälleenlaskentapäivä:</b></td>
-            <td>{{ index_calculation.calculation_variables.calculation_date|format_date }}</td>
-            {% if not sapc_calculation %}
-                <td><b>= Osakkeiden velaton hinta</b></td>
-                <td class="text-right">{{ index_calculation.calculation_variables.debt_free_price|intcomma }}</td>
-            {% endif %}
-        </tr>
-        <tr>
-            <td><b>ja sen {{ index_name_short }}:</b></td>
-            <td>{{ index_calculation.calculation_variables.completion_date_index|intcomma }}</td>
-            {% if not sapc_calculation %}
-                <td><b>- osuus yhtiön lainoista {{ index_calculation.calculation_variables.apartment_share_of_housing_company_loans_date|format_date }}</b></td>
-                <td class="text-right">{{ index_calculation.calculation_variables.apartment_share_of_housing_company_loans|intcomma }}</td>
-            {% endif %}
-        </tr>
-        {% if not sapc_calculation %}
-            <tr>
-                <td></td>
-                <td></td>
-                <td><b>= Enimmäismyyntihinta</b></td>
-                <td class="text-right">{{ index_calculation.maximum_price|intcomma }}</td>
-            </tr>
-            <tr>
-                <td></td>
-                <td></td>
-                <td><b>Velaton hinta euroa/m² (*)<br>* Lasketaan osakkeiden velattomasta hinnasta</b></td>
-                <td class="text-right">{{ index_calculation.calculation_variables.debt_free_price_m2|intcomma }}</td>
-            </tr>
-        {% endif %}
     </table>
 {% endmacro %}
 

--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -37,6 +37,15 @@
             margin-right: 250px;
             margin-bottom: 30px;
         }
+        p.bordered-header {
+            text-align: center;
+            padding-left: 40px;
+            padding-right: 40px;
+            padding-top: 5px;
+            padding-bottom: -5px;
+            margin-top: 20px;
+            margin-bottom: 30px;
+        }
 
         .text-right {
             text-align: right;
@@ -57,10 +66,22 @@
 
 {% block title %}{{ title }}{% endblock %}
 
-{% block content %}
-    {% set apartment = maximum_price_calculation.apartment %}
-    {% set is_pre_2011 = apartment.completion_date|is_date_pre_2011 %}
+{# Init variables #}
+{% set apartment = maximum_price_calculation.apartment %}
+{% set is_pre_2011 = apartment.completion_date|is_date_pre_2011 %}
+{% set is_surface_area_maximum = maximum_price_calculation.json.calculations.surface_area_price_ceiling.maximum %}
+{% set sapc_calculation = maximum_price_calculation.json.calculations.surface_area_price_ceiling %}
+{% if maximum_price_calculation.json.calculations.market_price_index.maximum_price > maximum_price_calculation.json.calculations.construction_price_index.maximum_price %}
+    {% set index_calculation = maximum_price_calculation.json.calculations.market_price_index %}
+    {% set index_name = "MARKKINAHINTAINDEKSILLÄ" %}
+    {% set index_name_short = "mark.hintaindeksi" %}
+{% else %}
+    {% set index_calculation = maximum_price_calculation.json.calculations.construction_price_index %}
+    {% set index_name = "RAKENNUSKUSTANNUSINDEKSILLÄ" %}
+    {% set index_name_short = "rak.kust.indeksi" %}
+{% endif %}
 
+{% block content %}
     <h3>Helsingin kaupunki</h3>
     <h3>
         {{ apartment.street_address }} {{ apartment.stair }} {{ apartment.apartment_number }}
@@ -97,9 +118,12 @@
     <br>
 
     <p class="plain-text">
-        Huoneiston vahvistettu enimmäismyyntihinta on
-        {{ maximum_price_calculation.maximum_price|wordify }} ({{ maximum_price_calculation.maximum_price|intcomma }})
-        euroa. Enimmäismyyntihinta on voimassa kolme kuukautta laskelman päiväyksestä.
+        Huoneiston vahvistettu enimmäismyyntihinta on {{ maximum_price_calculation.maximum_price|wordify }} ({{ maximum_price_calculation.maximum_price|intcomma }}) euroa.
+        {% if is_surface_area_maximum %}
+            Enimmäismyyntihinta on vahvistettu rajahinnan perusteella ja laskelma on voimassa {{ maximum_price_calculation.valid_until|format_date }} asti.
+        {% else %}
+            Enimmäismyyntihinta on voimassa kolme kuukautta laskelman päiväyksestä.
+        {% endif %}
     </p>
     <p class="plain-text">Jos huoneiston osuus yhtiön lainoista on muuttunut ilmoitetusta määrästä, tulee kaupantekohetkellä huoneistolle kuuluva osuus ottaa huomioon siten, ettei enimmäishintalaskelmassa (liite 1) mainittu osakkeiden velaton hinta ylity.</p>
     <p class="plain-text">Enimmäishintalaskelman uudistuksen voi tilata puhelimitse. Rajahinta tarkistetaan ja markkinahintaindeksi julkaistaan neljännesvuosittain 1.2., 1.5., 1.8. ja 1. 11.</p>
@@ -123,22 +147,41 @@
     <pdf:nexttemplate name="template_attachment_1" />
     <pdf:nextpage />
 
-    {% if maximum_price_calculation.json.calculations.market_price_index.maximum_price > maximum_price_calculation.json.calculations.construction_price_index.maximum_price %}
-        {% set calculation = maximum_price_calculation.json.calculations.market_price_index %}
-        {% set index_name = "MARKKINAHINTAINDEKSILLÄ" %}
-        {% set index_name_short = "mark.hintaindeksi" %}
-    {% else %}
-        {% set calculation = maximum_price_calculation.json.calculations.construction_price_index %}
-        {% set index_name = "RAKENNUSKUSTANNUSINDEKSILLÄ" %}
-        {% set index_name_short = "rak.kust.indeksi" %}
+    {# Rajaneliöhinta #}
+    {% if is_surface_area_maximum %}
+        <h2 class="bordered-header">ENIMMÄISHINTALASKELMA<br>RAJAHINNALLA</h2>
+
+        {{ apartment_info(apartment) }}
+        {{ calculation_details_table(apartment, maximum_price_calculation, index_calculation, index_name_short, sapc_calculation) }}
+
+        <br>
+        <p>
+            Huoneiston laskennallinen enimmäisneliöhinta alittaa voimassa olevan rajahinnan {{ sapc_calculation.calculation_variables.calculation_date_value|intcomma }} euroa/m², jolloin enimmäishinta lasketaan rajahinnan perusteella.
+            <br>
+            <b>Mahdollisia yhtiö- ja huoneistokohtaisten parannusten kustannuksia ei voi lisätä rajahinnan mukaiseen enimmäishintaan.</b>
+        </p>
+        <br>
+        <br>
+        {{ sapc_calculation_details_table(sapc_calculation) }}
+        <br>
+        <p>Laskelma on voimassa {{ sapc_calculation.valid_until|format_date }} asti.</p>
+
+        <pdf:nexttemplate name="template_attachment_2" />
+        <pdf:nextpage />
     {% endif %}
 
+
+    {# Markkinahinta- / Rakennuskustanniksindeksi #}
     <h2 class="bordered-header">ENIMMÄISHINTALASKELMA<br>{{ index_name }}</h2>
 
     {{ apartment_info(apartment) }}
-    {{ calculation_details_table(apartment, maximum_price_calculation, calculation) }}
+    {{ calculation_details_table(apartment, maximum_price_calculation, index_calculation, index_name_short, none) }}
 
+    {% if is_surface_area_maximum %}
+        <p class="bordered-header"><b>Huoneiston laskennallinen enimmäisneliöhinta, {{ index_calculation.calculation_variables.debt_free_price_m2|intcomma }} euroa/m², alittaa voimassa olevan rajahinnan {{ sapc_calculation.calculation_variables.calculation_date_value|intcomma }} euroa/m², jolloin enimmäishinta lasketaan rajahinnan perusteella.</b></p>
+    {% endif %}
 
+    {# Parannukset #}
     {% if is_pre_2011 %}
         <pdf:nexttemplate name="template_attachment_2" />
         <pdf:nextpage />
@@ -146,76 +189,125 @@
         <h2 class="bordered-header">ENIMMÄISHINTALASKELMA<br>{{ index_name }}</h2>
         <h3 class="bordered-header">HUONEISTON OSUUS YHTIÖN PARANNUKSISTA</h3>
 
-        {{ improvements_table(calculation) }}
+        {{ improvements_table(index_calculation) }}
     {% endif %}
 
 {% endblock %}
 
 
-{% macro calculation_details_table(apartment, maximum_price_calculation, calculation) %}
+{% macro sapc_calculation_details_table(sapc_calculation) %}
     <table>
         <tr>
-            <td style="width: 200px"><b>Huoneluku:</b></td>
-            <td style="width: 150px">{{ apartment.rooms }} {{ apartment.apartment_type.value }}</td>
-            <td style="width: 350px"><b>Hankinta-arvo</b></td>
-            <td style="width: 100px" class="text-right">{{ calculation.calculation_variables.acquisition_price|intcomma }}</td>
+            <td style="width: 262px;">Velaton enimmäishinta</td>
+            <td style="width: 110px;" class="text-right">{{ sapc_calculation.calculation_variables.surface_area|intcomma }}m²</td>
+            <td style="width: 30px" class="text-right">×</td>
+            <td style="width: 110px;" class="text-right">{{ sapc_calculation.calculation_variables.calculation_date_value|intcomma }} euroa/m²</td>
+            <td style="width: 30px" class="text-right">=</td>
+            <td style="width: 140px;" class="text-right">{{ sapc_calculation.maximum_price|intcomma }} euroa</td>
+        </tr>
+        <tr>
+            <td>— osuus yhtiön lainoista <i>*TODO*</i></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td class="text-right"><i>*TODO*</i> euroa</td>
+        </tr>
+        <tr style="border-top: 1px solid black; padding-top: 4px;">
+            <td>Enimmäismyyntihinta kaupanteossa</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td class="text-right">{{ sapc_calculation.maximum_price|intcomma }} euroa</td>
+        </tr>
+    </table>
+{% endmacro %}
+
+
+{% macro calculation_details_table(apartment, maximum_price_calculation, index_calculation, index_name_short, sapc_calculation) %}
+    <table>
+        <tr>
+            <td style="width: 180px;"><b>Huoneluku:</b></td>
+            <td style="width: 150px;">{{ apartment.rooms }} {{ apartment.apartment_type.value }}</td>
+            {% if not sapc_calculation %}
+                <td style="width: 300px;"><b>Hankinta-arvo</b></td>
+                <td style="width: 80px;" class="text-right">{{ index_calculation.calculation_variables.acquisition_price|intcomma }}</td>
+            {% endif %}
         </tr>
         <tr>
             <td><b>Pinta-ala m²:</b></td>
             <td>{{ maximum_price_calculation.json.apartment.surface_area|intcomma }}</td>
-            <td><b>+ Rakennusaik. lisä- ja muutostyöt</b></td>
-            <td class="text-right">{{ calculation.calculation_variables.additional_work_during_construction|intcomma }}</td>
+            {% if not sapc_calculation %}
+                <td><b>+ Rakennusaik. lisä- ja muutostyöt</b></td>
+                <td class="text-right">{{ index_calculation.calculation_variables.additional_work_during_construction|intcomma }}</td>
+            {% endif %}
         </tr>
         <tr>
             <td><b>Osakenumerot:</b></td>
             <td>{{ maximum_price_calculation.json.apartment.shares.start }} - {{ maximum_price_calculation.json.apartment.shares.end }}</td>
-            <td><b>= Perushinta</b></td>
-            <td class="text-right">{{ calculation.calculation_variables.basic_price|intcomma }}</td>
+            {% if not sapc_calculation %}
+                <td><b>= Perushinta</b></td>
+                <td class="text-right">{{ index_calculation.calculation_variables.basic_price|intcomma }}</td>
+            {% endif %}
         </tr>
         <tr>
             <td><b>Osakelkm:</b></td>
             <td>{{ maximum_price_calculation.json.apartment.shares.total }}</td>
-            <td><b>+ Indeksin muutos</b></td>
-            <td class="text-right">{{ calculation.calculation_variables.index_adjustment|intcomma }}</td>
+            {% if not sapc_calculation %}
+                <td><b>+ Indeksin muutos</b></td>
+                <td class="text-right">{{ index_calculation.calculation_variables.index_adjustment|intcomma }}</td>
+            {% endif %}
         </tr>
         <tr>
             <td><b>Valmistumispäivä:</b></td>
-            <td>{{ calculation.calculation_variables.completion_date|format_date }}</td>
-            <td><b>+ Huoneistokohtaiset parannukset</b></td>
-            <td class="text-right">{{ calculation.calculation_variables.apartment_improvements }}</td>
+            <td>{{ index_calculation.calculation_variables.completion_date|format_date }}</td>
+            {% if not sapc_calculation %}
+                <td><b>+ Huoneistokohtaiset parannukset</b></td>
+                <td class="text-right">{{ index_calculation.calculation_variables.apartment_improvements|intcomma }}</td>
+            {% endif %}
         </tr>
         <tr>
             <td><b>ja sen {{ index_name_short }}:</b></td>
-            <td>{{ calculation.calculation_variables.completion_date_index|intcomma }}</td>
-            <td><b>+ Osuus yhtiön parannuksista</b></td>
-            <td class="text-right">{{ calculation.calculation_variables.housing_company_improvements.summary.value_for_apartment|intcomma }}</td>
+            <td>{{ index_calculation.calculation_variables.completion_date_index|intcomma }}</td>
+            {% if not sapc_calculation %}
+                <td><b>+ Osuus yhtiön parannuksista</b></td>
+                <td class="text-right">{{ index_calculation.calculation_variables.housing_company_improvements.summary.value_for_apartment|intcomma }}</td>
+            {% endif %}
         </tr>
         <tr>
             <td><b>Jälleenlaskentapäivä:</b></td>
-            <td>{{ calculation.calculation_variables.calculation_date|format_date }}</td>
-            <td><b>= Osakkeiden velaton hinta</b></td>
-            <td class="text-right">{{ calculation.calculation_variables.debt_free_price|intcomma }}</td>
+            <td>{{ index_calculation.calculation_variables.calculation_date|format_date }}</td>
+            {% if not sapc_calculation %}
+                <td><b>= Osakkeiden velaton hinta</b></td>
+                <td class="text-right">{{ index_calculation.calculation_variables.debt_free_price|intcomma }}</td>
+            {% endif %}
         </tr>
         <tr>
             <td><b>ja sen {{ index_name_short }}:</b></td>
-            <td>{{ calculation.calculation_variables.completion_date_index|intcomma }}</td>
-            <td><b>- osuus yhtiön lainoista {{ calculation.calculation_variables.apartment_share_of_housing_company_loans_date|format_date }}</b></td>
-            <td class="text-right">{{ calculation.calculation_variables.apartment_share_of_housing_company_loans|intcomma }}</td>
+            <td>{{ index_calculation.calculation_variables.completion_date_index|intcomma }}</td>
+            {% if not sapc_calculation %}
+                <td><b>- osuus yhtiön lainoista {{ index_calculation.calculation_variables.apartment_share_of_housing_company_loans_date|format_date }}</b></td>
+                <td class="text-right">{{ index_calculation.calculation_variables.apartment_share_of_housing_company_loans|intcomma }}</td>
+            {% endif %}
         </tr>
-        <tr>
-            <td></td>
-            <td></td>
-            <td><b>= Enimmäismyyntihinta</b></td>
-            <td class="text-right">{{ calculation.maximum_price|intcomma }}</td>
-        </tr>
-        <tr>
-            <td></td>
-            <td></td>
-            <td><b>Velaton hinta euroa/m² (*)<br>* Lasketaan osakkeiden velattomasta hinnasta</b></td>
-            <td class="text-right">{{ calculation.calculation_variables.debt_free_price_m2|intcomma }}</td>
-        </tr>
+        {% if not sapc_calculation %}
+            <tr>
+                <td></td>
+                <td></td>
+                <td><b>= Enimmäismyyntihinta</b></td>
+                <td class="text-right">{{ index_calculation.maximum_price|intcomma }}</td>
+            </tr>
+            <tr>
+                <td></td>
+                <td></td>
+                <td><b>Velaton hinta euroa/m² (*)<br>* Lasketaan osakkeiden velattomasta hinnasta</b></td>
+                <td class="text-right">{{ index_calculation.calculation_variables.debt_free_price_m2|intcomma }}</td>
+            </tr>
+        {% endif %}
     </table>
 {% endmacro %}
+
 
 {% macro improvements_table(calculation) %}
     {# Table max width is 682px #}

--- a/backend/hitas/templates/unconfirmed_maximum_price.jinja
+++ b/backend/hitas/templates/unconfirmed_maximum_price.jinja
@@ -23,7 +23,7 @@
     <table>
         {% for ownership in apartment.ownerships %}
         <tr>
-            <td>Omistaja ja omistusosuus (%)</td>
+            <td>{% if loop.index == 1 %}Omistaja ja omistusosuus (%){% endif %}</td>
             <td>{{ ownership.owner.name}}</td>
             <td>{{ ownership.percentage }}</td>
         </tr>

--- a/backend/hitas/templatetags/custom_tags.py
+++ b/backend/hitas/templatetags/custom_tags.py
@@ -1,16 +1,26 @@
 from datetime import datetime
+from typing import Union
 
 import django_jinja.library
 from django.contrib.humanize.templatetags.humanize import intcomma as humanize_intcomma
+from num2words import num2words
 
 
 @django_jinja.library.filter
-def format_date(value: str) -> str:
+def format_date(value: Union[str, datetime.date]) -> str:
+    if type(value) == str:
+        value = datetime.strptime(value, "%Y-%m-%d")
+
     if value:
-        return datetime.strftime(datetime.strptime(value, "%Y-%m-%d"), "%d.%m.%Y")
+        return datetime.strftime(value, "%d.%m.%Y")
     return "-"
 
 
 @django_jinja.library.filter
 def intcomma(value) -> str:
     return humanize_intcomma(value)
+
+
+@django_jinja.library.filter
+def wordify(value: int) -> str:
+    return num2words(value, lang="fi")

--- a/backend/hitas/templatetags/custom_tags.py
+++ b/backend/hitas/templatetags/custom_tags.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from decimal import Decimal
 from typing import Union
 
 import django_jinja.library
@@ -18,7 +19,9 @@ def format_date(value: Union[str, datetime.date]) -> str:
 
 @django_jinja.library.filter
 def intcomma(value) -> str:
-    return humanize_intcomma(value)
+    if not value:
+        return "0"
+    return humanize_intcomma(Decimal(str(value)).normalize())
 
 
 @django_jinja.library.filter

--- a/backend/hitas/templatetags/custom_tags.py
+++ b/backend/hitas/templatetags/custom_tags.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from typing import Union
 
@@ -8,7 +8,7 @@ from num2words import num2words
 
 
 @django_jinja.library.filter
-def format_date(value: Union[str, datetime.date]) -> str:
+def format_date(value: Union[str, datetime]) -> str:
     if type(value) == str:
         value = datetime.strptime(value, "%Y-%m-%d")
 
@@ -27,3 +27,10 @@ def intcomma(value) -> str:
 @django_jinja.library.filter
 def wordify(value: int) -> str:
     return num2words(value, lang="fi")
+
+
+@django_jinja.library.filter
+def is_date_pre_2011(value: Union[str, datetime.date]) -> bool:
+    if type(value) == str:
+        value = datetime.strptime(value, "%Y-%m-%d")
+    return value < date(2011, 1, 1)

--- a/backend/hitas/templatetags/custom_tags.py
+++ b/backend/hitas/templatetags/custom_tags.py
@@ -1,6 +1,7 @@
+import itertools
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Union
+from typing import Any, Union
 
 import django_jinja.library
 from django.contrib.humanize.templatetags.humanize import intcomma as humanize_intcomma
@@ -34,3 +35,13 @@ def is_date_pre_2011(value: Union[str, datetime.date]) -> bool:
     if type(value) == str:
         value = datetime.strptime(value, "%Y-%m-%d")
     return value < date(2011, 1, 1)
+
+
+@django_jinja.library.filter
+def value_or_blank(value: Any) -> str:
+    return value or ""
+
+
+@django_jinja.library.global_function
+def zip_lists(*args):
+    return itertools.zip_longest(*args)

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -416,6 +416,14 @@ websocket-client = ">=0.32.0"
 ssh = ["paramiko (>=2.4.3)"]
 
 [[package]]
+name = "docopt"
+version = "0.6.2"
+description = "Pythonic argument parser, that will make you smile"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "drf-nested-routers"
 version = "0.93.4"
 description = "Nested resources for the Django Rest Framework"
@@ -778,6 +786,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "num2words"
+version = "0.5.12"
+description = "Modules to convert numbers to words. Easily extensible."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+docopt = ">=0.6.2"
+
+[[package]]
 name = "openapi-core"
 version = "0.16.1"
 description = "client-side and server-side support for the OpenAPI Specification v3"
@@ -815,9 +834,9 @@ attrs = ">=19.2.0"
 jsonschema = ">=4.0.0,<5.0.0"
 
 [package.extras]
-isodate = ["isodate"]
-strict-rfc3339 = ["strict-rfc3339"]
 rfc3339-validator = ["rfc3339-validator"]
+strict-rfc3339 = ["strict-rfc3339"]
+isodate = ["isodate"]
 
 [[package]]
 name = "openapi-spec-validator"
@@ -1602,10 +1621,7 @@ python-versions = "^3.10"
 content-hash = "e842c049bcc837a5d6933dee4e23448a09a3052c9743fb0a8a02eb49851d796b"
 
 [metadata.files]
-appnope = [
-    {file = "appnope-0.1.3-py2.py3-none-any.whl", hash = "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"},
-    {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},
-]
+appnope = []
 arabic-reshaper = []
 asgiref = [
     {file = "asgiref-3.5.2-py3-none-any.whl", hash = "sha256:1d2880b792ae8757289136f1db2b7b99100ce959b2aa57fd69dab783d05afac4"},
@@ -1670,7 +1686,13 @@ django-nested-inline = [
 django-safedelete = []
 djangorestframework = []
 docker = []
-drf-nested-routers = []
+docopt = [
+    {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
+]
+drf-nested-routers = [
+    {file = "drf-nested-routers-0.93.4.tar.gz", hash = "sha256:01aa556b8c08608bb74fb34f6ca065a5183f2cda4dc0478192cc17a2581d71b0"},
+    {file = "drf_nested_routers-0.93.4-py2.py3-none-any.whl", hash = "sha256:996b77f3f4dfaf64569e7b8f04e3919945f90f95366838ca5b8bed9dd709d6c5"},
+]
 ecdsa = []
 exceptiongroup = []
 executing = []
@@ -1681,9 +1703,14 @@ factory-boy = [
 faker = []
 flake8 = []
 flake8-print = []
-future = []
+future = [
+    {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
+]
 greenlet = []
-html5lib = []
+html5lib = [
+    {file = "html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d"},
+    {file = "html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"},
+]
 idna = []
 importlib-resources = []
 iniconfig = [
@@ -1714,6 +1741,7 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
+num2words = []
 openapi-core = []
 openapi-schema-validator = []
 openapi-spec-validator = []
@@ -1722,9 +1750,7 @@ packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
-parse = [
-    {file = "parse-1.19.0.tar.gz", hash = "sha256:9ff82852bcb65d139813e2a5197627a94966245c897796760a3a2a8eb66f020b"},
-]
+parse = []
 parso = [
     {file = "parso-0.8.3-py2.py3-none-any.whl", hash = "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"},
     {file = "parso-0.8.3.tar.gz", hash = "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0"},
@@ -1752,10 +1778,7 @@ ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
 ]
-pure-eval = [
-    {file = "pure_eval-0.2.2-py3-none-any.whl", hash = "sha256:01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350"},
-    {file = "pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"},
-]
+pure-eval = []
 pyasn1 = [
     {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},
     {file = "pyasn1-0.4.8-py2.5.egg", hash = "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf"},
@@ -1772,7 +1795,10 @@ pyasn1 = [
     {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
 ]
 pycodestyle = []
-pycparser = []
+pycparser = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
 pyflakes = []
 pygments = []
 pyhanko = []
@@ -1789,7 +1815,10 @@ pytest-django = [
     {file = "pytest-django-4.5.2.tar.gz", hash = "sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2"},
     {file = "pytest_django-4.5.2-py3-none-any.whl", hash = "sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e"},
 ]
-python-bidi = []
+python-bidi = [
+    {file = "python-bidi-0.4.2.tar.gz", hash = "sha256:5347f71e82b3e9976dc657f09ded2bfe39ba8d6777ca81a5b2c56c30121c496e"},
+    {file = "python_bidi-0.4.2-py2.py3-none-any.whl", hash = "sha256:50eef6f6a0bbdd685f9e8c207f3c9050f5b578d0a46e37c76a9c4baea2cc2e13"},
+]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
@@ -1838,10 +1867,7 @@ pyyaml = [
 ]
 qrcode = []
 reportlab = []
-requests = [
-    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
-    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
-]
+requests = []
 rsa = []
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -1869,73 +1895,11 @@ wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
     {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
-webencodings = []
+webencodings = [
+    {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
+    {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
+]
 websocket-client = []
 werkzeug = []
-wrapt = [
-    {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59"},
-    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462"},
-    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1"},
-    {file = "wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320"},
-    {file = "wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069"},
-    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656"},
-    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
-    {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
-    {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
-    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d"},
-    {file = "wrapt-1.14.1-cp35-cp35m-win32.whl", hash = "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7"},
-    {file = "wrapt-1.14.1-cp35-cp35m-win_amd64.whl", hash = "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00"},
-    {file = "wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1"},
-    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569"},
-    {file = "wrapt-1.14.1-cp36-cp36m-win32.whl", hash = "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed"},
-    {file = "wrapt-1.14.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471"},
-    {file = "wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d"},
-    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015"},
-    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a"},
-    {file = "wrapt-1.14.1-cp37-cp37m-win32.whl", hash = "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853"},
-    {file = "wrapt-1.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c"},
-    {file = "wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456"},
-    {file = "wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1"},
-    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0"},
-    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57"},
-    {file = "wrapt-1.14.1-cp38-cp38-win32.whl", hash = "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5"},
-    {file = "wrapt-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d"},
-    {file = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383"},
-    {file = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735"},
-    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3"},
-    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe"},
-    {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
-    {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
-    {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
-]
+wrapt = []
 xhtml2pdf = []

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,6 +25,7 @@ django-safedelete = "^1.3.0"
 python-dateutil = "^2.8.2"
 xhtml2pdf = "^0.2.8"
 django-jinja = "^2.10.2"
+num2words = "^0.5.12"
 
 [tool.poetry.dev-dependencies]
 autoflake = "^1.4"

--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -180,7 +180,6 @@ const detailApi = hitasApi.injectEndpoints({
         getApartmentDetail: builder.query<IApartmentDetails, IApartmentQuery>({
             query: (params: IApartmentQuery) => ({
                 url: `housing-companies/${params.housingCompanyId}/apartments/${params.apartmentId}`,
-                params: params,
             }),
             providesTags: (result, error, arg) => [{type: "Apartment", id: arg.apartmentId}],
         }),

--- a/frontend/src/common/components/FilterComboboxField.tsx
+++ b/frontend/src/common/components/FilterComboboxField.tsx
@@ -6,7 +6,7 @@ interface FilterComboboxProps {
     label: string;
     options: {label: string}[];
     filterFieldName: string;
-    filterParams: {string: string | number};
+    filterParams: object;
     setFilterParams: (object) => void;
 }
 

--- a/frontend/src/common/components/FilterIntegerField.tsx
+++ b/frontend/src/common/components/FilterIntegerField.tsx
@@ -7,7 +7,7 @@ interface FilterIntegerFieldProps {
     minLength: number;
     maxLength: number;
     filterFieldName: string;
-    filterParams: {string: string | number};
+    filterParams: object;
     setFilterParams: (object) => void;
 }
 

--- a/frontend/src/common/components/FilterRelatedModelComboboxField.tsx
+++ b/frontend/src/common/components/FilterRelatedModelComboboxField.tsx
@@ -7,7 +7,7 @@ interface FilterRelatedModelComboboxFieldProps {
     queryFunction;
     labelField: string;
     filterFieldName: string;
-    filterParams: {string: string | number};
+    filterParams: object;
     setFilterParams: (object) => void;
 }
 

--- a/frontend/src/common/components/FilterTextInputField.tsx
+++ b/frontend/src/common/components/FilterTextInputField.tsx
@@ -5,7 +5,7 @@ import {TextInput} from "hds-react";
 interface FilterTextInputFieldProps {
     label: string;
     filterFieldName: string;
-    filterParams: {string: string | number};
+    filterParams: object;
     setFilterParams: (object) => void;
     minLength?: number;
     maxLength?: number;

--- a/frontend/src/features/codes/IndicesList.tsx
+++ b/frontend/src/features/codes/IndicesList.tsx
@@ -113,7 +113,7 @@ const initialSaveData: IIndex = {
 };
 
 const IndicesList = (): JSX.Element => {
-    const [filterParams, setFilterParams] = useState({string: ""});
+    const [filterParams, setFilterParams] = useState({});
     const [currentIndexType, setCurrentIndexType] = useState(indexTypes[0]);
     const [currentPage, setCurrentPage] = useState(1);
     const [formData, setFormData] = useImmer(initialSaveData);

--- a/frontend/src/features/housingCompany/HousingCompanyListPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyListPage.tsx
@@ -115,7 +115,7 @@ const HousingCompanyFilters = ({filterParams, setFilterParams}): JSX.Element => 
 };
 
 const HousingCompanyListPage = (): JSX.Element => {
-    const [filterParams, setFilterParams] = useState({string: ""});
+    const [filterParams, setFilterParams] = useState({});
 
     return (
         <div className="view--housing-company-list">


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Added support for printing maximum price calculation PDFs using market index, construction index and surface area prices
- Initial support for improvements (some required fields are still missing)

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [ ] Automatic tests has been added 
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan

- Go to an apartment details page and download the confirmed maximum price document
  - Try it out with apartments that have different calculation methods used in the maximum price calculation

## Tickets

This pull request resolves all or part of the following ticket(s): HT-214, HT-273, HT-274, HT-311, HT-312, HT-314, HT-315, HT-324, HT-339, HT-340
