### PR TITLE
Add interest during construction

### DIFF
--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -494,6 +494,7 @@ def _test_max_prices(
         surface_area=50 if not null_values else None,
         interest_during_construction_6=1000,
         interest_during_construction_14=2000,
+        building__real_estate__housing_company__financing_method__old_hitas_ruleset=old_hitas_ruleset,
     )
 
     if create_completion_indices:
@@ -505,10 +506,6 @@ def _test_max_prices(
         cpi_factory.create(month=now, value=150)
         mpi_factory.create(month=now, value=250)
         SurfaceAreaPriceCeilingFactory.create(month=now, value=3000)
-
-    if old_hitas_ruleset:
-        ap.housing_company.financing_method.old_hitas_ruleset = old_hitas_ruleset
-        ap.housing_company.financing_method.save()
 
     # Validate apartment details has correct data returned
     response = api_client.get(

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -40,7 +40,6 @@ from hitas.tests.factories.indices import (
 )
 from hitas.views.apartment import ApartmentDetailSerializer
 
-
 PRE_2005_DATE = datetime.date(2004, 12, 1)
 PRE_2011_DATE = datetime.date(2010, 12, 1)
 POST_2011_DATE = datetime.date(2011, 1, 1)

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -354,7 +354,7 @@ def test__api__apartment__retrieve(api_client: HitasAPIClient):
                     "name": cpi.name,
                     "value": float(cpi.value),
                     "completion_date": cpi.completion_date.strftime("%Y-%m"),
-                    "depreciation_percentage": cpi.depreciation_percentage.value,
+                    "depreciation_percentage": float(cpi.depreciation_percentage.value),
                 },
             ],
             "market_price_index": [

--- a/backend/hitas/tests/apis/test_api_postal_codes.py
+++ b/backend/hitas/tests/apis/test_api_postal_codes.py
@@ -30,8 +30,8 @@ def test__api__postal_codes__list__empty(api_client: HitasAPIClient):
 
 @pytest.mark.django_db
 def test__api__postal_code__list(api_client: HitasAPIClient):
-    pc1 = factories.HitasPostalCodeFactory.create()
-    pc2 = factories.HitasPostalCodeFactory.create()
+    pc1 = factories.HitasPostalCodeFactory.create(value="00100")
+    pc2 = factories.HitasPostalCodeFactory.create(value="00101")
 
     response = api_client.get(reverse("hitas:postal-code-list"))
     assert response.status_code == status.HTTP_200_OK, response.json()

--- a/backend/hitas/utils.py
+++ b/backend/hitas/utils.py
@@ -2,8 +2,31 @@ import datetime
 import operator
 from typing import Any, Optional
 
+from django.db.models import Value
+from django.db.models.functions import Round
 from django.utils import timezone
 from rest_framework.authentication import TokenAuthentication
+
+
+class RoundWithPrecision(Round):
+    """Implement round from Django 4.0
+    https://github.com/django/django/blob/main/django/db/models/functions/math.py#L176
+    """
+
+    arity = None  # Override Transform's arity=1 to enable passing precision.
+
+    def __init__(self, expression, precision=0, **extra):
+        super().__init__(expression, precision, **extra)
+
+    def as_sqlite(self, compiler, connection, **extra_context):
+        precision = self.get_source_expressions()[1]
+        if isinstance(precision, Value) and precision.value < 0:
+            raise ValueError("SQLite does not support negative precision.")
+        return super().as_sqlite(compiler, connection, **extra_context)
+
+    def _resolve_output_field(self):
+        source = self.get_source_expressions()[0]
+        return source.output_field
 
 
 def safe_attrgetter(obj: Any, dotted_path: str, default: Optional[Any]) -> Any:

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -569,7 +569,7 @@ class ApartmentViewSet(HitasModelViewSet):
         ],
     ) -> RoundWithPrecision:
         original_value = Subquery(
-            table.objects.filter(month=OuterRef("completion_date")).values("value"),
+            table.objects.filter(month=OuterRef("completion_month")).values("value"),
             output_field=HitasModelDecimalField(),
         )
 
@@ -667,6 +667,7 @@ class ApartmentViewSet(HitasModelViewSet):
                 "building__real_estate__housing_company__financing_method__old_hitas_ruleset",
             )
             .annotate(
+                completion_month=TruncMonth("completion_date"),  # Used for calculating indexes
                 cpi=self.select_index(ConstructionPriceIndex),
                 cpi_2005_100=self.select_index(ConstructionPriceIndex2005Equal100),
                 mpi=self.select_index(MarketPriceIndex),

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, Optional, Union
 
 from django.core.exceptions import ValidationError
 from django.db.models import Prefetch, Q
-from django.db.models.expressions import RawSQL, Subquery, OuterRef, F, Case, When, Value
-from django.db.models.functions import TruncMonth, Now, NullIf, Coalesce
+from django.db.models.expressions import Case, F, OuterRef, Subquery, Value, When
+from django.db.models.functions import Coalesce, Now, NullIf, TruncMonth
 from django.http import HttpResponse
 from django.urls import reverse
 from django.utils import timezone
@@ -23,18 +23,18 @@ from hitas.models import (
     ApartmentConstructionPriceImprovement,
     ApartmentMaximumPriceCalculation,
     Building,
+    ConstructionPriceIndex,
+    ConstructionPriceIndex2005Equal100,
     HousingCompany,
+    MarketPriceIndex,
+    MarketPriceIndex2005Equal100,
     Owner,
     Ownership,
     SurfaceAreaPriceCeiling,
-    MarketPriceIndex,
-    MarketPriceIndex2005Equal100,
-    ConstructionPriceIndex,
-    ConstructionPriceIndex2005Equal100,
 )
 from hitas.models._base import HitasModelDecimalField
 from hitas.models.apartment import ApartmentMarketPriceImprovement, ApartmentState, DepreciationPercentage
-from hitas.utils import this_month, RoundWithPrecision
+from hitas.utils import RoundWithPrecision, this_month
 from hitas.views.codes import ReadOnlyApartmentTypeSerializer
 from hitas.views.ownership import OwnershipSerializer
 from hitas.views.utils import (


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Adds 6% or 14% interest to pre-2011 index calculations on the `/api/v1/housing-companies/{housing_company_id}/apartments/{apartment_id}` endpoint.
- Refactored old SQL strings to django ORM methods. New methods use subqueries instead of aliased joins, and they are much easier to read IMO.
    - In theory, subqueries might be slightly slower due to SQL compilers having better micro-optimization for joins, but I didn't measure any difference with debug-toolbar
- Added conditionals for adding thee interest based on the index calculation wanted.
- Added `select_related` for `financing_method` on the queryset for optimization since `old_hitas_ruleset` is needed to determine if interest should be used.
- Switched from `extra` to `annotations` since extra is [soft-deprecated](https://docs.djangoproject.com/en/4.1/ref/models/querysets/#:~:text=Use%20this%20method%20as%20a%20last%20resort).
- Refactored surface area price ceiling from SQL strings to django ORM methods for consistency with the new index calculations. This also uses subqueries now (see the note above).
- Refactored tests to support `old_hitas_ruleset` as well as pre-2005 construction price index calculations

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [x] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- [ ] Checked that unconfirmed maximum prices for apartments that finished construction before 2011/01/01 should now have interest included
    - [ ] For the market price index, it is the 6% interest
    - [ ] For the construction price index, it is the 6% interest if construction finished on or after 2005/01/01, and 14% if before
- [ ] Interest is only calculated if the financing method has the `old_hitas_ruleset` flag. Note that interest is not calculated for pre-2011 apartments if they use new rulesets.

## Tickets

HT-327 - Hinta-arvion laskenta muutokset - rakennusaikainen korko - backend
