### PR TITLE
Spinner and headings

### DIFF
--- a/frontend/src/common/components/Heading.tsx
+++ b/frontend/src/common/components/Heading.tsx
@@ -2,16 +2,16 @@ import React from "react";
 
 interface HeadingProps {
     children;
-    type?: "main" | "regular" | "small";
+    type?: "main" | "list" | "body";
 }
 
 const Heading = ({children, type = "main"}: HeadingProps) => {
     switch (type) {
         case "main":
             return <h1 className={`heading--${type}`}>{children}</h1>;
-        case "regular":
+        case "list":
             return <h2 className={`heading--${type}`}>{children}</h2>;
-        case "small":
+        case "body":
             return <h3 className={`heading--${type}`}>{children}</h3>;
     }
 };

--- a/frontend/src/common/components/Heading.tsx
+++ b/frontend/src/common/components/Heading.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+interface HeadingProps {
+    children;
+    type?: "main" | "regular" | "small";
+}
+
+const Heading = ({children, type = "main"}: HeadingProps) => {
+    switch (type) {
+        case "main":
+            return <h1 className={`heading--${type}`}>{children}</h1>;
+        case "regular":
+            return <h2 className={`heading--${type}`}>{children}</h2>;
+        case "small":
+            return <h3 className={`heading--${type}`}>{children}</h3>;
+    }
+};
+
+export default Heading;

--- a/frontend/src/common/components/ImprovementsTable.tsx
+++ b/frontend/src/common/components/ImprovementsTable.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import {IApartmentDetails, IHousingCompanyDetails} from "../models";
 import {formatMoney} from "../utils";
-import {EditButton} from "./index";
+import {EditButton, Heading} from "./index";
 
 interface ImprovementsTableProps {
     data: IApartmentDetails | IHousingCompanyDetails;
@@ -17,7 +17,7 @@ export default function ImprovementsTable({data, title, editableType, editPath}:
 
     return (
         <div className="list__wrapper list-wrapper--upgrades">
-            <h2 className="detail-list__heading">
+            <Heading type="list">
                 {title}
                 {editableType !== undefined && (
                     <EditButton
@@ -26,7 +26,7 @@ export default function ImprovementsTable({data, title, editableType, editPath}:
                         className="pull-right"
                     />
                 )}
-            </h2>
+            </Heading>
             <ul className="detail-list__list">
                 {data.improvements.market_price_index.length || data.improvements.construction_price_index.length ? (
                     <>

--- a/frontend/src/common/components/QueryStateHandler.tsx
+++ b/frontend/src/common/components/QueryStateHandler.tsx
@@ -37,7 +37,6 @@ export default function QueryStateHandler({
             </p>
         );
     }
-    console.log(error);
     return error ? (
         errorComponent
     ) : isLoading ? (

--- a/frontend/src/common/components/QueryStateHandler.tsx
+++ b/frontend/src/common/components/QueryStateHandler.tsx
@@ -28,15 +28,24 @@ export default function QueryStateHandler({
     children,
 }: QueryLoadingProps): JSX.Element {
     // When loading or an error has occurred, show an appropriate message, otherwise return children
-
+    const errorMessage = error ? (error as {error: string}).error : "";
     if (errorComponent === undefined) {
-        errorComponent = <p>Virhe</p>;
+        errorComponent = (
+            <p className="query-handler-error">
+                Ladattaessa tapahtui virhe 😞
+                {error !== undefined && <code className="query-error-message">{errorMessage as string}</code>}
+            </p>
+        );
     }
-
+    console.log(error);
     return error ? (
         errorComponent
     ) : isLoading ? (
-        <LoadingSpinner />
+        <div className="spinner-wrap">
+            <div className="spinner-container">
+                <LoadingSpinner />
+            </div>
+        </div>
     ) : data && (!("contents" in data) || data.contents.length) ? (
         <>{children}</>
     ) : (

--- a/frontend/src/common/components/index.ts
+++ b/frontend/src/common/components/index.ts
@@ -4,6 +4,7 @@ import EditButton from "./EditButton";
 import FilterComboboxField from "./FilterComboboxField";
 import FilterIntegerField from "./FilterIntegerField";
 import FilterTextInputField from "./FilterTextInputField";
+import Heading from "./Heading";
 import ImprovementsTable from "./ImprovementsTable";
 import ListPageNumbers from "./ListPageNumbers";
 import NavigateBackButton from "./NavigateBackButton";
@@ -15,6 +16,7 @@ import SaveDialogModal from "./SaveDialogModal";
 import FormInputField from "./formInputField/FormInputField";
 
 export {
+    Heading,
     ConfirmDialogModal,
     DetailField,
     EditButton,

--- a/frontend/src/features/apartment/ApartmentCreatePage.tsx
+++ b/frontend/src/features/apartment/ApartmentCreatePage.tsx
@@ -15,6 +15,7 @@ import {
 import {
     ConfirmDialogModal,
     FormInputField,
+    Heading,
     NavigateBackButton,
     RemoveButton,
     SaveButton,
@@ -241,12 +242,12 @@ const ApartmentCreatePage = () => {
 
     return (
         <div className="view--create view--set-apartment">
-            <h1 className="main-heading">
+            <Heading>
                 {state?.apartment
                     ? `${state.apartment.address.street_address} - ${state.apartment.address.stair}
                     ${state.apartment.address.apartment_number}`
                     : "Uusi asunto"}
-            </h1>
+            </Heading>
             <div className="field-sets">
                 <Fieldset heading="">
                     <TextInput

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -9,7 +9,7 @@ import {
     useGetApartmentDetailQuery,
     useGetHousingCompanyDetailQuery,
 } from "../../app/services";
-import {DetailField, EditButton, ImprovementsTable, QueryStateHandler} from "../../common/components";
+import {DetailField, EditButton, Heading, ImprovementsTable, QueryStateHandler} from "../../common/components";
 import FormTextInputField from "../../common/components/formInputField/FormTextInputField";
 import {
     IApartmentConfirmedMaximumPrice,
@@ -250,14 +250,14 @@ const LoadedApartmentDetails = ({data}: {data: IApartmentDetails}): JSX.Element 
 
     return (
         <>
-            <h1 className="main-heading">
+            <Heading type="main">
                 <Link to={`/housing-companies/${data.links.housing_company.id}`}>
                     <span className="name">{data.links.housing_company.display_name}</span>
                     <span className="address">{formatAddress(data.address)}</span>
                     <StatusLabel>{data.state}</StatusLabel>
                 </Link>
                 <EditButton state={{apartment: data}} />
-            </h1>
+            </Heading>
             <h2 className="apartment-stats">
                 <span className="apartment-stats--number">
                     {data.address.stair}

--- a/frontend/src/features/apartment/ApartmentImprovementsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentImprovementsPage.tsx
@@ -6,7 +6,7 @@ import {useImmer} from "use-immer";
 import {v4 as uuidv4} from "uuid";
 
 import {useSaveApartmentMutation} from "../../app/services";
-import {ConfirmDialogModal, FormInputField, NavigateBackButton, SaveButton} from "../../common/components";
+import {ConfirmDialogModal, FormInputField, Heading, NavigateBackButton, SaveButton} from "../../common/components";
 import {
     IApartmentConstructionPriceIndexImprovement,
     IApartmentDetails,
@@ -176,10 +176,10 @@ const ApartmentImprovementsPage = () => {
 
     return (
         <div className="view--create view--create-improvements">
-            <h1 className="main-heading">
+            <Heading>
                 {apartmentData.address.street_address} - {apartmentData.address.stair}
                 {apartmentData.address.apartment_number} Parannukset
-            </h1>
+            </Heading>
             <div className="field-sets">
                 <Fieldset heading="Markkinahintaindeksillä laskettavat parannukset">
                     <ul className="improvements-list">

--- a/frontend/src/features/apartment/ApartmentListPage.tsx
+++ b/frontend/src/features/apartment/ApartmentListPage.tsx
@@ -4,7 +4,13 @@ import {Checkbox, SearchInput, StatusLabel, TextInput} from "hds-react";
 import {Link} from "react-router-dom";
 
 import {useGetApartmentsQuery, useGetHousingCompanyApartmentsQuery} from "../../app/services";
-import {FilterIntegerField, FilterTextInputField, ListPageNumbers, QueryStateHandler} from "../../common/components";
+import {
+    FilterIntegerField,
+    FilterTextInputField,
+    Heading,
+    ListPageNumbers,
+    QueryStateHandler,
+} from "../../common/components";
 import {IApartment, IApartmentAddress, IApartmentListResponse, IOwnership} from "../../common/models";
 
 interface ApartmentListItemProps {
@@ -187,7 +193,7 @@ const ApartmentListPage = (): JSX.Element => {
 
     return (
         <div className="view--apartments-listing">
-            <h1 className="main-heading">Kaikki kohteet</h1>
+            <Heading>Kaikki kohteet</Heading>
             <div className="listing">
                 <SearchInput
                     className="search"

--- a/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
+++ b/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
@@ -10,7 +10,13 @@ import {
     useGetHousingCompanyDetailQuery,
     useSaveApartmentMaximumPriceMutation,
 } from "../../app/services";
-import {FormInputField, ImprovementsTable, NavigateBackButton, QueryStateHandler} from "../../common/components";
+import {
+    FormInputField,
+    Heading,
+    ImprovementsTable,
+    NavigateBackButton,
+    QueryStateHandler,
+} from "../../common/components";
 import {
     IApartmentDetails,
     IApartmentMaximumPrice,
@@ -81,12 +87,12 @@ const LoadedApartmentMaxPrice = ({apartment}: {apartment: IApartmentDetails}): J
 
     return (
         <div className="view--set-apartment">
-            <h1 className="main-heading">
+            <Heading>
                 <div>
                     {apartment.address.street_address} - {apartment.address.stair}
                     {apartment.address.apartment_number} ({apartment.links.housing_company.display_name})
                 </div>
-            </h1>
+            </Heading>
             <div className="field-sets">
                 <Fieldset heading="">
                     <h2 className="detail-list__heading">Laskentaan vaikuttavat asunnon tiedot</h2>

--- a/frontend/src/features/housingCompany/BuildingCreatePage.tsx
+++ b/frontend/src/features/housingCompany/BuildingCreatePage.tsx
@@ -5,7 +5,7 @@ import {useParams} from "react-router-dom";
 import {useImmer} from "use-immer";
 
 import {useCreateBuildingMutation, useGetHousingCompanyDetailQuery} from "../../app/services";
-import {FormInputField, NavigateBackButton, SaveButton, SaveDialogModal} from "../../common/components";
+import {FormInputField, Heading, NavigateBackButton, SaveButton, SaveDialogModal} from "../../common/components";
 import {IBuildingWritable} from "../../common/models";
 
 const blankForm: IBuildingWritable = {
@@ -47,9 +47,9 @@ const BuildingCreatePage = (): JSX.Element => {
 
     return (
         <div className="view--create view--create-company">
-            <h1 className="main-heading">
+            <Heading>
                 <span>Uusi rakennus</span>
-            </h1>
+            </Heading>
             <div className="field-sets">
                 <Fieldset heading="">
                     <div className="row">

--- a/frontend/src/features/housingCompany/HousingCompanyCreatePage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyCreatePage.tsx
@@ -12,7 +12,7 @@ import {
     useGetPropertyManagersQuery,
     useSaveHousingCompanyMutation,
 } from "../../app/services";
-import {FormInputField, SaveButton, SaveDialogModal} from "../../common/components";
+import {FormInputField, Heading, SaveButton, SaveDialogModal} from "../../common/components";
 import {
     HousingCompanyStates,
     ICode,
@@ -111,9 +111,9 @@ const HousingCompanyCreatePage = (): JSX.Element => {
 
     return (
         <div className="view--create view--create-company">
-            <h1 className="main-heading">
+            <Heading>
                 <span>{state?.housingCompany ? state?.housingCompany.name.official : "Uusi yhtiö"}</span>
-            </h1>
+            </Heading>
             <div className="field-sets">
                 <Fieldset heading="">
                     <div className="row">

--- a/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
@@ -155,7 +155,7 @@ const LoadedHousingCompanyDetails = ({data}: {data: IHousingCompanyDetails}) => 
                 />
                 <div style={{display: "flex", flexFlow: "row nowrap", gap: "var(--spacing-layout-s)"}}>
                     <div className="list-wrapper list-wrapper--real-estates">
-                        <h2 className="detail-list__heading">
+                        <Heading type="list">
                             <span>Kiinteistöt</span>
                             <Link to="real-estates">
                                 <Button
@@ -165,7 +165,7 @@ const LoadedHousingCompanyDetails = ({data}: {data: IHousingCompanyDetails}) => 
                                     <IconPlus />
                                 </Button>
                             </Link>
-                        </h2>
+                        </Heading>
                         <ul className="detail-list__list">
                             {data.real_estates.map((realEstate) => (
                                 <li
@@ -179,7 +179,7 @@ const LoadedHousingCompanyDetails = ({data}: {data: IHousingCompanyDetails}) => 
                         </ul>
                     </div>
                     <div className="list-wrapper list-wrapper--buildings">
-                        <h2 className="detail-list__heading">
+                        <Heading type="list">
                             <span>Rakennukset</span>
                             <Link to="buildings">
                                 <Button
@@ -189,7 +189,7 @@ const LoadedHousingCompanyDetails = ({data}: {data: IHousingCompanyDetails}) => 
                                     <IconPlus />
                                 </Button>
                             </Link>
-                        </h2>
+                        </Heading>
                         <ul className="detail-list__list">
                             {data.real_estates.flatMap((realEstate) => {
                                 return realEstate.buildings.map((building) => (
@@ -206,7 +206,7 @@ const LoadedHousingCompanyDetails = ({data}: {data: IHousingCompanyDetails}) => 
                     </div>
                 </div>
                 <div className="list-wrapper list-wrapper--apartments">
-                    <h2>
+                    <Heading type="list">
                         <span>Asunnot</span>
                         <Link to="apartments/create">
                             <Button
@@ -217,7 +217,7 @@ const LoadedHousingCompanyDetails = ({data}: {data: IHousingCompanyDetails}) => 
                                 Lisää asunto
                             </Button>
                         </Link>
-                    </h2>
+                    </Heading>
                     <div className="listing">
                         <HousingCompanyApartmentResultsList housingCompanyId={params.housingCompanyId} />
                     </div>

--- a/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
@@ -4,7 +4,7 @@ import {Button, IconPlus, StatusLabel, Tabs} from "hds-react";
 import {Link, useParams} from "react-router-dom";
 
 import {useGetHousingCompanyDetailQuery} from "../../app/services";
-import {DetailField, EditButton, ImprovementsTable, QueryStateHandler} from "../../common/components";
+import {DetailField, EditButton, Heading, ImprovementsTable, QueryStateHandler} from "../../common/components";
 import {IHousingCompanyDetails} from "../../common/models";
 import {formatAddress, formatDate, formatMoney} from "../../common/utils";
 import {HousingCompanyApartmentResultsList} from "../apartment/ApartmentListPage";
@@ -13,10 +13,10 @@ const LoadedHousingCompanyDetails = ({data}: {data: IHousingCompanyDetails}) => 
     const params = useParams() as {readonly housingCompanyId: string};
     return (
         <>
-            <h1 className="main-heading">
+            <Heading>
                 {data.name.display}
                 <EditButton state={{housingCompany: data}} />
-            </h1>
+            </Heading>
 
             <div className="company-status">
                 <StatusLabel>Vapautunut 1.6.2022 ({data.state})</StatusLabel>

--- a/frontend/src/features/housingCompany/HousingCompanyImprovementsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyImprovementsPage.tsx
@@ -6,7 +6,7 @@ import {useImmer} from "use-immer";
 import {v4 as uuidv4} from "uuid";
 
 import {useSaveHousingCompanyMutation} from "../../app/services";
-import {ConfirmDialogModal, FormInputField, NavigateBackButton, SaveButton} from "../../common/components";
+import {ConfirmDialogModal, FormInputField, Heading, NavigateBackButton, SaveButton} from "../../common/components";
 import {IHousingCompanyDetails, IHousingCompanyWritable, IImprovement} from "../../common/models";
 import {dotted, hitasToast} from "../../common/utils";
 
@@ -145,7 +145,7 @@ const HousingCompanyImprovementsPage = () => {
 
     return (
         <div className="view--create view--create-improvements">
-            <h1 className="main-heading">{housingCompanyData.name.display} Parannukset</h1>
+            <Heading>{housingCompanyData.name.display} Parannukset</Heading>
             <div className="field-sets">
                 <Fieldset heading="Markkinahintaindeksillä laskettavat parannukset">
                     <ul className="improvements-list">

--- a/frontend/src/features/housingCompany/HousingCompanyListPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyListPage.tsx
@@ -4,7 +4,13 @@ import {Button, IconPlus, IconSearch} from "hds-react";
 import {Link} from "react-router-dom";
 
 import {useGetDevelopersQuery, useGetHousingCompaniesQuery, useGetPropertyManagersQuery} from "../../app/services";
-import {FilterIntegerField, FilterTextInputField, ListPageNumbers, QueryStateHandler} from "../../common/components";
+import {
+    FilterIntegerField,
+    FilterTextInputField,
+    Heading,
+    ListPageNumbers,
+    QueryStateHandler,
+} from "../../common/components";
 import FilterRelatedModelComboboxField from "../../common/components/FilterRelatedModelComboboxField";
 import {IHousingCompany, IHousingCompanyListResponse} from "../../common/models";
 import {formatAddress, formatDate} from "../../common/utils";
@@ -119,7 +125,7 @@ const HousingCompanyListPage = (): JSX.Element => {
 
     return (
         <div className="view--housing-company-list">
-            <h1 className="main-heading">
+            <Heading>
                 <span>Kaikki kohteet</span>
                 <Link to="create">
                     <Button
@@ -129,7 +135,7 @@ const HousingCompanyListPage = (): JSX.Element => {
                         Lisää uusi yhtiö
                     </Button>
                 </Link>
-            </h1>
+            </Heading>
             <div className="listing">
                 <div className="search">
                     <FilterTextInputField

--- a/frontend/src/features/housingCompany/RealEstateCreatePage.tsx
+++ b/frontend/src/features/housingCompany/RealEstateCreatePage.tsx
@@ -5,7 +5,7 @@ import {useParams} from "react-router-dom";
 import {useImmer} from "use-immer";
 
 import {useCreateRealEstateMutation} from "../../app/services";
-import {FormInputField, NavigateBackButton, SaveButton, SaveDialogModal} from "../../common/components";
+import {FormInputField, Heading, NavigateBackButton, SaveButton, SaveDialogModal} from "../../common/components";
 import {IRealEstate} from "../../common/models";
 
 const RealEstateCreatePage = (): JSX.Element => {
@@ -26,9 +26,9 @@ const RealEstateCreatePage = (): JSX.Element => {
 
     return (
         <div className="view--create view--create-real-estate">
-            <h1 className="main-heading">
+            <Heading>
                 <span>Uusi kiinteistö</span>
-            </h1>
+            </Heading>
             <div className="field-sets">
                 <Fieldset heading="">
                     <div className="row">

--- a/frontend/src/styles/abstracts/_typography.sass
+++ b/frontend/src/styles/abstracts/_typography.sass
@@ -22,6 +22,14 @@ body
   .company &
     margin-bottom: 16px
 
+.query-handler-error
+  font-size: 2rem
+  font-weight: 700
+  .query-error-message
+    color: var(--color-error)
+    font-family: monospace
+    font-size: $fontsize-body-m
+    font-weight: normal
 
 .list-wrapper
   h2

--- a/frontend/src/styles/abstracts/_typography.sass
+++ b/frontend/src/styles/abstracts/_typography.sass
@@ -16,12 +16,12 @@ body
   a, span
     display: flex
 
+  button
+    font-size: $fontsize-body-l
+
   .company &
     margin-bottom: 16px
 
-h1, h2, h3
-  button
-    font-size: $fontsize-body-l
 
 .list-wrapper
   h2

--- a/frontend/src/styles/abstracts/_typography.sass
+++ b/frontend/src/styles/abstracts/_typography.sass
@@ -3,14 +3,18 @@
 body
   font-family: $font-default
 
-.main-heading
+[class^="heading--"]
   width: 100%
   display: flex
   justify-content: space-between
+  align-items: center
   font-size: $fontsize-heading-xl
   line-height: $lineheight-l
   border-bottom: 1px solid #ccc
   margin: 0 0 32px
+
+  a, span
+    display: flex
 
   .company &
     margin-bottom: 16px

--- a/frontend/src/styles/base/_general.sass
+++ b/frontend/src/styles/base/_general.sass
@@ -15,6 +15,29 @@ ul, ol
   list-style-type: none
   padding-left: 0
 
+.spinner
+  &-wrap
+    @include flexbox()
+    height: 100%
+    justify-content: center
+    align-items: center
+    [class*="LoadingSpinner-module_loadingSpinner"]
+      opacity: 0.8
+      --spinner-color: var(--color-white)
+      .results &
+        --spinner-size: 12rem
+        --spinner-thickness: 1.4rem
+
+.query-handler-error
+  display: flex
+  flex-flow: column
+  height: 100%
+  align-items: center
+  justify-content: center
+  margin: 0
+  .query-error-message
+    margin-top: 0.5rem
+
 .row
   @include flexbox()
   @include flex-flow(row nowrap)

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -3,7 +3,7 @@
 .view--apartment-details
   margin-top: -60px
 
-  .main-heading
+  .heading--main
     flex-flow: row
     height: 75px
     padding: $spacing-layout-s
@@ -15,7 +15,7 @@
       display: inherit
       align-items: center
 
-    span
+    a > span
       display: inline-block
       margin-right: $spacing-layout-s
 

--- a/frontend/src/styles/components/_Codes.sass
+++ b/frontend/src/styles/components/_Codes.sass
@@ -23,8 +23,7 @@
     @include flex-grow(1)
 
   .results
-    grid-row: 1
-    grid-column: 2
+    height: 510px
 
   .filters
     padding: 0


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds the Heading component, to function as a wrapper component for our header texts and buttons. Also restyles the loading spinner and the error page shown when there is no response from the backend.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [X] Changes have been tested

## Test plan

The Heading component is by design hard to notice, altho there is some vertical centerings which were off by a few pixels that are now fixed. Other than that all headings should look and work exactly as they did before. Implemented for all main headings and list headings.

To see the loading spinner for more than a few (micro)seconds use e.g. Redux DevTools browser extension to enable rewinding the view to a state where it has yet to receive a response from the API. The error screen on the other hand can be seen e.g. by running only the front while the backend is down.

## Tickets

This pull request resolves all or part of the following ticket(s): 