### PR TITLE
Fixed the redirect by navigating to the previous page in history

### DIFF
--- a/frontend/src/features/housingCompany/HousingCompanyImprovementsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyImprovementsPage.tsx
@@ -122,7 +122,7 @@ const HousingCompanyImprovementsPage = () => {
     useEffect(() => {
         if (!isLoading && !error && data && data.id) {
             hitasToast("Parannukset tallennettu onnistuneesti!");
-            navigate(`/housing-companies/${data.id}`);
+            navigate(-1); // get the user back to where they opened this view
         } else if (error) {
             hitasToast("Virhe tallentaessa parannuksia!", "error");
         }


### PR DESCRIPTION
# Hitas Pull Request

# Description

The HousingCompanyImprovementsPage used to redirect the user to the housing company page after a successful save, but since it can also be reachec via the apartment detail page the redirect can't be "static". The redirect is fixed to go to the previous page in navigation history, so it will work even in possible future uses of ImprovementLists.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [X] Changes have been tested

## Test plan

Go to apartment detail page and from there go to edit the housing company improvements. Click Tallenna in the improvement page, and you're back at the apartment detail page. Same thing with works with housing company page respectively.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-342
