### PR TITLE
Validate shares when creating/updating apartments

### DIFF
--- a/backend/hitas/models/apartment.py
+++ b/backend/hitas/models/apartment.py
@@ -37,6 +37,7 @@ class Apartment(ExternalHitasModel):
     # 'Huoneiden määrä'
     rooms = models.IntegerField(null=True, validators=[MinValueValidator(1)])
 
+    # 'Pienin ja suurin osakenumero'
     share_number_start = models.IntegerField(null=True, validators=[MinValueValidator(1)])
     share_number_end = models.IntegerField(null=True, validators=[MinValueValidator(1)])
 

--- a/backend/hitas/models/housing_company.py
+++ b/backend/hitas/models/housing_company.py
@@ -28,7 +28,7 @@ class HousingCompanyState(Enum):
         READY_NO_STATISTICS = _("Ready, no statistics")
 
 
-# Taloyhtiö
+# Taloyhtiö / "Osakeyhtiö"
 class HousingCompany(ExternalHitasModel):
     _safedelete_policy = SOFT_DELETE_CASCADE
 

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -1549,8 +1549,8 @@ def test__api__apartment__create__incorrect_building_id(api_client: HitasAPIClie
             100,  # start_2
             120,  # end_2
             [  # fields
-                {"field": "shares.start", "message": "Share 20 has already been taken by foo 1."},
-                {"field": "shares.end", "message": "Share 100 has already been taken by bar 2."},
+                {"field": "shares.start", "message": "Share 20 has already been taken by foo a 1."},
+                {"field": "shares.end", "message": "Share 100 has already been taken by bar b 2."},
             ],
         ],
         [
@@ -1559,10 +1559,10 @@ def test__api__apartment__create__incorrect_building_id(api_client: HitasAPIClie
             99,  # start_2
             120,  # end_2
             [  # fields
-                {"field": "shares.start", "message": "Shares 20-21 have already been taken by foo 1."},
-                {"field": "shares.start", "message": "Shares 99-100 have already been taken by bar 2."},
-                {"field": "shares.end", "message": "Shares 20-21 have already been taken by foo 1."},
-                {"field": "shares.end", "message": "Shares 99-100 have already been taken by bar 2."},
+                {"field": "shares.start", "message": "Shares 20-21 have already been taken by foo a 1."},
+                {"field": "shares.start", "message": "Shares 99-100 have already been taken by bar b 2."},
+                {"field": "shares.end", "message": "Shares 20-21 have already been taken by foo a 1."},
+                {"field": "shares.end", "message": "Shares 99-100 have already been taken by bar b 2."},
             ],
         ],
         [
@@ -1571,10 +1571,10 @@ def test__api__apartment__create__incorrect_building_id(api_client: HitasAPIClie
             80,  # start_2
             90,  # end_2
             [  # fields
-                {"field": "shares.start", "message": "Shares 30-40 have already been taken by foo 1."},
-                {"field": "shares.start", "message": "Shares 80-90 have already been taken by bar 2."},
-                {"field": "shares.end", "message": "Shares 30-40 have already been taken by foo 1."},
-                {"field": "shares.end", "message": "Shares 80-90 have already been taken by bar 2."},
+                {"field": "shares.start", "message": "Shares 30-40 have already been taken by foo a 1."},
+                {"field": "shares.start", "message": "Shares 80-90 have already been taken by bar b 2."},
+                {"field": "shares.end", "message": "Shares 30-40 have already been taken by foo a 1."},
+                {"field": "shares.end", "message": "Shares 80-90 have already been taken by bar b 2."},
             ],
         ],
         [
@@ -1583,8 +1583,8 @@ def test__api__apartment__create__incorrect_building_id(api_client: HitasAPIClie
             10,  # start_2
             110,  # end_2
             [  # fields
-                {"field": "shares.start", "message": "Shares 20-100 have already been taken by bar 2."},
-                {"field": "shares.end", "message": "Shares 20-100 have already been taken by bar 2."},
+                {"field": "shares.start", "message": "Shares 20-100 have already been taken by bar b 2."},
+                {"field": "shares.end", "message": "Shares 20-100 have already been taken by bar b 2."},
             ],
         ],
         [
@@ -1593,8 +1593,8 @@ def test__api__apartment__create__incorrect_building_id(api_client: HitasAPIClie
             20,  # start_2
             100,  # end_2
             [  # fields
-                {"field": "shares.start", "message": "Shares 20-100 have already been taken by bar 2."},
-                {"field": "shares.end", "message": "Shares 20-100 have already been taken by bar 2."},
+                {"field": "shares.start", "message": "Shares 20-100 have already been taken by bar b 2."},
+                {"field": "shares.end", "message": "Shares 20-100 have already been taken by bar b 2."},
             ],
         ],
     ],
@@ -1619,6 +1619,7 @@ def test__api__apartment__create__overlapping_shares(
     ApartmentFactory.create(
         building=b1,
         street_address="foo",
+        stair="a",
         apartment_number=1,
         share_number_start=start_1,
         share_number_end=end_1,
@@ -1626,6 +1627,7 @@ def test__api__apartment__create__overlapping_shares(
     ApartmentFactory.create(
         building=b1,
         street_address="bar",
+        stair="b",
         apartment_number=2,
         share_number_start=start_2,
         share_number_end=end_2,
@@ -1851,8 +1853,8 @@ def test__api__apartment__update__update_owner(api_client: HitasAPIClient, owner
             100,  # start_2
             120,  # end_2
             [  # fields
-                {"field": "shares.start", "message": "Share 20 has already been taken by foo 1."},
-                {"field": "shares.end", "message": "Share 100 has already been taken by bar 2."},
+                {"field": "shares.start", "message": "Share 20 has already been taken by foo a 1."},
+                {"field": "shares.end", "message": "Share 100 has already been taken by bar b 2."},
             ],
         ],
         [
@@ -1861,10 +1863,10 @@ def test__api__apartment__update__update_owner(api_client: HitasAPIClient, owner
             99,  # start_2
             120,  # end_2
             [  # fields
-                {"field": "shares.start", "message": "Shares 20-21 have already been taken by foo 1."},
-                {"field": "shares.start", "message": "Shares 99-100 have already been taken by bar 2."},
-                {"field": "shares.end", "message": "Shares 20-21 have already been taken by foo 1."},
-                {"field": "shares.end", "message": "Shares 99-100 have already been taken by bar 2."},
+                {"field": "shares.start", "message": "Shares 20-21 have already been taken by foo a 1."},
+                {"field": "shares.start", "message": "Shares 99-100 have already been taken by bar b 2."},
+                {"field": "shares.end", "message": "Shares 20-21 have already been taken by foo a 1."},
+                {"field": "shares.end", "message": "Shares 99-100 have already been taken by bar b 2."},
             ],
         ],
         [
@@ -1873,10 +1875,10 @@ def test__api__apartment__update__update_owner(api_client: HitasAPIClient, owner
             80,  # start_2
             90,  # end_2
             [  # fields
-                {"field": "shares.start", "message": "Shares 30-40 have already been taken by foo 1."},
-                {"field": "shares.start", "message": "Shares 80-90 have already been taken by bar 2."},
-                {"field": "shares.end", "message": "Shares 30-40 have already been taken by foo 1."},
-                {"field": "shares.end", "message": "Shares 80-90 have already been taken by bar 2."},
+                {"field": "shares.start", "message": "Shares 30-40 have already been taken by foo a 1."},
+                {"field": "shares.start", "message": "Shares 80-90 have already been taken by bar b 2."},
+                {"field": "shares.end", "message": "Shares 30-40 have already been taken by foo a 1."},
+                {"field": "shares.end", "message": "Shares 80-90 have already been taken by bar b 2."},
             ],
         ],
         [
@@ -1885,8 +1887,8 @@ def test__api__apartment__update__update_owner(api_client: HitasAPIClient, owner
             10,  # start_2
             110,  # end_2
             [  # fields
-                {"field": "shares.start", "message": "Shares 20-100 have already been taken by bar 2."},
-                {"field": "shares.end", "message": "Shares 20-100 have already been taken by bar 2."},
+                {"field": "shares.start", "message": "Shares 20-100 have already been taken by bar b 2."},
+                {"field": "shares.end", "message": "Shares 20-100 have already been taken by bar b 2."},
             ],
         ],
         [
@@ -1895,8 +1897,8 @@ def test__api__apartment__update__update_owner(api_client: HitasAPIClient, owner
             20,  # start_2
             100,  # end_2
             [  # fields
-                {"field": "shares.start", "message": "Shares 20-100 have already been taken by bar 2."},
-                {"field": "shares.end", "message": "Shares 20-100 have already been taken by bar 2."},
+                {"field": "shares.start", "message": "Shares 20-100 have already been taken by bar b 2."},
+                {"field": "shares.end", "message": "Shares 20-100 have already been taken by bar b 2."},
             ],
         ],
     ],
@@ -1921,6 +1923,7 @@ def test__api__apartment__update__overlapping_shares(
     ApartmentFactory.create(
         building=building_1,
         street_address="foo",
+        stair="a",
         apartment_number=1,
         share_number_start=start_1,
         share_number_end=end_1,
@@ -1928,6 +1931,7 @@ def test__api__apartment__update__overlapping_shares(
     ApartmentFactory.create(
         building=building_1,
         street_address="bar",
+        stair="b",
         apartment_number=2,
         share_number_start=start_2,
         share_number_end=end_2,
@@ -1935,6 +1939,7 @@ def test__api__apartment__update__overlapping_shares(
     apartment_1: Apartment = ApartmentFactory.create(
         building=building_1,
         street_address="baz",
+        stair="c",
         apartment_number=3,
         share_number_start=200,
         share_number_end=300,

--- a/backend/hitas/utils.py
+++ b/backend/hitas/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import operator
+import uuid
 from typing import Any, Optional
 
 from django.db.models import Value
@@ -55,3 +56,11 @@ def this_month() -> datetime.date:
 
 def monthify(date: datetime.date) -> datetime.date:
     return date.replace(day=1)
+
+
+def valid_uuid(value: str, version: int = 4) -> bool:
+    try:
+        uuid.UUID(value, version=version)
+        return True
+    except ValueError:
+        return False

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -2,7 +2,7 @@ import datetime
 import uuid
 from collections import OrderedDict
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, Iterable
 
 from django.core.exceptions import ValidationError
 from django.db.models import Prefetch, Q
@@ -34,7 +34,7 @@ from hitas.models import (
 )
 from hitas.models._base import HitasModelDecimalField
 from hitas.models.apartment import ApartmentMarketPriceImprovement, ApartmentState, DepreciationPercentage
-from hitas.utils import RoundWithPrecision, this_month
+from hitas.utils import RoundWithPrecision, this_month, valid_uuid
 from hitas.views.codes import ReadOnlyApartmentTypeSerializer
 from hitas.views.ownership import OwnershipSerializer
 from hitas.views.utils import (
@@ -44,6 +44,7 @@ from hitas.views.utils import (
     HitasModelViewSet,
     UUIDRelatedField,
     ValueOrNullField,
+    UUIDField,
 )
 from hitas.views.utils.merge import merge_model
 from hitas.views.utils.pdf import get_pdf_response
@@ -141,7 +142,73 @@ class SharesSerializer(serializers.Serializer):
         if start > end:
             raise ValidationError({"start": "'shares.start' must not be greater than 'shares.end'."})
 
+        apartment_filter = Q(building__real_estate__housing_company__uuid=F("_housing_company"))
+        if self.parent.instance is not None:
+            apartment_filter &= ~Q(uuid=self.parent.instance.uuid)
+
+        building_id: Optional[str] = None
+        building_input = self.parent.initial_data["building"]
+        if isinstance(building_input, dict):
+            building_id = building_input.get("id")
+
+        if not isinstance(building_id, str) or not valid_uuid(building_id):
+            return data
+
+        apartments: Iterable[dict[str, Any]] = (
+            Apartment.objects.annotate(
+                _housing_company=Subquery(
+                    HousingCompany.objects.filter(real_estates__buildings__uuid=building_id).values("uuid"),
+                ),
+            )
+            .filter(apartment_filter)
+            .only("street_address", "apartment_number", "share_number_start", "share_number_end")
+            .values("street_address", "apartment_number", "share_number_start", "share_number_end")
+        )
+
+        if apartments:
+            self.check_share_ranges(start, end, apartments)
+
         return data
+
+    @staticmethod
+    def check_share_ranges(start: int, end: int, apartments: Iterable[dict[str, Any]]) -> None:
+        new_share_range = set(range(start, end + 1))
+        share_ranges: dict[range, str] = {
+            range(
+                apartment["share_number_start"],
+                apartment["share_number_end"] + 1,
+            ): f"{apartment['street_address']} {apartment['apartment_number']}"
+            for apartment in apartments
+            if apartment["share_number_start"] is not None and apartment["share_number_start"] is not None
+        }
+
+        errors: dict[str, list[str]] = {}
+        for share_range, address in share_ranges.items():
+            overlapping: set[int] = new_share_range.intersection(share_range)
+            if not overlapping:
+                continue
+
+            if len(overlapping) == 1:
+                share: int = next(iter(overlapping))
+                if share == start:
+                    errors.setdefault("start", [])
+                    errors["start"].append(f"Share {share} has already been taken by {address}.")
+                    continue
+
+                errors.setdefault("end", [])
+                errors["end"].append(f"Share {share} has already been taken by {address}.")
+                continue
+
+            sorted_shares: list[int] = sorted(overlapping)
+            first: int = sorted_shares[0]
+            last: int = sorted_shares[-1]
+            errors.setdefault("start", [])
+            errors.setdefault("end", [])
+            errors["start"].append(f"Shares {first}-{last} have already been taken by {address}.")
+            errors["end"].append(f"Shares {first}-{last} have already been taken by {address}.")
+
+        if errors:
+            raise ValidationError(errors)
 
     def run_validation(self, data=empty):
         value = super().run_validation(data)


### PR DESCRIPTION
# Hitas Pull Request

# Description

Shares in the same housing company should not overlap. Raise an error if this happens.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [x] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests have been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in the test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- [x] Adding an apartment with overlapping shares raises an error about the shares
    - [x] Displays the overlapping share range
    - [x] Displays the apartment that the overlap is from
    - [x] Displays a single share if only the start or end of the range overlaps (both are inclusive)
        - [x] Displays only on the start field if the start overlaps
        - [x] Displays only on the end field if the end overlaps
- [x] Editing an apartment so that its shares now overlap with another building in the same housing company raises an error
    - [x] Displays the overlapping share range
    - [x] Displays the apartment that the overlap is from
    - [x] Displays a single share if only the start or end of the range overlaps (both are inclusive)
        - [x] Displays only on the start field if the start overlaps
        - [x] Displays only on the end field if the end overlaps

## Tickets

This pull request resolves all or part of the following ticket(s): HT-355


[HT-355]: https://helsinkisolutionoffice.atlassian.net/browse/HT-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ