### PR TITLE
Fixes the 404-error encountered when removing real estates

### DIFF
--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -207,20 +207,20 @@ const mutationApi = hitasApi.injectEndpoints({
                 body: data,
                 headers: {"Content-type": "application/json; charset=UTF-8"},
             }),
-            invalidatesTags: (result, error, arg) => [{type: "HousingCompany", id: arg.housingCompanyId}],
-        }),
-        removeRealEstate: builder.mutation<IRealEstate, {id: string; housingCompanyId: string}>({
-            query: ({id, housingCompanyId}) => ({
-                url: `housing-companies/${housingCompanyId}/real-estates/${housingCompanyId}`,
-                method: "DELETE",
-                headers: {"Content-type": "application/json; charset=UTF-8"},
-            }),
             invalidatesTags: (result, error, arg) => [
                 {
                     type: "HousingCompany",
                     id: arg.housingCompanyId,
                 },
             ],
+        }),
+        removeRealEstate: builder.mutation<IRealEstate, {id: string; housingCompanyId: string}>({
+            query: ({id, housingCompanyId}) => ({
+                url: `housing-companies/${housingCompanyId}/real-estates/${id}`,
+                method: "DELETE",
+                headers: {"Content-type": "application/json; charset=UTF-8"},
+            }),
+            invalidatesTags: (result, error, arg) => [{type: "HousingCompany", id: arg.housingCompanyId}],
         }),
         createBuilding: builder.mutation<
             IBuilding,
@@ -240,12 +240,7 @@ const mutationApi = hitasApi.injectEndpoints({
                 method: "DELETE",
                 headers: {"Content-type": "application/json; charset=UTF-8"},
             }),
-            invalidatesTags: (result, error, arg) => [
-                {
-                    type: "HousingCompany",
-                    id: arg.housingCompanyId,
-                },
-            ],
+            invalidatesTags: (result, error, arg) => [{type: "HousingCompany", id: arg.housingCompanyId}],
         }),
         saveApartment: builder.mutation<
             IApartmentDetails,

--- a/frontend/src/features/housingCompany/HousingCompanyRealEstatesPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyRealEstatesPage.tsx
@@ -43,6 +43,7 @@ const HousingCompanyRealEstatesPage = (): JSX.Element => {
     };
     const handleConfirmedRemove = () => {
         removeRealEstate({id: realEstateToRemove as string, housingCompanyId: params.housingCompanyId as string});
+        setIsConfirmModalVisible(false);
     };
 
     return (


### PR DESCRIPTION
# Hitas Pull Request

# Description

Fixes the 404-error encountered when trying to remove an otherwise removable real estate.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [X] Changes have been tested

## Test plan

Go to any housing company page and click "Muokkaa" on the real estates, add a real estate (to make sure it's an empty one and can thus be removed) and then remove it. Observe the lack of 404-errors.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-239
