### PR TITLE
backend: Display correct value for debt-free-price in SAPC Calculation

### DIFF
--- a/backend/hitas/calculations/max_prices/rules.py
+++ b/backend/hitas/calculations/max_prices/rules.py
@@ -49,6 +49,7 @@ class CalculatorRules:
             calculation_variables=SurfaceAreaPriceCeilingCalculation.CalculationVars(
                 calculation_date=calculation_date,
                 calculation_date_value=apartment.surface_area_price_ceiling_m2,
+                debt_free_price=apartment.surface_area_price_ceiling,
                 surface_area=apartment.surface_area,
                 apartment_share_of_housing_company_loans=apartment_share_of_housing_company_loans,
                 apartment_share_of_housing_company_loans_date=apartment_share_of_housing_company_loans_date,

--- a/backend/hitas/calculations/max_prices/types.py
+++ b/backend/hitas/calculations/max_prices/types.py
@@ -74,6 +74,7 @@ class SurfaceAreaPriceCeilingCalculation:
     class CalculationVars:
         calculation_date: datetime.date
         calculation_date_value: Decimal
+        debt_free_price: Decimal
         surface_area: Decimal
         apartment_share_of_housing_company_loans: Decimal
         apartment_share_of_housing_company_loans_date: datetime.date

--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -221,7 +221,7 @@
             <td style="width: 30px" class="text-right">×</td>
             <td style="width: 110px;" class="text-right">{{ sapc_calculation.calculation_variables.calculation_date_value|intcomma }} euroa/m²</td>
             <td style="width: 30px" class="text-right">=</td>
-            <td style="width: 140px;" class="text-right">{{ sapc_calculation.maximum_price|intcomma }} euroa</td>
+            <td style="width: 140px;" class="text-right">{{ sapc_calculation.calculation_variables.debt_free_price|intcomma }} euroa</td>
         </tr>
         <tr>
             <td>— osuus yhtiön lainoista {{ sapc_calculation.calculation_variables.apartment_share_of_housing_company_loans_date|format_date }}</td>

--- a/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
@@ -185,6 +185,7 @@ def test__api__apartment_max_price__construction_price_index__2011_onwards(api_c
                 "calculation_variables": {
                     "calculation_date": "2022-07-05",
                     "calculation_date_value": 4869.0,
+                    "debt_free_price": 146070.0,
                     "surface_area": 30.0,
                     "apartment_share_of_housing_company_loans": 2500.0,
                     "apartment_share_of_housing_company_loans_date": "2022-07-28",
@@ -396,6 +397,7 @@ def test__api__apartment_max_price__market_price_index__2011_onwards(api_client:
                 "calculation_variables": {
                     "calculation_date": "2022-07-05",
                     "calculation_date_value": 4869.0,
+                    "debt_free_price": 233712,
                     "surface_area": 48.0,
                     "apartment_share_of_housing_company_loans": 2500.0,
                     "apartment_share_of_housing_company_loans_date": "2022-07-28",
@@ -651,6 +653,7 @@ def test__api__apartment_max_price__market_price_index__pre_2011(api_client: Hit
                 "calculation_variables": {
                     "calculation_date": "2022-09-07",
                     "calculation_date_value": 4872.0,
+                    "debt_free_price": 265524,
                     "surface_area": 54.5,
                     "apartment_share_of_housing_company_loans": 0.0,
                     "apartment_share_of_housing_company_loans_date": "2022-09-05",
@@ -929,6 +932,7 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
                 "calculation_variables": {
                     "calculation_date": "2022-11-21",
                     "calculation_date_value": 4733.0,
+                    "debt_free_price": 215352.0,
                     "surface_area": 45.5,
                     "apartment_share_of_housing_company_loans": 3000.0,
                     "apartment_share_of_housing_company_loans_date": "2022-11-20",
@@ -1087,6 +1091,7 @@ def test__api__apartment_max_price__surface_area_price_ceiling(api_client: Hitas
                 "calculation_variables": {
                     "calculation_date": "2022-09-29",
                     "calculation_date_value": 4872.0,
+                    "debt_free_price": 236292,
                     "surface_area": 48.5,
                     "apartment_share_of_housing_company_loans": 0,
                     "apartment_share_of_housing_company_loans_date": "2022-10-01",

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -4489,6 +4489,11 @@ components:
                       type: number
                       minimum: 0
                       example: 129.29
+                    debt_free_price:
+                      description: Value of the apartment without removing the housing company loans.
+                      type: number
+                      minimum: 0
+                      example: 226058.97
                     surface_area:
                       description: Apartment's surface area
                       type: number


### PR DESCRIPTION
# Hitas Pull Request

# Description

Previously the maximum price for surface area * calculation_date_value had debts already removed, now show the value without removing the debt part first.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [x] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan

Create a new maximum price calculation with debt that uses surface area price ceiling and check out the PDF 

## Tickets

This pull request resolves all or part of the following ticket(s): HT-347