### PR TITLE
Accept empty strings in date fields in maximum price endpoint

### DIFF
--- a/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_create.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_create.py
@@ -169,3 +169,20 @@ def test__api__apartment_max_price__too_high_loan(api_client: HitasAPIClient):
         "reason": "Conflict",
         "status": 409,
     }
+
+
+@pytest.mark.parametrize("date", ["", None])
+@pytest.mark.django_db
+def test__api__apartment_max_price__missing_date(api_client: HitasAPIClient, date):
+    a: Apartment = ApartmentFactory.create()
+    create_necessary_indices(completion_month=monthify(a.completion_date), calculation_month=this_month())
+
+    data = {
+        "apartment_share_of_housing_company_loans_date": date,
+        "calculation_date": date,
+    }
+
+    response = api_client.post(
+        reverse("hitas:maximum-price-list", args=[a.housing_company.uuid.hex, a.uuid.hex]), data=data, format="json"
+    )
+    assert response.status_code == status.HTTP_200_OK, response.json()

--- a/backend/hitas/views/apartment_max_price.py
+++ b/backend/hitas/views/apartment_max_price.py
@@ -154,10 +154,17 @@ class ConfirmSerializer(Serializer):
 
 
 class CreateCalculationSerializer(Serializer):
-    calculation_date = fields.DateField(required=False, allow_null=True)
-    apartment_share_of_housing_company_loans = fields.IntegerField(allow_null=True, required=False, min_value=0)
+    apartment_share_of_housing_company_loans = fields.IntegerField(required=False, allow_null=True, min_value=0)
     apartment_share_of_housing_company_loans_date = fields.DateField(required=False, allow_null=True)
+    calculation_date = fields.DateField(required=False, allow_null=True)
     additional_info = fields.CharField(required=False, allow_null=True, allow_blank=True)
+
+    def to_internal_value(self, data):
+        if data.get("apartment_share_of_housing_company_loans_date") == "":
+            data["apartment_share_of_housing_company_loans_date"] = None
+        if data.get("calculation_date") == "":
+            data["calculation_date"] = None
+        return super().to_internal_value(data)
 
     def validate_calculation_date(self, date):
         return self._validate_not_in_future(date)

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1005,10 +1005,16 @@ paths:
                   description: |-
                     Date which is used for calculating the maximum price. This cannot be in the future.
                     This mainly affects which indices are used and the validity period.
-                  type: string
+                  anyOf:
+                    - type: string
+                      format: date
+                      example: 2022-07-05
+                      nullable: true
+                    - type: string
+                      maxLength: 0
+                      example: ""
+                      nullable: true
                   nullable: true
-                  format: date
-                  example: 2022-07-05
                 apartment_share_of_housing_company_loans:
                   description: |-
                     How much the apartment's share of the housing company loans are on the calculation date
@@ -1017,9 +1023,16 @@ paths:
                   example: 2500
                 apartment_share_of_housing_company_loans_date:
                   description: Date for `apartment_share_of_housing_company_loans`
-                  type: string
-                  format: date
-                  example: 2022-07-28
+                  anyOf:
+                    - type: string
+                      format: date
+                      example: 2022-07-05
+                      nullable: true
+                    - type: string
+                      maxLength: 0
+                      example: ""
+                      nullable: true
+                  nullable: true
                 additional_info:
                   description: Additional information to be displayed on the generated PDF
                   type: string


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Accept empty strings in date fields in maximum price endpoint.
- Empty strings are handled like `null` values would be.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [x] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [x] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- Automatic tests
- In frontend, go to create a new confirmed maximum price calculation, set any value for date fields and clear them, then click *Laske* and watch it not fail anymore :)

## Tickets

This pull request resolves all or part of the following ticket(s): HT-237 Comments