### PR TITLE
Ownership percentage error message

### DIFF
--- a/frontend/src/features/apartment/ApartmentCreatePage.tsx
+++ b/frontend/src/features/apartment/ApartmentCreatePage.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from "react";
 
-import {Button, Fieldset, IconCrossCircle, IconPlus, TextInput} from "hds-react";
+import {Button, Fieldset, IconAlertCircleFill, IconCrossCircle, IconPlus, TextInput} from "hds-react";
 import {useLocation, useNavigate, useParams} from "react-router-dom";
 import {useImmer} from "use-immer";
 import {v4 as uuidv4} from "uuid";
@@ -185,6 +185,12 @@ const ApartmentCreatePage = () => {
         setFormOwnershipsList((draft) => {
             draft.splice(index, 1);
         });
+    };
+    const getOwnershipPercentageError = (error) => {
+        if (error && error?.data?.fields && error.data.fields.filter((e) => e.field === "ownerships.percentage")) {
+            return error.data.fields.filter((e) => e.field === "ownerships.percentage")[0].message;
+        }
+        return "";
     };
 
     // Handle remove flow
@@ -501,6 +507,12 @@ const ApartmentCreatePage = () => {
                         ) : (
                             <div>Ei omistajuuksia</div>
                         )}
+                        {getOwnershipPercentageError(error) && (
+                            <>
+                                <IconAlertCircleFill className="error-text" />
+                                <span className="error-text">{getOwnershipPercentageError(error)}</span>
+                            </>
+                        )}
                     </ul>
                     <Button
                         onClick={handleAddOwnershipLine}
@@ -529,7 +541,7 @@ const ApartmentCreatePage = () => {
                 {isEditPage && (
                     <RemoveButton
                         onClick={() => setIsRemoveModalVisible(true)}
-                        isLoading={isLoading}
+                        isLoading={isRemoving}
                     />
                 )}
                 <SaveButton

--- a/frontend/src/styles/base/_general.sass
+++ b/frontend/src/styles/base/_general.sass
@@ -38,3 +38,6 @@ ul, ol
   flex-direction: row
   justify-content: right
   gap: 10px
+
+.error-text
+  color: var(--color-error)


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Display apartment ownerships percentage errors

![image](https://user-images.githubusercontent.com/50950050/205367371-bb57ac8b-3893-4aa2-b5d0-402a35294c34.png)

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [x] Changes have been tested
- **Backend**
    - [ ] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan

Edit an apartment and set invalid ownership percentages, see that the error message is visible

## Tickets

This pull request resolves all or part of the following ticket(s): HT-334