### PR TITLE
Add caching to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches:
-      - master
+    - master
   pull_request:
     branches:
-      - master
+    - master
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -31,25 +31,40 @@ jobs:
     - name: "Frontend - Install dependencies"
       uses: borales/actions-yarn@v4
       with:
-        dir: 'frontend'
+        dir: "frontend"
         cmd: install
 
     - name: "Frontend - Check for ESLint issues"
       uses: borales/actions-yarn@v4
       with:
-        dir: 'frontend'
+        dir: "frontend"
         cmd: eslint-check
 
     - name: "Frontend - Check for Prettier issues"
       uses: borales/actions-yarn@v4
       with:
-        dir: 'frontend'
+        dir: "frontend"
         cmd: prettier-check
 
-    - name: "Test for building frontend"
-      run: >
-        cd frontend
-        && docker build .
+  build-frontend:
+    name: "Test building frontend docker image"
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: "Checkout code"
+      uses: actions/checkout@v3
+
+    - name: "Set up Docker Buildx"
+      uses: docker/setup-buildx-action@v1
+
+    - name: "Build frontend container"
+      uses: docker/build-push-action@v2
+      with:
+        context: frontend
+        push: false
+        tags: hitas-frontend
+        cache-from: type=gha,scope=frontend
+        cache-to: type=gha,scope=frontend
 
   backend:
     name: "Backend checks"
@@ -85,6 +100,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: "Set up Python 3.10"
+      id: setup-python
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
@@ -94,12 +110,17 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
+          ${{ env.pythonLocation }}
           ${{ env.POETRY_HOME }}
           ${{ env.POETRY_CACHE_DIR }}
           ${{ env.PRE_COMMIT_HOME }}
-        # Invalidate cache if pre-commit changes, dependencies changes, or poetry version changes
-        # Can also manually override cache by changing "cache-v1" version.
-        key: cache-v1-${{ hashFiles('**/poetry.lock', '**/.pre-commit-config.yaml') }}-${{ env.POETRY_VERSION }}
+        # Invalidate cache when any of these changes:
+        # - python version
+        # - poetry version
+        # - dependencies
+        # - pre-commit config
+        # - manually changed "cache-v1" prefix
+        key: cache-v1-${{ hashFiles('**/poetry.lock', '**/.pre-commit-config.yaml') }}-poetry${{ env.POETRY_VERSION }}-python${{ steps.setup-python.outputs.python-version }}
 
     - name: "Install Poetry"
       if: steps.cache.outputs.cache-hit != 'true'
@@ -114,8 +135,13 @@ jobs:
         cd backend
         && poetry install --no-root
 
-    - name: "Run pre-commit hooks against all files"
+    - name: "Install pre-commit hook environments"
       if: steps.cache.outputs.cache-hit != 'true'
+      run: >
+        cd backend
+        && pre-commit install-hooks
+
+    - name: "Run pre-commit hooks against all files"
       run: >
         cd backend
         && pre-commit run --all-files
@@ -130,7 +156,22 @@ jobs:
         cd backend
         && ./manage.py makemigrations --check --no-color --no-input --dry-run
 
-    - name: "Test for building backend"
-      run: >
-        cd backend
-        && docker build .
+  build-backend:
+    name: "Test building backend docker image"
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: "Checkout code"
+      uses: actions/checkout@v3
+
+    - name: "Set up Docker Buildx"
+      uses: docker/setup-buildx-action@v1
+
+    - name: "Build backend container"
+      uses: docker/build-push-action@v2
+      with:
+        context: backend
+        push: false
+        tags: hitas-backend
+        cache-from: type=gha,scope=backend
+        cache-to: type=gha,scope=backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,18 +4,64 @@ name: "Hitas CI"
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build:
-    name: "Build"
+  frontend:
+    name: "Frontend checks"
     runs-on: ubuntu-latest
+
+    steps:
+    - name: "Checkout code"
+      uses: actions/checkout@v3
+
+    - name: "Frontend - Set Node.js 16.x"
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+
+    - name: "Frontend - Install dependencies"
+      uses: borales/actions-yarn@v4
+      with:
+        dir: 'frontend'
+        cmd: install
+
+    - name: "Frontend - Check for ESLint issues"
+      uses: borales/actions-yarn@v4
+      with:
+        dir: 'frontend'
+        cmd: eslint-check
+
+    - name: "Frontend - Check for Prettier issues"
+      uses: borales/actions-yarn@v4
+      with:
+        dir: 'frontend'
+        cmd: prettier-check
+
+    - name: "Test for building frontend"
+      run: >
+        cd frontend
+        && docker build .
+
+  backend:
+    name: "Backend checks"
+    runs-on: ubuntu-latest
+    env:
+      POETRY_VERSION: 1.3.1
+      POETRY_VIRTUALENVS_CREATE: 0
+      POETRY_HOME: ~/.local
+      POETRY_CACHE_DIR: ~/.cache/pypoetry
+      PRE_COMMIT_HOME: ~/.cache/pre-commit
+      SECRET_KEY: xxx
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/github_actions
 
     # Majority of the tests require database
     services:
@@ -38,64 +84,53 @@ jobs:
     - name: "Checkout code"
       uses: actions/checkout@v3
 
-    # Frontend
-    - name: Frontend - Set Node.js 16.x
-      uses: actions/setup-node@v3
-      with:
-        node-version: 16.x
-
-    - name: Frontend - Install dependencies
-      uses: borales/actions-yarn@v4
-      with:
-        dir: 'frontend'
-        cmd: install
-
-    - name: Frontend - Check for ESLint issues
-      uses: borales/actions-yarn@v4
-      with:
-        dir: 'frontend'
-        cmd: eslint-check
-
-    - name: Frontend - Check for Prettier issues
-      uses: borales/actions-yarn@v4
-      with:
-        dir: 'frontend'
-        cmd: prettier-check
-
-    # Backend
     - name: "Set up Python 3.10"
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: "3.10"
+
+    - name: "Load cached dependencies and pre-commit hooks"
+      id: cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ env.POETRY_HOME }}
+          ${{ env.POETRY_CACHE_DIR }}
+          ${{ env.PRE_COMMIT_HOME }}
+        # Invalidate cache if pre-commit changes, dependencies changes, or poetry version changes
+        # Can also manually override cache by changing "cache-v1" version.
+        key: cache-v1-${{ hashFiles('**/poetry.lock', '**/.pre-commit-config.yaml') }}-${{ env.POETRY_VERSION }}
 
     - name: "Install Poetry"
-      run: >
-        curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.3.1 python -
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: curl -sSL https://install.python-poetry.org | python -
 
-    - name: "Install test dependencies"
-      run: cd backend && ~/.local/bin/poetry install --no-root
-      env:
-        POETRY_VIRTUALENVS_CREATE: 0
+    - name: "Add poetry install directory to path"
+      run: echo "${{ env.POETRY_HOME }}" >> $GITHUB_PATH
 
-    - name: "Run pre-commit on backend"
+    - name: "Install dependencies"
+      if: steps.cache.outputs.cache-hit != 'true'
       run: >
         cd backend
-        && pre-commit install
+        && poetry install --no-root
+
+    - name: "Run pre-commit hooks against all files"
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: >
+        cd backend
         && pre-commit run --all-files
 
     - name: "Run tests"
-      env:
-        SECRET_KEY: xxx
-        DATABASE_URL: postgres://postgres:postgres@localhost:5432/github_actions
-      run: cd backend && pytest -vvv --cov=. .
+      run: >
+        cd backend
+        && pytest -vvv --cov=. .
 
     - name: "Test for migration issues"
-      env:
-        SECRET_KEY: xxx
-      run: cd backend && ./manage.py makemigrations --check --no-color --no-input --dry-run
-
-    - name: "Test for building frontend"
-      run: cd frontend && docker build .
+      run: >
+        cd backend
+        && ./manage.py makemigrations --check --no-color --no-input --dry-run
 
     - name: "Test for building backend"
-      run: cd backend && docker build .
+      run: >
+        cd backend
+        && docker build .

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -48,9 +48,14 @@ faker = "15.3.4"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "config.settings"
-norecursedirs = "node_modules"
 addopts = "--nomigrations"
-filterwarnings = ["ignore::DeprecationWarning:openapi_core*"]
+filterwarnings = [
+    "ignore::DeprecationWarning:openapi_core*",
+]
+norecursedirs = [
+    "node_modules",
+    ".cache",
+]
 
 [tool.black]
 line_length = 120


### PR DESCRIPTION
# Hitas Pull Request

# Description

Add caching and parallel jobs to CI to make it much faster. The new execution time is about x4 faster (2-3 minutes instead of 8-9 minutes when cache is hit, about 5 minutes when cache miss)
- Split `build` to `frontend checks`, `backend checks`, `test frontend docker build`, and `test backend docker build`
- Add caching of dependencies and pre-commit hooks for the backend
- Add docker layer caching for test builds
- Format the CI file to be more consistent

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [x] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- [x] Run CI with and without caches active
- [X] Changing dependencies will invalidate the cache
- [X] Changing pre-commit hooks will invalidate the cache
- [X] Changing python version will invalidate the cache
- [X] Changing poetry version will invalidate the cache
- [X] Changing manual cache key version will invalidate the cache

## Tickets

HT-378 - DX parannuksia
