### PR TITLE
Add apartment count to building and housing company endpoints

### DIFF
--- a/backend/hitas/tests/apis/test_api_building.py
+++ b/backend/hitas/tests/apis/test_api_building.py
@@ -64,6 +64,7 @@ def test__api__building__list(api_client: HitasAPIClient):
                 "street_address": bu1.street_address,
             },
             "building_identifier": bu1.building_identifier,
+            "apartment_count": 0,
         },
         {
             "id": bu2.uuid.hex,
@@ -73,6 +74,7 @@ def test__api__building__list(api_client: HitasAPIClient):
                 "street_address": bu2.street_address,
             },
             "building_identifier": bu2.building_identifier,
+            "apartment_count": 0,
         },
     ]
     assert response.json()["page"] == {
@@ -123,6 +125,7 @@ def test__api__building__retrieve(api_client: HitasAPIClient):
             "street_address": bu1.street_address,
         },
         "building_identifier": bu1.building_identifier,
+        "apartment_count": 0,
     }
 
 
@@ -315,6 +318,7 @@ def test__api__building__update(api_client: HitasAPIClient):
             "street_address": data["address"]["street_address"],
         },
         "building_identifier": data["building_identifier"],
+        "apartment_count": 0,
     }
 
     get_response = api_client.get(url)

--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -280,6 +280,7 @@ def test__api__housing_company__retrieve(api_client: HitasAPIClient, apt_with_nu
                             "street_address": hc1_re1_bu1.street_address,
                         },
                         "building_identifier": hc1_re1_bu1.building_identifier,
+                        "apartment_count": 2,
                     },
                     {
                         "id": hc1_re1_bu2.uuid.hex,
@@ -289,6 +290,7 @@ def test__api__housing_company__retrieve(api_client: HitasAPIClient, apt_with_nu
                             "street_address": hc1_re1_bu2.street_address,
                         },
                         "building_identifier": hc1_re1_bu2.building_identifier,
+                        "apartment_count": 1,
                     },
                 ],
             },
@@ -309,6 +311,7 @@ def test__api__housing_company__retrieve(api_client: HitasAPIClient, apt_with_nu
                             "street_address": hc1_re2_bu1.street_address,
                         },
                         "building_identifier": hc1_re2_bu1.building_identifier,
+                        "apartment_count": 0,
                     }
                 ],
             },

--- a/backend/hitas/tests/apis/test_api_real_estate.py
+++ b/backend/hitas/tests/apis/test_api_real_estate.py
@@ -65,6 +65,7 @@ def test__api__real_estate__list(api_client: HitasAPIClient):
                         "street_address": bu1.street_address,
                     },
                     "building_identifier": bu1.building_identifier,
+                    "apartment_count": 0,
                 },
                 {
                     "id": bu2.uuid.hex,
@@ -74,6 +75,7 @@ def test__api__real_estate__list(api_client: HitasAPIClient):
                         "street_address": bu2.street_address,
                     },
                     "building_identifier": bu2.building_identifier,
+                    "apartment_count": 0,
                 },
             ],
         },
@@ -145,6 +147,7 @@ def test__api__real_estate__retrieve(api_client: HitasAPIClient):
                     "street_address": hc1_re1_bu1.street_address,
                 },
                 "building_identifier": hc1_re1_bu1.building_identifier,
+                "apartment_count": 0,
             },
             {
                 "id": hc1_re1_bu2.uuid.hex,
@@ -154,6 +157,7 @@ def test__api__real_estate__retrieve(api_client: HitasAPIClient):
                     "street_address": hc1_re1_bu2.street_address,
                 },
                 "building_identifier": hc1_re1_bu2.building_identifier,
+                "apartment_count": 0,
             },
         ],
     }

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3270,6 +3270,11 @@ components:
           pattern: '^$|^1\d{8}[A-Za-z0-9]$|^\d{1,4}-\d{1,4}-\d{1,4}-\d{1,4} [A-Za-z0-9] \d{3}$'
           nullable: true
           example: 100012345A
+        apartment_count:
+          description: How many apartments are in this building
+          type: integer
+          minimum: 0
+          example: 4
 
     MinimalHousingCompany:
       description: Housing company identifier


### PR DESCRIPTION
# Hitas Pull Request

# Description

See title.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [X] Changes have been tested
    - [X] Automatic tests has been added
    - [X] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- [x] Apartment count is shown and is correct in these endpoints:
    - [x]  `/api/v1/housing-companies/{housing_company_id}`
    - [x]  `/api/v1/housing-companies/{housing_company_id}/real-estates`
    - [x]  `/api/v1/housing-companies/{housing_company_id}/real-estates/{real_estate_id}`
    - [x]  `/api/v1/housing-companies/{housing_company_id}/real-estates/{real_estate_id}/buildings`
    - [x]  `/api/v1/housing-companies/{housing_company_id}/real-estates/{real_estate_id}/buildings/{building_id}`

## Tickets

This pull request resolves all or part of the following ticket(s): HT-386
