### PR TITLE
fix improvement texts being empty

### DIFF
--- a/frontend/src/common/components/formInputField/FormTextInputField.tsx
+++ b/frontend/src/common/components/formInputField/FormTextInputField.tsx
@@ -29,6 +29,7 @@ export default function FormTextInputField({
     }
 
     const inputProps = {
+        value: value,
         onChange: handleOnChange,
         required: required,
         ...rest,


### PR DESCRIPTION
# Hitas Pull Request

# Description

Fixes improvement text fields (name, date), being empty when they should have been populated with existing improvement values

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [x] Changes have been tested
- **Backend**
    - [ ] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

Check e.g. Apartment improvements, that the name of an existing improvement is correctly populated

## Tickets

This pull request resolves all or part of the following ticket(s): -