### PR TITLE
Pdf improvements

### DIFF
--- a/backend/hitas/templates/components/improvements_table.jinja
+++ b/backend/hitas/templates/components/improvements_table.jinja
@@ -3,7 +3,7 @@
 {# Pre-2011 Constructin Price Index #}
 
 {% macro apartment_improvements_table_cpi(improvements) %}
-{% if improvements %}
+{% if improvements["items"] %}
     <h3 class="bordered-header">HUONEISTOKOHTAISET PARANNUKSET</h3>
     <table class="improvements-table">
         <tr style="border-bottom: 1px solid black;">
@@ -48,7 +48,7 @@
 {% endmacro %}
 
 {% macro housing_company_improvements_table_pre_2011_cpi(improvements) %}
-{% if improvements %}
+{% if improvements["items"] %}
     <h3 class="bordered-header">HUONEISTON OSUUS YHTIÖN PARANNUKSISTA</h3>
     <table class="improvements-table">
         <tr style="border-bottom: 1px solid black;">
@@ -78,7 +78,7 @@
 {# Pre-2011 Market Price Index #}
 
 {% macro apartment_improvements_table_mpi(improvements) %}
-{% if improvements %}
+{% if improvements["items"] %}
     <h3 class="bordered-header">HUONEISTOKOHTAISET PARANNUKSET</h3>
     <table class="improvements-table">
         <tr style="border-bottom: 1px solid black;">
@@ -124,7 +124,7 @@
 {% endmacro %}
 
 {% macro housing_company_improvements_table_pre_2011_mpi(improvements) %}
-{% if improvements %}
+{% if improvements["items"] %}
     <h3 class="bordered-header">HUONEISTON OSUUS YHTIÖN PARANNUKSISTA</h3>
     <table class="improvements-table">
         <tr style="border-bottom: 1px solid black;">
@@ -174,7 +174,7 @@
 {# 2011 Onwards #}
 
 {% macro housing_company_improvements_table_post_2011(improvements) %}
-{% if improvements %}
+{% if improvements["items"] %}
     <h3 class="bordered-header">HUONEISTON OSUUS YHTIÖN PARANNUKSISTA</h3>
     <table class="improvements-table">
         <tr style="border-bottom: 1px solid black;">

--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -190,16 +190,18 @@
     {% endif %}
 
     {# Parannukset #}
-    {% if index_calculation.calculation_variables.housing_company_improvements or index_calculation.calculation_variables.apartment_improvements %}
+    {% if index_calculation.calculation_variables.housing_company_improvements["items"]
+        or (
+            not maximum_price_calculation.json.new_hitas
+            and index_calculation.calculation_variables.apartment_improvements["items"]
+        )%}
         <pdf:nexttemplate name="template_attachment_2" />
         <pdf:nextpage />
 
         <h2 class="bordered-header">ENIMMÄISHINTALASKELMA<br>{{ index_name }}</h2>
 
         {% if maximum_price_calculation.json.new_hitas %}
-            {% if index_calculation.calculation_variables.housing_company_improvements %}
-                {{ housing_company_improvements_table_post_2011(index_calculation.calculation_variables.housing_company_improvements) }}
-            {% endif %}
+            {{ housing_company_improvements_table_post_2011(index_calculation.calculation_variables.housing_company_improvements) }}
         {% else %}
             {% if index_name_short == "mark.hintaindeksi" %}
                 {{ apartment_improvements_table_mpi(index_calculation.calculation_variables.apartment_improvements) }}

--- a/frontend/src/features/apartment/ApartmentImprovementsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentImprovementsPage.tsx
@@ -114,7 +114,7 @@ const ApartmentImprovementsPage = () => {
         });
     };
     const handleConfirmedRemoveMarketImprovementLine = () => {
-        if (marketIndexToRemove) {
+        if (marketIndexToRemove !== null) {
             setMarketIndexImprovements((draft) => {
                 draft.splice(marketIndexToRemove, 1);
             });
@@ -142,7 +142,7 @@ const ApartmentImprovementsPage = () => {
         });
     };
     const handleConfirmedRemoveConstructionImprovementLine = () => {
-        if (constructionIndexToRemove) {
+        if (constructionIndexToRemove !== null) {
             setConstructionIndexImprovements((draft) => {
                 draft.splice(constructionIndexToRemove, 1);
             });

--- a/frontend/src/features/housingCompany/HousingCompanyImprovementsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyImprovementsPage.tsx
@@ -84,7 +84,7 @@ const HousingCompanyImprovementsPage = () => {
         });
     };
     const handleConfirmedRemoveMarketImprovementLine = () => {
-        if (marketIndexToRemove) {
+        if (marketIndexToRemove !== null) {
             setMarketIndexImprovements((draft) => {
                 draft.splice(marketIndexToRemove, 1);
             });
@@ -111,7 +111,7 @@ const HousingCompanyImprovementsPage = () => {
         });
     };
     const handleConfirmedRemoveConstructionImprovementLine = () => {
-        if (constructionIndexToRemove) {
+        if (constructionIndexToRemove !== null) {
             setConstructionIndexImprovements((draft) => {
                 draft.splice(constructionIndexToRemove, 1);
             });


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Fix removing the last apartment or housing company improvement
- Display improvements on max price PDF only if there is any

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [x] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- Try to remove last improvement on apartment or housing company
- Check that the max price PDF doesnt have improvements table/page when there are no improvements on the apartment and/or company

## Tickets

This pull request resolves all or part of the following ticket(s):  HIT-315