### PR TITLE
Use acquisition_price in the unconfirmed max price PDF

### DIFF
--- a/backend/hitas/templates/unconfirmed_maximum_price.jinja
+++ b/backend/hitas/templates/unconfirmed_maximum_price.jinja
@@ -52,7 +52,7 @@
         </tr>
         <tr>
             <td>Alkuperäinen velaton hankintahinta, euroa</td>
-            <td>{{ apartment.prices.debt_free_purchase_price|intcomma }}</td>
+            <td>{{ apartment.prices.acquisition_price|intcomma }}</td>
         </tr>
         <tr>
             <td>Rakennuttajalta tilatut lisä- ja muutostyöt</td>


### PR DESCRIPTION
# Hitas Pull Request

# Description

In unconfirmed max price pdf, _**Alkuperäinen velaton hankintahinta, euroa**_ is now the `acquisition_price` (=`debt_free_purchase_price` + `primary_loan_amount`).

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

See description.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-360
