### PR TITLE
Construction time interest

### DIFF
--- a/backend/hitas/calculations/max_prices/rules_pre_2011.py
+++ b/backend/hitas/calculations/max_prices/rules_pre_2011.py
@@ -103,11 +103,12 @@ class RulesPre2011(CalculatorRules):
         )
 
         # Interest during construction
-        interest_during_construction = (
-            apartment.interest_during_construction_14
-            if apartment.completion_date < datetime.date(2005, 1, 1)
-            else apartment.interest_during_construction_6
-        ) or 0
+        if apartment.completion_date < datetime.date(2005, 1, 1):
+            interest_during_construction = apartment.interest_during_construction_14 or 0
+            interest_during_construction_percentage = 14
+        else:
+            interest_during_construction = apartment.interest_during_construction_6 or 0
+            interest_during_construction_percentage = 6
 
         # Debt free shares price
         debt_free_shares_price = (
@@ -130,6 +131,7 @@ class RulesPre2011(CalculatorRules):
                 housing_company_assets=housing_company_assets,
                 apartment_share_of_housing_company_assets=apartment_share_of_housing_company_assets,
                 interest_during_construction=interest_during_construction,
+                interest_during_construction_percentage=interest_during_construction_percentage,
                 apartment_improvements=apartment_improvements_result,
                 housing_company_improvements=hc_improvements_result,
                 debt_free_price=debt_free_shares_price,
@@ -227,6 +229,7 @@ class RulesPre2011(CalculatorRules):
             calculation_variables=IndexCalculation.CalculationVarsMarketPriceIndexBefore2011(
                 acquisition_price=apartment.acquisition_price,
                 interest_during_construction=apartment.interest_during_construction_6 or 0,
+                interest_during_construction_percentage=6,
                 basic_price=basic_price,
                 index_adjustment=index_adjustment,
                 apartment_improvements=apartment_improvements_result,

--- a/backend/hitas/calculations/max_prices/rules_pre_2011.py
+++ b/backend/hitas/calculations/max_prices/rules_pre_2011.py
@@ -107,7 +107,7 @@ class RulesPre2011(CalculatorRules):
             apartment.interest_during_construction_14
             if apartment.completion_date < datetime.date(2005, 1, 1)
             else apartment.interest_during_construction_6
-        )
+        ) or 0
 
         # Debt free shares price
         debt_free_shares_price = (
@@ -156,7 +156,7 @@ class RulesPre2011(CalculatorRules):
         # Start calculations
 
         # Basic price
-        basic_price = apartment.acquisition_price + apartment.interest_during_construction_6
+        basic_price = apartment.acquisition_price + (apartment.interest_during_construction_6 or 0)
 
         # Index adjustment
         index_adjustment = (apartment.calculation_date_mpi / apartment.completion_date_mpi) * basic_price - basic_price
@@ -226,7 +226,7 @@ class RulesPre2011(CalculatorRules):
             valid_until=calculation_date + relativedelta(months=3),
             calculation_variables=IndexCalculation.CalculationVarsMarketPriceIndexBefore2011(
                 acquisition_price=apartment.acquisition_price,
-                interest_during_construction=apartment.interest_during_construction_6,
+                interest_during_construction=apartment.interest_during_construction_6 or 0,
                 basic_price=basic_price,
                 index_adjustment=index_adjustment,
                 apartment_improvements=apartment_improvements_result,

--- a/backend/hitas/calculations/max_prices/types.py
+++ b/backend/hitas/calculations/max_prices/types.py
@@ -52,12 +52,14 @@ class IndexCalculation:
         housing_company_assets: Decimal
         apartment_share_of_housing_company_assets: Decimal
         interest_during_construction: Decimal
+        interest_during_construction_percentage: int
         apartment_improvements: MaxPriceImprovements
 
     @dataclass
     class CalculationVarsMarketPriceIndexBefore2011(CommonCalculationVars):
         acquisition_price: Decimal
         interest_during_construction: Decimal
+        interest_during_construction_percentage: int
         basic_price: Decimal
         index_adjustment: Decimal
         apartment_improvements: MaxPriceImprovements

--- a/backend/hitas/templates/components/calculation_details_table.jinja
+++ b/backend/hitas/templates/components/calculation_details_table.jinja
@@ -38,7 +38,7 @@
             {% if index_name_short == "mark.hintaindeksi" %}
                 {% set table_right = [
                     ["Hankinta-arvo", vars.acquisition_price|intcomma],
-                    ["+ Rakennusaikaiset korot (6 %)", vars.interest_during_construction|intcomma],
+                    ["+ Rakennusaikaiset korot ("~vars.interest_during_construction_percentage~" %)", vars.interest_during_construction|intcomma],
                     ["= Perushinta", vars.basic_price|intcomma],
                     ["+ Indeksin muutos", vars.index_adjustment|intcomma],
                     ["+ Huoneistokohtaiset parannukset", vars.apartment_improvements.summary.accepted_value|intcomma],
@@ -55,7 +55,7 @@
                     ["+ Kiinteistön parannukset", vars.housing_company_improvements.summary.value|intcomma],
                     ["= Yhtiön varat yhteensä", vars.housing_company_assets|intcomma],
                     ["Osakkeiden osuus", vars.apartment_share_of_housing_company_assets|intcomma],
-                    ["+ Rakennusaikaiset korot (TODO %)", vars.interest_during_construction|intcomma],
+                    ["+ Rakennusaikaiset korot ("~vars.interest_during_construction_percentage~" %)", vars.interest_during_construction|intcomma],
                     ["+ Huoneistokohtaiset parannukset", vars.apartment_improvements.summary.value_for_apartment|intcomma],
                     ["= Osakkeiden velaton hinta", vars.debt_free_price|intcomma],
                     ["- osuus yhtiön lainoista "~vars.apartment_share_of_housing_company_loans_date|format_date, vars.apartment_share_of_housing_company_loans|intcomma],

--- a/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
@@ -508,6 +508,7 @@ def test__api__apartment_max_price__market_price_index__pre_2011(api_client: Hit
                     "housing_company_assets": 170_886.35,
                     "apartment_share_of_housing_company_assets": 170886.35,
                     "interest_during_construction": 4000.0,
+                    "interest_during_construction_percentage": 14,
                     "apartment_improvements": {
                         "items": [
                             {
@@ -559,6 +560,7 @@ def test__api__apartment_max_price__market_price_index__pre_2011(api_client: Hit
                 "calculation_variables": {
                     "acquisition_price": 123173.0,
                     "interest_during_construction": 3455.0,
+                    "interest_during_construction_percentage": 6,
                     "basic_price": 126628.0,
                     "index_adjustment": 153577.28,
                     "apartment_improvements": {
@@ -793,6 +795,7 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
                     "housing_company_assets": 20_823_677.55,
                     "apartment_share_of_housing_company_assets": 219010.27,
                     "interest_during_construction": 2703.0,
+                    "interest_during_construction_percentage": 6,
                     "apartment_improvements": {
                         "items": [
                             {
@@ -868,6 +871,7 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
                 "calculation_variables": {
                     "acquisition_price": 175_930.0,
                     "interest_during_construction": 2703.0,
+                    "interest_during_construction_percentage": 6,
                     "basic_price": 178_633.0,
                     "index_adjustment": 205_671.91,
                     "apartment_improvements": {
@@ -1018,6 +1022,7 @@ def test__api__apartment_max_price__pre_2011__no_improvements(api_client: HitasA
             "housing_company_assets": 200000.0,
             "apartment_share_of_housing_company_assets": 200000.0,
             "interest_during_construction": 0.0,
+            "interest_during_construction_percentage": 14,
             "apartment_improvements": {
                 "items": [],
                 "summary": {
@@ -1052,6 +1057,7 @@ def test__api__apartment_max_price__pre_2011__no_improvements(api_client: HitasA
         "calculation_variables": {
             "acquisition_price": 100000.0,
             "interest_during_construction": 0.0,
+            "interest_during_construction_percentage": 6,
             "basic_price": 100000.0,
             "index_adjustment": 100000.0,
             "apartment_improvements": {

--- a/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
@@ -970,13 +970,14 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
     }
 
 
+@pytest.mark.parametrize("interest_during_construction", [0, None])
 @pytest.mark.django_db
-def test__api__apartment_max_price__pre_2011__no_improvements(api_client: HitasAPIClient):
+def test__api__apartment_max_price__pre_2011__no_improvements(api_client: HitasAPIClient, interest_during_construction):
     a: Apartment = ApartmentFactory.create(
         debt_free_purchase_price=100000,
         primary_loan_amount=0,
-        interest_during_construction_6=0,
-        interest_during_construction_14=0,
+        interest_during_construction_6=interest_during_construction,
+        interest_during_construction_14=interest_during_construction,
         additional_work_during_construction=0,
         completion_date=datetime.date(2003, 5, 9),
         surface_area=10,

--- a/frontend/src/features/apartment/ApartmentCreatePage.tsx
+++ b/frontend/src/features/apartment/ApartmentCreatePage.tsx
@@ -55,6 +55,16 @@ const convertApartmentDetailToWritable = (ap: IApartmentDetails): IApartmentWrit
             ...ap.address,
             street_address: ap.links.building.street_address,
         },
+        prices: {
+            ...ap.prices,
+            construction: {
+                ...ap.prices.construction,
+                interest: ap.prices.construction.interest || {
+                    rate_6: null,
+                    rate_14: null,
+                },
+            },
+        },
     };
 };
 

--- a/frontend/src/features/apartment/components/ApartmentMaximumPriceBreakdownModal.tsx
+++ b/frontend/src/features/apartment/components/ApartmentMaximumPriceBreakdownModal.tsx
@@ -20,7 +20,6 @@ const tableTheme = {
 };
 
 const getDepreciation = (depreciation) => {
-    console.log(depreciation);
     if (depreciation === null) return 0;
     else if (depreciation?.amount !== undefined) return depreciation.amount;
     else return depreciation;
@@ -127,7 +126,7 @@ const MarketPricePre2011Breakdown = ({calculation}: {calculation: IIndexCalculat
                 value={calculation.calculation_variables.acquisition_price}
             />
             <BreakdownValue
-                label="+ Rakennusaikaiset korot (TODO %)"
+                label={`+ Rakennusaikaiset korot (${calculation.calculation_variables.interest_during_construction_percentage}%)`}
                 value={calculation.calculation_variables.interest_during_construction}
             />
             <BreakdownValue
@@ -224,7 +223,7 @@ const ConstructionPricePre2011Breakdown = ({
                 value={calculation.calculation_variables.apartment_share_of_housing_company_assets}
             />
             <BreakdownValue
-                label="+ Rakennusaikaiset korot (TODO %)"
+                label={`+ Rakennusaikaiset korot (${calculation.calculation_variables.interest_during_construction_percentage}%)`}
                 value={calculation.calculation_variables.interest_during_construction}
             />
             <BreakdownValue


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Fix doing calculations while 6% and 14% are `None`
- Fix modifying construction time interest percentage value for existing apartments
- Add correct construction time interest percentage value to calculation PDF and breakdown modal

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [x] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated

## Test plan

See description :)

## Tickets

This pull request resolves all or part of the following ticket(s): HT-374, slack bug report
