### PR TITLE
Removes "huoneistokohtaiset parannukset" from max price breakdowns

### DIFF
--- a/frontend/src/features/apartment/components/ApartmentMaximumPriceBreakdownModal.tsx
+++ b/frontend/src/features/apartment/components/ApartmentMaximumPriceBreakdownModal.tsx
@@ -138,10 +138,6 @@ const MarketPricePre2011Breakdown = ({calculation}: {calculation: IIndexCalculat
                 value={calculation.calculation_variables.index_adjustment}
             />
             <BreakdownValue
-                label="+ Huoneistokohtaiset parannukset"
-                value={calculation.calculation_variables.apartment_improvements.summary.accepted_value}
-            />
-            <BreakdownValue
                 label="+ Osuus yhtiön parannuksista"
                 value={calculation.calculation_variables.housing_company_improvements.summary.accepted_value}
             />
@@ -245,10 +241,6 @@ const ConstructionPricePre2011Breakdown = ({
             <BreakdownValue
                 label={`+ Rakennusaikaiset korot (${calculation.calculation_variables.interest_during_construction_percentage}%)`}
                 value={calculation.calculation_variables.interest_during_construction}
-            />
-            <BreakdownValue
-                label="+ Huoneistokohtaiset parannukset"
-                value={calculation.calculation_variables.apartment_improvements.summary.value_for_apartment}
             />
             <BreakdownValue
                 label="= Osakkeiden velaton hinta"

--- a/frontend/src/styles/components/_ApartmentMaxPricePage.sass
+++ b/frontend/src/styles/components/_ApartmentMaxPricePage.sass
@@ -92,6 +92,8 @@
       margin: 0 0 $spacing-m
       text-align: right
       font-weight: bold
+  table
+    border-bottom: 1px solid $color-black-50
 
 .maximumPriceImprovementsTable
   div


### PR DESCRIPTION
- also adds a bottom border to the tables used for improvements

# Hitas Pull Request

# Description

Removes "Huoneistokohtaiset parannukset" from and adds a border to the tables used in the maximum price breakdown.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [X] Changes have been tested

## Test plan

Go make a new maximum price calculation and see that there is no "Huoneistokohtaiset parannukset" item there anymore

## Tickets

This pull request resolves all or part of the following ticket(s): HT-330
