### PR TITLE
Fix fetching apartments with no apartment type

### DIFF
--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -210,6 +210,87 @@ def test__api__apartment__list(api_client: HitasAPIClient):
     }
 
 
+@pytest.mark.django_db
+def test__api__apartment__list__minimal(api_client: HitasAPIClient):
+    hc: HousingCompany = HousingCompanyFactory.create()
+    re: RealEstate = RealEstateFactory.create(housing_company=hc)
+    b: Building = BuildingFactory.create(real_estate=re)
+    ap1: Apartment = ApartmentFactory.create(
+        building=b,
+        state=ApartmentState.FREE,
+        apartment_type=None,
+        surface_area=None,
+        rooms=None,
+        share_number_start=None,
+        share_number_end=None,
+        completion_date=None,
+        street_address="Fakestreet 1",
+        apartment_number=1,
+        floor=None,
+        stair="A",
+        debt_free_purchase_price=None,
+        primary_loan_amount=None,
+        purchase_price=None,
+        first_purchase_date=None,
+        latest_purchase_date=None,
+        additional_work_during_construction=None,
+        loans_during_construction=None,
+        interest_during_construction_6=None,
+        interest_during_construction_14=None,
+        debt_free_purchase_price_during_construction=None,
+        notes=None,
+    )
+
+    response = api_client.get(reverse("hitas:apartment-list", args=[hc.uuid.hex]))
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json()["contents"] == [
+        {
+            "id": ap1.uuid.hex,
+            "state": ap1.state.value,
+            "type": ap1.apartment_type,
+            "surface_area": ap1.surface_area,
+            "rooms": ap1.rooms,
+            "address": {
+                "street_address": ap1.street_address,
+                "postal_code": hc.postal_code.value,
+                "city": hc.postal_code.city,
+                "apartment_number": ap1.apartment_number,
+                "stair": ap1.stair,
+                "floor": ap1.floor,
+            },
+            "completion_date": ap1.completion_date,
+            "ownerships": [],
+            "links": {
+                "housing_company": {
+                    "id": hc.uuid.hex,
+                    "display_name": hc.display_name,
+                    "link": f"/api/v1/housing-companies/{hc.uuid.hex}",
+                },
+                "real_estate": {
+                    "id": ap1.building.real_estate.uuid.hex,
+                    "link": (
+                        f"/api/v1/housing-companies/{hc.uuid.hex}" f"/real-estates/{ap1.building.real_estate.uuid.hex}"
+                    ),
+                },
+                "building": {
+                    "id": ap1.building.uuid.hex,
+                    "street_address": ap1.building.street_address,
+                    "link": (
+                        f"/api/v1/housing-companies/{hc.uuid.hex}"
+                        f"/real-estates/{ap1.building.real_estate.uuid.hex}"
+                        f"/buildings/{ap1.building.uuid.hex}"
+                    ),
+                },
+                "apartment": {
+                    "id": ap1.uuid.hex,
+                    "link": f"/api/v1/housing-companies/{hc.uuid.hex}/apartments/{ap1.uuid.hex}",
+                },
+            },
+        },
+    ]
+
+
 # Retrieve tests
 
 

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -609,7 +609,11 @@ class ApartmentDetailSerializer(EnumSupportSerializerMixin, HitasModelSerializer
 
 
 class ApartmentListSerializer(ApartmentDetailSerializer):
-    type = serializers.CharField(source="apartment_type.value")
+    type = serializers.SerializerMethodField()
+
+    @staticmethod
+    def get_type(instance: Apartment) -> Optional[str]:
+        return getattr(getattr(instance, "apartment_type", None), "value", None)
 
     class Meta:
         model = Apartment

--- a/backend/hitas/views/apartment_list.py
+++ b/backend/hitas/views/apartment_list.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from enumfields.drf import EnumSupportSerializerMixin
 from rest_framework import mixins, serializers, viewsets
 
@@ -34,12 +36,16 @@ class ApartmentFilterSet(HitasFilterSet):
 
 class ApartmentListSerializer(EnumSupportSerializerMixin, HitasModelSerializer):
     state = HitasEnumField(enum=ApartmentState)
-    type = serializers.CharField(source="apartment_type.value")
+    type = serializers.SerializerMethodField()
     address = ApartmentHitasAddressSerializer(source="*")
     surface_area = HitasDecimalField()
     completion_date = serializers.DateField(required=False, allow_null=True)
     ownerships = OwnershipSerializer(many=True, read_only=False)
     links = serializers.SerializerMethodField()
+
+    @staticmethod
+    def get_type(instance: Apartment) -> Optional[str]:
+        return getattr(getattr(instance, "apartment_type", None), "value", None)
 
     def get_links(self, instance: Apartment):
         return create_links(instance)

--- a/frontend/src/features/apartment/ApartmentCreatePage.tsx
+++ b/frontend/src/features/apartment/ApartmentCreatePage.tsx
@@ -330,7 +330,7 @@ const ApartmentCreatePage = () => {
                             inputType="relatedModel"
                             label="Asuntotyyppi"
                             fieldPath="type.id"
-                            placeholder={state?.apartment !== undefined ? state.apartment.type.value : ""}
+                            placeholder={state?.apartment.type !== null ? state?.apartment.type.value : ""}
                             queryFunction={useGetApartmentTypesQuery}
                             relatedModelSearchField="value"
                             getRelatedModelLabel={(obj: ICode) => obj.value}

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -264,8 +264,8 @@ const LoadedApartmentDetails = ({data}: {data: IApartmentDetails}): JSX.Element 
                     {data.address.apartment_number}
                 </span>
                 <span>
-                    {data.rooms ? data.rooms : ""}
-                    {data.type ? data.type.value : ""}
+                    {data.rooms || ""}
+                    {data.type?.value || ""}
                 </span>
                 <span>{data.surface_area ? data.surface_area + "m²" : ""}</span>
                 <span>{data.address.floor ? data.address.floor + ".krs" : ""}</span>

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -264,11 +264,11 @@ const LoadedApartmentDetails = ({data}: {data: IApartmentDetails}): JSX.Element 
                     {data.address.apartment_number}
                 </span>
                 <span>
-                    {data.rooms}
-                    {data.type.value}
+                    {data.rooms ? data.rooms : ""}
+                    {data.type ? data.type.value : ""}
                 </span>
-                <span>{data.surface_area}m²</span>
-                <span>{data.address.floor}.krs</span>
+                <span>{data.surface_area ? data.surface_area + "m²" : ""}</span>
+                <span>{data.address.floor ? data.address.floor + ".krs" : ""}</span>
             </h2>
             <div className="apartment-action-cards">
                 <ApartmentMaximumPricesCard apartment={data} />

--- a/frontend/src/features/apartment/ApartmentListPage.tsx
+++ b/frontend/src/features/apartment/ApartmentListPage.tsx
@@ -59,7 +59,7 @@ const ApartmentListItem = ({
                         <br />
                         {`${address.postal_code} ${address.city}`}
                     </div>
-                    <div className="area">{`${surfaceArea || ""}${surfaceArea ? "m²" : ""} ${
+                    <div className="area">{`${surfaceArea ? surfaceArea + "m²" : ""} ${
                         rooms || ""
                     } ${apartmentType}`}</div>
                 </div>

--- a/frontend/src/features/apartment/ApartmentListPage.tsx
+++ b/frontend/src/features/apartment/ApartmentListPage.tsx
@@ -59,7 +59,9 @@ const ApartmentListItem = ({
                         <br />
                         {`${address.postal_code} ${address.city}`}
                     </div>
-                    <div className="area">{`${surfaceArea || ""} m² ${rooms || ""} ${apartmentType}`}</div>
+                    <div className="area">{`${surfaceArea || ""}${surfaceArea ? "m²" : ""} ${
+                        rooms || ""
+                    } ${apartmentType}`}</div>
                 </div>
                 <div className="state">
                     <StatusLabel>{state}</StatusLabel>
@@ -110,7 +112,7 @@ const LoadedApartmentResultsList = ({data}: {data: IApartmentListResponse}) => {
                         apartmentNumber={item.address.apartment_number}
                         stair={item.address.stair || ""}
                         ownerships={item.ownerships}
-                        apartmentType={item.type}
+                        apartmentType={item.type || ""}
                         rooms={item.rooms}
                         surfaceArea={item.surface_area}
                         address={item.address}

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -37,7 +37,7 @@
 
     span
 
-      &:not(:last-child):after
+      &:not(:last-child):not(:empty):after
         display: inline-flex
         width: $spacing-layout-m
         content: "|"

--- a/frontend/src/styles/components/_ApartmentList.sass
+++ b/frontend/src/styles/components/_ApartmentList.sass
@@ -14,9 +14,6 @@
   .results-list > a:last-child
     border-bottom: 1px solid #ccc
 
-  .listing >  .search [class^="Icon-module"]
-    top: 0
-
   .list-header
 
     &.apartment


### PR DESCRIPTION
# Hitas Pull Request

# Description

Fixes the problems when viewing an apartment didn't have a set type, in listings, detail page and edit/create page.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [ ] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

Create a new apartment without specifying an apartment type. Check that it shows up correctly (== no `null` displayed anywhere, and preferably no crashes either) in both the housing company apartments list and the universal apartments list. Check that the same holds true for the detail and editing pages, too.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-389