### PR TITLE
Confirm improvement removal

### DIFF
--- a/frontend/src/common/components/ConfirmDialogModal.tsx
+++ b/frontend/src/common/components/ConfirmDialogModal.tsx
@@ -8,10 +8,10 @@ import {Link} from "react-router-dom";
 import {NavigateBackButton, QueryStateHandler} from "./index";
 
 interface ConfirmDialogModalProps {
-    data;
+    data?;
     modalText: string;
     successText: string;
-    error: FetchBaseQueryError | SerializedError | undefined;
+    error?: FetchBaseQueryError | SerializedError | undefined;
     linkURL?: string;
     linkText?: string;
     buttonText?: string;


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds a confirmation modal for the removal of improvements. Implemented in `ApartmentImprovementsPage` and `HousingCompanyImprovementsPage.`

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [X] Changes have been tested

## Test plan

Go to either an apartment's or housing company's improvements page, and either remove an existing improvement or add a line and remove it. You should be prompted with a confirm dialog, similar to the other removal confirmation windows.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-336
