### PR TITLE
Add git-blame-ignore-revs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -44,3 +44,16 @@
 
 * It's possible to take a look into `openapi.yaml`
 * After running `make docker-build` Swagger editor is running in [localhost:8090](localhost:8090)
+
+## Git blame ignore refs
+
+Project includes a `.git-blame-ignore-revs` file for ignoring certain commits from `git blame`.
+This can be useful for ignoring e.g. formatting commits, so that it is more clear from `git blame` 
+where the actual code change came from. Configure your git to use it for this project with the 
+following command:
+
+```shell
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+Git will now automatically look for the file when using `git blame`, no additional setup needed.


### PR DESCRIPTION
Can be used to ignore formatting commits etc.

# Hitas Pull Request

# Description

Adds .git-blame-ignore-revs to be able to ignore certain refs (like formatting) from blame output. Configure this to the project with:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

Using it is optional.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [ ] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- No need to test, simply adds a file for the future.

## Tickets

-
