### PR TITLE
Add help text to Makefiles and format PHONY declarations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,20 @@
-.PHONY = up
+.PHONY: help
+.PHONY: up
+
+
+define helptext
+
+ Commands:
+
+ up                              Build and run docker containers for the stack.
+
+endef
+
+export helptext
+
+# Help should be first so that make without arguments is the same as help
+help:
+	@echo "$$helptext"
 
 up:
 	docker-compose up --detach --build

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Setting up the environment
 
-Run `docker-compose up --build --detach`
+Run `docker-compose up --build --detach` or `make up` if [Make] is installed.
 
 After that the environment is up with following accesses:
 
@@ -11,3 +11,6 @@ After that the environment is up with following accesses:
 * Access Django admin from [localhost:8080/admin](http://localhost:8080/admin). Default username/password `hitas`/`hitas`
 - Access OpenAPI documentation from [localhost:8090](http://localhost:8090)
 - Access PostgreSQL from [hitas:hitas@localhost:5432/hitas](postgres://hitas:hitas@localhost:5432/hitas)
+
+
+[Make]: https://www.gnu.org/software/make/

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,32 @@
-.PHONY = all docker-build docker-build-backend-only tests format dump
+.PHONY: helptext
+.PHONY: all
+.PHONY: docker-build
+.PHONY: docker-build-backend-only
+.PHONY: tests
+.PHONY: format
+.PHONY: dump
+.PHONY: hitasmigrate
+
+
+define helptext
+
+ Commands:
+
+ all                                Format, test and build docker container stack.
+ docker-build                       Build docker container stack.
+ docker-build-backend-only          Build backend container only.
+ tests                              Run tests.
+ format                             Format code.
+ dump                               Create a database dump with the current schema.
+ hitasmigrate                       Migrate oracle database.
+
+endef
+
+export helptext
+
+# Help should be first so that make without arguments is the same as help
+help:
+	@echo "$$helptext"
 
 all: format tests docker-build
 
@@ -23,7 +51,6 @@ dump:
 	./manage.py dumpdata users authtoken hitas > initial.json
 	cat initial.json | jq '.|=sort_by(.model, .pk)' > initial-formatted.json
 	mv initial-formatted.json initial.json
-
 
 hitasmigrate:
 	./manage.py hitasmigrate --truncate

--- a/backend/README.md
+++ b/backend/README.md
@@ -11,7 +11,7 @@
 
 1. Clone this repository
 2. Enter the backend directory `cd hitas/backend`
-3. Start the app by running `make`
+3. Start the app by running `make docker-build`
 4. Access Django admin from [localhost:8080/admin](http://localhost:8080/admin). Default username `hitas`/`hitas`
 
 
@@ -43,4 +43,4 @@
 ## API definitions
 
 * It's possible to take a look into `openapi.yaml`
-* After running `make` Swagger editor is running in [localhost:8090](localhost:8090)
+* After running `make docker-build` Swagger editor is running in [localhost:8090](localhost:8090)


### PR DESCRIPTION
# Hitas Pull Request

# Description

Add help text to Makefiles and format `PHONY` declarations. Update README to use the explicit `make docker-build` instead of just `make`.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [ ] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- No need to test anything, just Makefile and README changes

## Tickets

-
