### PR TITLE
Ignore eol errors for prettier when building frontend

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -19,7 +19,12 @@
     ],
     "rules": {
         "no-console": 1, // 1 = warning
-        "prettier/prettier": 2, // 2 = error
+        "prettier/prettier": [
+          2, // 2 = error
+          {
+            "endOfLine": "auto"
+          }
+        ],
         "comma-dangle": 0,
         "require-jsdoc": 0,
         "max-len": [0, 120, 2],


### PR DESCRIPTION
# Hitas Pull Request

# Description

Prettier gives a buttload of errors if this is not set in windows.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [ ] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- Shouldn't affect anything?

## Tickets

-
