### PR TITLE
Removes extraneous line from the max price breakdown

### DIFF
--- a/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
+++ b/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
@@ -128,13 +128,6 @@ const MaximumPriceModalContent = ({
                             value={calculation.calculations.market_price_index.calculation_variables.index_adjustment}
                         />
                         <BreakdownValue
-                            label="+ Huoneistokohtaiset parannukset"
-                            value={
-                                calculation.calculations.market_price_index.calculation_variables
-                                    .housing_company_improvements?.summary.value
-                            }
-                        />
-                        <BreakdownValue
                             label="+ Osuus yhtiön parannuksista"
                             value={
                                 calculation.calculations.market_price_index.calculation_variables


### PR DESCRIPTION
# Hitas Pull Request

# Description

There was a line in the confirmed maximum price breakdown which had an error, and turns out was not needed at all as it proved to be unnecessary in its entirety (as per Saila's comment in HT-330). That line is removed here.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [X] Changes have been tested
    
## Test plan

Go to confirm a max price, and see that there is no line with "Huoneistokohtaiset parannukset".

## Tickets

This pull request resolves all or part of the following ticket(s): HT-330
