### PR TITLE
Fix hitasmigrate truncation

### DIFF
--- a/backend/hitas/oracle_migration/runner.py
+++ b/backend/hitas/oracle_migration/runner.py
@@ -841,8 +841,11 @@ def turn_off_auto_now(model: Type[models.Model], field_name: str) -> None:
 
 def do_truncate():
     for model_class in [
-        HousingCompany,
+        Apartment,
         ApartmentType,
+        Building,
+        RealEstate,
+        HousingCompany,
         PropertyManager,
         BuildingType,
         Developer,


### PR DESCRIPTION
# Hitas Pull Request

# Description

Changing `on_delete` from cascade to protect on the following relations broke `hitasmigrate`, as housing companies could not be deleted without first deleting the contained apartments, buildings, and real estates.

- Real estate -> Housing Company
- Building -> Real Estate
- Apartments -> Building

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- [x] Check that `./manage.py hitasmigrate --truncate-only` now truncates instead of complaining about existing objects.

## Tickets

This pull request resolves all or part of the following ticket(s): ---
