### PR TITLE
Apartment building ID format

### DIFF
--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -40,7 +40,7 @@ from hitas.views.utils import (
 )
 from hitas.views.utils.merge import merge_model
 from hitas.views.utils.pdf import get_pdf_response
-from hitas.views.utils.serializers import YearMonthSerializer
+from hitas.views.utils.serializers import ReadOnlySerializer, YearMonthSerializer
 
 
 class MarketPriceImprovementSerializer(serializers.ModelSerializer):
@@ -341,6 +341,16 @@ class ApartmentImprovementSerializer(serializers.Serializer):
     )
 
 
+class ReadOnlyBuildingSerializer(ReadOnlySerializer):
+    id = UUIDRelatedField(queryset=Building.objects, source="uuid", write_only=True)
+
+    def get_model_class(self):
+        return Building
+
+    class Meta:
+        fields = ["id"]
+
+
 class ApartmentDetailSerializer(EnumSupportSerializerMixin, HitasModelSerializer):
     state = HitasEnumField(enum=ApartmentState, required=False, allow_null=True)
     type = ReadOnlyApartmentTypeSerializer(source="apartment_type")
@@ -352,7 +362,7 @@ class ApartmentDetailSerializer(EnumSupportSerializerMixin, HitasModelSerializer
     prices = PricesSerializer(source="*", required=False, allow_null=True)
     ownerships = OwnershipSerializer(many=True)
     links = serializers.SerializerMethodField()
-    building = UUIDRelatedField(queryset=Building.objects.all(), write_only=True)
+    building = ReadOnlyBuildingSerializer(write_only=True)
     improvements = ApartmentImprovementSerializer(source="*")
 
     @staticmethod

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3150,10 +3150,16 @@ components:
           readOnly: true
           $ref: '#/components/schemas/ApartmentLinks'
         building:
-          description: Building ID this apartment is associated with
-          type: string
+          description: Building this apartment is associated with
+          type: object
+          additionalProperties: false
           writeOnly: true
-          example: dc1072975bab4ba69f64814f021c6785
+          properties:
+            id:
+              writeOnly: true
+              description: Building ID this apartment is associated with
+              type: string
+              example: dc1072975bab4ba69f64814f021c6785
         notes:
           description: Apartment notes
           type: string

--- a/frontend/src/common/models.ts
+++ b/frontend/src/common/models.ts
@@ -266,7 +266,7 @@ export interface IApartmentWritable {
     address: Omit<IApartmentAddress, "apartment_number"> & {apartment_number: number | null};
     prices: Omit<IApartmentPrices, "maximum_prices" | "acquisition_price">;
     completion_date?: string | null;
-    building: string;
+    building: {id: string};
     ownerships: IOwnership[];
     notes: string;
     improvements: {

--- a/frontend/src/features/apartment/ApartmentCreatePage.tsx
+++ b/frontend/src/features/apartment/ApartmentCreatePage.tsx
@@ -50,7 +50,7 @@ const convertApartmentDetailToWritable = (ap: IApartmentDetails): IApartmentWrit
         ...ap,
         shares: ap.shares || {start: null, end: null},
         ownerships: [], // Stored in a separate state, not needed here
-        building: ap.links.building.id,
+        building: {id: ap.links.building.id},
         address: {
             ...ap.address,
             street_address: ap.links.building.street_address,
@@ -114,7 +114,7 @@ const ApartmentCreatePage = () => {
                           additional_work: null,
                       },
                   },
-                  building: (buildingOptions.length === 1 && buildingOptions[0].value) || "",
+                  building: {id: (buildingOptions.length === 1 && buildingOptions[0].value) || ""},
                   ownerships: [],
                   improvements: {
                       market_price_index: [],
@@ -134,7 +134,7 @@ const ApartmentCreatePage = () => {
             // Copy street_address from selected building
             address: {
                 ...formData.address,
-                street_address: buildingOptions.find((option) => option.value === formData.building)?.label || "",
+                street_address: buildingOptions.find((option) => option.value === formData.building.id)?.label || "",
             },
 
             // Clean away ownership items that don't have an owner selected
@@ -246,7 +246,7 @@ const ApartmentCreatePage = () => {
                             placeholder={formData.address.street_address}
                             defaultValue={{
                                 label: formData.address.street_address || "",
-                                value: formData.building || "",
+                                value: formData.building.id || "",
                             }}
                             options={buildingOptions || []}
                             required

--- a/frontend/src/features/apartment/ApartmentImprovementsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentImprovementsPage.tsx
@@ -26,7 +26,7 @@ const convertApartmentDetailToWritable = (ap: IApartmentDetails): IApartmentWrit
     return {
         ...ap,
         shares: ap.shares || {start: null, end: null},
-        building: ap.links.building.id,
+        building: {id: ap.links.building.id},
         address: {
             ...ap.address,
             street_address: ap.links.building.street_address,


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Use the standard format for Apartment building IDs as is used everywhere else:
  - Old format: `{building: <id>}`
  - New format: `{building: {id: <id>}}`
## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [x] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [x] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan

Check the Apartment save request and verify building ID format and that no unexpected errors are raised

## Tickets

This pull request resolves all or part of the following ticket(s): HT-275
