### PR TITLE
backend: fix migration 0042

### DIFF
--- a/backend/hitas/migrations/0042_financing_method_fields.py
+++ b/backend/hitas/migrations/0042_financing_method_fields.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations, models
 
-from hitas.oracle_migration.runner import format_financing_method
+from hitas.oracle_migration.financing_types import format_financing_method
 
 
 def migrate_financing_methods(apps, schema_editor):

--- a/backend/hitas/oracle_migration/financing_types.py
+++ b/backend/hitas/oracle_migration/financing_types.py
@@ -1,3 +1,7 @@
+import re
+
+from hitas.models import FinancingMethod
+
 # +----------------------------------------------+--------------+----------------------+------------+
 # | Name                                         | 2011 onwards | Skip from statistics | Half-Hitas |
 # +----------------------------------------------+--------------+----------------------+------------+
@@ -50,3 +54,20 @@ def financing_method_include_in_statistics(financing_method: str):
 
 def financing_method_is_half_hitas(financing_method: str):
     return financing_method.startswith("PUOLIHITAS")
+
+
+def format_financing_method(fm: FinancingMethod) -> None:
+    # Only capitalize those with first letter lowercased
+    # Don't capitalize all - there's some that would suffer from it
+    if fm.value[0].islower():
+        fm.value = fm.value[0].upper() + fm.value[1:]
+
+    # If the name is in format '<Name> (<ID>)', strip the ID part out of the name
+    # Example: 'Vapaarahoitteinen, Ei Hitas (100)'
+    name_contains_id = re.match(r"(.*) \(\d{3}\)$", fm.value)
+    if name_contains_id:
+        fm.value = name_contains_id.group(1)
+
+    fm.include_in_statistics = financing_method_include_in_statistics(fm.value)
+    fm.half_hitas = financing_method_is_half_hitas(fm.value)
+    fm.old_hitas_ruleset = financing_method_is_before_2011(fm.value)

--- a/backend/hitas/oracle_migration/runner.py
+++ b/backend/hitas/oracle_migration/runner.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import re
 from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Callable, Dict, List, Optional, Type, TypeVar
@@ -50,11 +49,7 @@ from hitas.models import (
 from hitas.models.apartment import DepreciationPercentage
 from hitas.models.indices import AbstractIndex
 from hitas.oracle_migration.cost_areas import hitas_cost_area, init_cost_areas
-from hitas.oracle_migration.financing_types import (
-    financing_method_include_in_statistics,
-    financing_method_is_before_2011,
-    financing_method_is_half_hitas,
-)
+from hitas.oracle_migration.financing_types import format_financing_method
 from hitas.oracle_migration.globals import anonymize_data, faker, should_anonymize
 from hitas.oracle_migration.oracle_schema import (
     additional_infos,
@@ -738,23 +733,6 @@ def combine_notes(a: LegacyRow) -> str:
 
 def format_building_type(bt: BuildingType) -> None:
     bt.value = bt.value.capitalize()
-
-
-def format_financing_method(fm: FinancingMethod) -> None:
-    # Only capitalize those with first letter lowercased
-    # Don't capitalize all - there's some that would suffer from it
-    if fm.value[0].islower():
-        fm.value = fm.value[0].upper() + fm.value[1:]
-
-    # If the name is in format '<Name> (<ID>)', strip the ID part out of the name
-    # Example: 'Vapaarahoitteinen, Ei Hitas (100)'
-    name_contains_id = re.match(r"(.*) \(\d{3}\)$", fm.value)
-    if name_contains_id:
-        fm.value = name_contains_id.group(1)
-
-    fm.include_in_statistics = financing_method_include_in_statistics(fm.value)
-    fm.half_hitas = financing_method_is_half_hitas(fm.value)
-    fm.old_hitas_ruleset = financing_method_is_before_2011(fm.value)
 
 
 def housing_company_state_from(code: str) -> HousingCompanyState:


### PR DESCRIPTION
# Hitas Pull Request

# Description

 - move `format_financing_method` to `financing_types.py` so that the whole migration depepdency tree is not required for running this migration
 - fixes `ModuleNotFoundError: No module named 'sqlalchemy'` error when running the migration without dev dependencies

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan

Run migration before and after the commit.

## Tickets

This pull request resolves all or part of the following ticket(s): n/a
