### PR TITLE
backend: Fix apartment price estimate PDF first purchase date

### DIFF
--- a/backend/hitas/templates/unconfirmed_maximum_price.jinja
+++ b/backend/hitas/templates/unconfirmed_maximum_price.jinja
@@ -52,7 +52,7 @@
         </tr>
         <tr>
             <td>Huoneiston ensimmäinen kaupantekoajankohta</td>
-            <td>{{ apartment.first_purchase_date|format_date }}</td>
+            <td>{{ apartment.prices.first_purchase_date|format_date }}</td>
         </tr>
         {% if prices.surface_area_price_ceiling.maximum %}
             <tr>


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Incorrect place was accessed in the JSON

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan

Check that there is a value in first purchase date on the apartment price estimate pdf

## Tickets

This pull request resolves all or part of the following ticket(s): HT-268
