### PR TITLE
Sales page integration

### DIFF
--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -340,12 +340,16 @@ const mutationApi = hitasApi.injectEndpoints({
             }
         >({
             query: ({data, housingCompanyId, apartmentId}) => ({
-                url: `housing-companies/${housingCompanyId}/apartments/${apartmentId}/sales/`,
+                url: `housing-companies/${housingCompanyId}/apartments/${apartmentId}/sales`,
                 method: "POST",
                 body: data,
                 headers: {"Content-type": "application/json; charset=UTF-8"},
             }),
-            invalidatesTags: () => [{type: "Owner"}],
+            invalidatesTags: (result, error, arg) => [
+                {type: "Apartment", id: "LIST"},
+                {type: "Apartment", id: arg.apartmentId},
+                {type: "HousingCompany", id: arg.housingCompanyId},
+            ],
         }),
     }),
 });

--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -6,6 +6,7 @@ import {
     IApartmentMaximumPrice,
     IApartmentMaximumPriceWritable,
     IApartmentQuery,
+    IApartmentSale,
     IApartmentWritable,
     IBuilding,
     IBuildingWritable,
@@ -330,6 +331,22 @@ const mutationApi = hitasApi.injectEndpoints({
             }),
             invalidatesTags: (result, error, arg) => [{type: "Apartment"}, {type: "Index", id: "LIST"}],
         }),
+        createSale: builder.mutation<
+            IApartmentSale,
+            {
+                data: IApartmentSale;
+                housingCompanyId: string;
+                apartmentId: string;
+            }
+        >({
+            query: ({data, housingCompanyId, apartmentId}) => ({
+                url: `housing-companies/${housingCompanyId}/apartments/${apartmentId}/sales/`,
+                method: "POST",
+                body: data,
+                headers: {"Content-type": "application/json; charset=UTF-8"},
+            }),
+            invalidatesTags: () => [{type: "Owner"}],
+        }),
     }),
 });
 
@@ -361,4 +378,5 @@ export const {
     useCreateOwnerMutation,
     useSaveApartmentMaximumPriceMutation,
     useSaveIndexMutation,
+    useCreateSaleMutation,
 } = mutationApi;

--- a/frontend/src/common/components/EditButton.tsx
+++ b/frontend/src/common/components/EditButton.tsx
@@ -7,9 +7,15 @@ interface EditButtonProps {
     state: object;
     pathname?: string;
     className?: string;
+    disabled?: boolean;
 }
 
-export default function EditButton({state, pathname = "edit", className}: EditButtonProps): JSX.Element {
+export default function EditButton({
+    state,
+    pathname = "edit",
+    className,
+    disabled = false,
+}: EditButtonProps): JSX.Element {
     return (
         <Link
             to={{pathname: pathname}}
@@ -20,6 +26,7 @@ export default function EditButton({state, pathname = "edit", className}: EditBu
                 theme="black"
                 size="small"
                 iconLeft={<IconPen />}
+                disabled={disabled}
             >
                 Muokkaa
             </Button>

--- a/frontend/src/common/components/NavigateBackButton.tsx
+++ b/frontend/src/common/components/NavigateBackButton.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import {Button, IconArrowLeft} from "hds-react";
 import {useNavigate} from "react-router-dom";
 
-export default function NavigateBackButton(): JSX.Element {
+export default function NavigateBackButton({disabled = false}: {disabled?: boolean}): JSX.Element {
     const navigate = useNavigate();
     return (
         <Button
@@ -12,6 +12,7 @@ export default function NavigateBackButton(): JSX.Element {
             variant="secondary"
             className="back-button"
             onClick={() => navigate(-1)}
+            disabled={disabled}
         >
             Takaisin
         </Button>

--- a/frontend/src/common/components/OwnershipsList.tsx
+++ b/frontend/src/common/components/OwnershipsList.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import {Button, IconAlertCircleFill, IconCrossCircle, IconPlus} from "hds-react";
+import {Updater} from "use-immer";
 import {v4 as uuidv4} from "uuid";
 
 import {useGetOwnersQuery} from "../../app/services";
@@ -8,7 +9,15 @@ import {IOwner, IOwnership} from "../models";
 import {dotted, formatOwner} from "../utils";
 import {FormInputField} from "./index";
 
-const OwnershipsList = ({apartment, formOwnershipsList, setFormOwnershipsList}) => {
+const OwnershipsList = ({
+    formOwnershipsList,
+    setFormOwnershipsList,
+    noOwnersError = false,
+}: {
+    formOwnershipsList: (IOwnership & {key: string})[];
+    setFormOwnershipsList: Updater<(IOwnership & {key: string})[]>;
+    noOwnersError?: boolean;
+}) => {
     const error = {};
 
     // Ownerships
@@ -43,14 +52,14 @@ const OwnershipsList = ({apartment, formOwnershipsList, setFormOwnershipsList}) 
     };
 
     return (
-        <>
+        <div>
             <ul className="ownerships-list">
                 {formOwnershipsList.length ? (
                     <>
                         <li>
                             <legend className="ownership-headings">
-                                <span>Omistaja</span>
-                                <span>Omistajuusprosentti</span>
+                                <span>Omistaja *</span>
+                                <span>Omistajuusprosentti *</span>
                             </legend>
                         </li>
                         {formOwnershipsList.map((ownership: IOwnership & {key: string}, index) => (
@@ -74,6 +83,7 @@ const OwnershipsList = ({apartment, formOwnershipsList, setFormOwnershipsList}) 
                                         formData={formOwnershipsList[index]}
                                         setterFunction={handleSetOwnershipLine(index, "owner.id")}
                                         error={error}
+                                        required
                                     />
                                 </div>
                                 <div className="percentage">
@@ -86,6 +96,7 @@ const OwnershipsList = ({apartment, formOwnershipsList, setFormOwnershipsList}) 
                                         formData={formOwnershipsList[index]}
                                         setterFunction={handleSetOwnershipLine(index, "percentage")}
                                         error={error}
+                                        required
                                     />
                                 </div>
                                 <div className="icon--remove">
@@ -98,7 +109,14 @@ const OwnershipsList = ({apartment, formOwnershipsList, setFormOwnershipsList}) 
                         ))}
                     </>
                 ) : (
-                    <div style={{textAlign: "center"}}>- Asunnolla ei ole omistajuuksia -</div>
+                    <div
+                        className={noOwnersError ? "error-text" : ""}
+                        style={{textAlign: "center"}}
+                    >
+                        <IconAlertCircleFill />
+                        Asunnolla ei ole omistajuuksia
+                        <IconAlertCircleFill />
+                    </div>
                 )}
                 {getOwnershipPercentageError(error) && (
                     <>
@@ -111,13 +129,13 @@ const OwnershipsList = ({apartment, formOwnershipsList, setFormOwnershipsList}) 
                 <Button
                     onClick={handleAddOwnershipLine}
                     iconLeft={<IconPlus />}
-                    variant="secondary"
+                    variant={formOwnershipsList.length > 0 ? "secondary" : "primary"}
                     theme="black"
                 >
                     Lisää omistajuus
                 </Button>
             </div>
-        </>
+        </div>
     );
 };
 

--- a/frontend/src/common/components/RemoveButton.tsx
+++ b/frontend/src/common/components/RemoveButton.tsx
@@ -5,15 +5,17 @@ import {Button, IconCrossCircleFill} from "hds-react";
 interface RemoveButtonProps {
     onClick: () => void;
     isLoading: boolean;
+    disabled?: boolean;
 }
 
-export default function RemoveButton({onClick, isLoading}: RemoveButtonProps): JSX.Element {
+export default function RemoveButton({onClick, isLoading, disabled = false}: RemoveButtonProps): JSX.Element {
     return (
         <Button
             iconLeft={<IconCrossCircleFill />}
             theme="black"
             onClick={onClick}
             isLoading={isLoading}
+            disabled={disabled}
         >
             Poista
         </Button>

--- a/frontend/src/common/components/SaveButton.tsx
+++ b/frontend/src/common/components/SaveButton.tsx
@@ -5,15 +5,17 @@ import {Button, IconSaveDisketteFill} from "hds-react";
 interface SaveButtonProps {
     onClick: () => void;
     isLoading?: boolean;
+    disabled?: boolean;
 }
 
-export default function SaveButton({onClick, isLoading = false}: SaveButtonProps): JSX.Element {
+export default function SaveButton({onClick, isLoading = false, disabled = false}: SaveButtonProps): JSX.Element {
     return (
         <Button
             iconLeft={<IconSaveDisketteFill />}
             theme="black"
             onClick={onClick}
             isLoading={isLoading}
+            disabled={disabled}
         >
             Tallenna
         </Button>

--- a/frontend/src/common/components/formInputField/FormOwnershipInputField.tsx
+++ b/frontend/src/common/components/formInputField/FormOwnershipInputField.tsx
@@ -5,7 +5,7 @@ import {useImmer} from "use-immer";
 
 import {useCreateOwnerMutation} from "../../../app/services";
 import {IOwner} from "../../models";
-import {hitasToast, validateSocialSecurityNumber} from "../../utils";
+import {doesAContainB, hitasToast, validateSocialSecurityNumber} from "../../utils";
 import QueryStateHandler from "../QueryStateHandler";
 import SaveButton from "../SaveButton";
 import FormInputField, {CommonFormInputFieldProps} from "./FormInputField";
@@ -118,11 +118,7 @@ export default function FormOwnershipInputField({
         (internalFilterValue.length >= MIN_LENGTH && {[relatedModelSearchField]: internalFilterValue}) || {},
         {skip: !isModalVisible}
     );
-    const [formData, setFormData] = useImmer<IOwner>({
-        name: "",
-        identifier: "",
-        email: "",
-    });
+    const [formData, setFormData] = useImmer<IOwner>({name: "", identifier: "", email: ""});
     const [createOwner, {data: createData, error: createError, isLoading: isCreating}] = useCreateOwnerMutation();
 
     const openModal = () => setIsModalVisible(true);
@@ -172,14 +168,15 @@ export default function FormOwnershipInputField({
     }, [formData.identifier, setIsInvalidSSNAllowed]);
 
     useEffect(() => {
-        if (!isCreating && !createError && createData) {
+        if (!isCreating && !createError && createData && doesAContainB(createData, formData)) {
+            setFormData({name: "", identifier: "", email: ""});
             hitasToast("Omistaja lisätty onnistuneesti!");
-            setDisplayedValue(createData.name);
+            setDisplayedValue(`${createData.name} (${createData.identifier})`);
             setFieldValue(createData.id);
             setIsAddingNew(false);
             closeModal();
         }
-    }, [createData, createError, isCreating, setFieldValue]);
+    }, [createData, createError, isCreating, setFieldValue, formData, setFormData]);
 
     return (
         <div className={`input-field input-field--related-model${required ? " input-field--required" : ""}`}>

--- a/frontend/src/common/components/formInputField/FormOwnershipInputField.tsx
+++ b/frontend/src/common/components/formInputField/FormOwnershipInputField.tsx
@@ -32,7 +32,7 @@ const CreateNewOwner = ({
         <>
             <Dialog.Content>
                 {error ? (
-                    <div>{`Virhe: ${error}`}</div>
+                    <div>{`Virhe: ${error.data.fields[0].message}`}</div>
                 ) : (
                     <>
                         <FormInputField

--- a/frontend/src/common/models.ts
+++ b/frontend/src/common/models.ts
@@ -280,12 +280,13 @@ export interface IApartmentWritable {
 }
 
 export interface IApartmentSale {
+    readonly id?: string;
     ownerships: IOwnership[];
-    notification_date: string;
-    purchase_date: string;
-    purchase_price: number;
-    apartment_share_of_housing_company_loans: number;
-    include_in_statistics: boolean;
+    notification_date: string | null;
+    purchase_date: string | null;
+    purchase_price: number | null;
+    apartment_share_of_housing_company_loans: number | null;
+    exclude_from_statistics: boolean;
 }
 
 // Maximum Price

--- a/frontend/src/common/models.ts
+++ b/frontend/src/common/models.ts
@@ -279,6 +279,15 @@ export interface IApartmentWritable {
     };
 }
 
+export interface IApartmentSale {
+    ownerships: IOwnership[];
+    notification_date: string;
+    purchase_date: string;
+    purchase_price: number;
+    apartment_share_of_housing_company_loans: number;
+    include_in_statistics: boolean;
+}
+
 // Maximum Price
 
 // //  Maximum Price Fields

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -134,7 +134,7 @@ function validateSocialSecurityNumber(value: string): boolean {
 const today = () => new Date().toISOString().split("T")[0]; // Today's date in YYYY-MM-DD format
 
 // Toast hook with easier Notification typing
-function hitasToast(message: string, type?: "success" | "info" | "error" | "alert", opts?: ToastOptions) {
+function hitasToast(message: string | JSX.Element, type?: "success" | "info" | "error" | "alert", opts?: ToastOptions) {
     toast(message, {...opts, className: type});
 }
 

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -138,6 +138,22 @@ function hitasToast(message: string | JSX.Element, type?: "success" | "info" | "
     toast(message, {...opts, className: type});
 }
 
+// Returns true if obj1 contains the same key/value pairs as obj2. Note that this is non-exclusive, so obj1 doesn't
+// have to be identical to obj2, as it can contain more data than only the ones from obj2.
+function doesAContainB(A: object, B: object): boolean {
+    const AProps = Object.getOwnPropertyNames(A);
+    const BProps = Object.getOwnPropertyNames(B);
+    if (AProps.length < BProps.length) {
+        return false;
+    }
+    for (const prop of BProps) {
+        if (!Object.prototype.hasOwnProperty.call(A, prop) || A[prop] !== B[prop]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 export {
     dotted,
     formatAddress,
@@ -149,4 +165,5 @@ export {
     validateSocialSecurityNumber,
     hitasToast,
     today,
+    doesAContainB,
 };

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -57,7 +57,7 @@ function formatIndex(indexType: string) {
         case "construction_price_index":
             return "rakennuskustannusindeksi";
         case "surface_area_price_ceiling":
-            return "rajaneliöhinta";
+            return "rajaneliöhintaindeksi";
     }
 }
 

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -131,6 +131,8 @@ function validateSocialSecurityNumber(value: string): boolean {
     return checkDigits[Number(value.substring(0, 6) + idNumber) % 31] === checkDigit;
 }
 
+const today = () => new Date().toISOString().split("T")[0]; // Today's date in YYYY-MM-DD format
+
 // Toast hook with easier Notification typing
 function hitasToast(message: string, type?: "success" | "info" | "error" | "alert", opts?: ToastOptions) {
     toast(message, {...opts, className: type});
@@ -146,4 +148,5 @@ export {
     validateBusinessId,
     validateSocialSecurityNumber,
     hitasToast,
+    today,
 };

--- a/frontend/src/features/apartment/ApartmentCreatePage.tsx
+++ b/frontend/src/features/apartment/ApartmentCreatePage.tsx
@@ -455,7 +455,6 @@ const ApartmentCreatePage = () => {
                     <OwnershipsList
                         formOwnershipsList={formOwnershipsList}
                         setFormOwnershipsList={setFormOwnershipsList}
-                        apartment={data}
                     />
                 </Fieldset>
                 <Fieldset heading="">

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -29,7 +29,7 @@ const ApartmentSalesConditionCard = ({apartment}: {apartment: IApartmentDetails}
                         theme="black"
                         iconLeft={<IconGlyphEuro />}
                     >
-                        Uusi kauppa
+                        Kauppatapahtuma
                     </Button>
                 </Link>
                 <Link to="sales-conditions">

--- a/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
+++ b/frontend/src/features/apartment/ApartmentMaxPricePage.tsx
@@ -23,6 +23,7 @@ import {
     IApartmentMaximumPriceWritable,
     IHousingCompanyDetails,
 } from "../../common/models";
+import {today} from "../../common/utils";
 import MaximumPriceModalContent from "./components/ApartmentMaximumPriceBreakdownModal";
 
 const MaximumPriceModalError = ({error, setIsModalVisible}) => {
@@ -48,11 +49,10 @@ const MaximumPriceModalError = ({error, setIsModalVisible}) => {
 
 const LoadedApartmentMaxPrice = ({apartment}: {apartment: IApartmentDetails}): JSX.Element => {
     const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
-    const today = new Date().toISOString().split("T")[0]; // Today's date in YYYY-MM format
     const [formData, setFormData] = useImmer<IApartmentMaximumPriceWritable>({
         apartment_share_of_housing_company_loans: null,
-        apartment_share_of_housing_company_loans_date: today,
-        calculation_date: today,
+        apartment_share_of_housing_company_loans_date: today(),
+        calculation_date: today(),
         additional_info: "",
     });
     const {

--- a/frontend/src/features/apartment/ApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentSalesPage.tsx
@@ -41,6 +41,7 @@ const MaximumPriceModalError = ({error, setIsModalVisible}) => {
 const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) => {
     const [isModalVisible, setIsModalVisible] = useState(false);
     const hasValidCalculation = apartment.prices.maximum_prices.confirmed?.valid.is_valid;
+    const [hasNoOwnershipsError, setHasNoOwnershipsError] = useState(false);
     const initialFormData = {
         notificationDate: null,
         apartmentSaleDate:
@@ -97,6 +98,12 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
             index: data ? data.index : maxPriceQuery?.index,
         });
         setIsModalVisible(true);
+    };
+    const handleSaveButton = () => {
+        if (formOwnershipsList.length < 1) {
+            hitasToast("Kaupalla täytyy olla ainakin yksi omistaja!", "error");
+            setHasNoOwnershipsError(true);
+        }
     };
     return (
         <>
@@ -208,20 +215,21 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
                         </div>
                     )}
                 </Fieldset>
-                <Fieldset heading="Omistajuudet">
+                <Fieldset
+                    className="ownerships-fieldset"
+                    heading="Omistajuudet *"
+                >
                     <OwnershipsList
                         formOwnershipsList={formOwnershipsList}
                         setFormOwnershipsList={setFormOwnershipsList}
-                        apartment={data}
+                        noOwnersError={hasNoOwnershipsError}
                     />
                 </Fieldset>
             </div>
             <div className="row row--buttons">
                 <NavigateBackButton />
                 <SaveButton
-                    onClick={() => {
-                        return;
-                    }}
+                    onClick={handleSaveButton}
                     isLoading={isLoading}
                 />
             </div>

--- a/frontend/src/features/apartment/ApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentSalesPage.tsx
@@ -73,14 +73,12 @@ const LoadedApartmentSalesPage = ({
     );
     const [maxPrices, setMaxPrices] = useState({
         maximumPrice: apartment.prices.maximum_prices.confirmed?.maximum_price,
-        maxPricePerSquare: apartment.prices.maximum_prices.confirmed?.maximum_price
-            ? apartment.prices.maximum_prices.confirmed?.maximum_price / apartment.surface_area
-            : 0,
-        debtFreePurchasePrice: apartment.prices.debt_free_purchase_price,
-        primaryLoanAmount: maxPriceCalculation
-            ? maxPriceCalculation?.calculations.construction_price_index.calculation_variables
-                  .apartment_share_of_housing_company_loans
-            : null,
+        maxPricePerSquare: maxPriceCalculation
+            ? maxPriceCalculation.calculations.construction_price_index.calculation_variables.debt_free_price_m2
+            : maxPriceData?.calculations.construction_price_index.calculation_variables.debt_free_price_m2,
+        debtFreePurchasePrice: maxPriceCalculation
+            ? maxPriceCalculation.calculations.construction_price_index.calculation_variables.debt_free_price
+            : maxPriceData?.calculations.construction_price_index.calculation_variables.debt_free_price,
         index: maxPriceData ? maxPriceData.index : maxPriceCalculation?.index,
     });
     const isTooHighPrice = Number(maxPrices.maximumPrice) < Number(formData.purchase_price);
@@ -107,11 +105,14 @@ const LoadedApartmentSalesPage = ({
             }).then(() => {
                 setMaxPrices({
                     maximumPrice: apartment.prices.maximum_prices.confirmed?.maximum_price,
-                    maxPricePerSquare: apartment.prices.maximum_prices.confirmed?.maximum_price
-                        ? apartment.prices.maximum_prices.confirmed?.maximum_price / apartment.surface_area
-                        : 0,
-                    debtFreePurchasePrice: apartment.prices.debt_free_purchase_price,
-                    primaryLoanAmount: apartment.prices.primary_loan_amount,
+                    maxPricePerSquare: maxPriceCalculation
+                        ? maxPriceCalculation.calculations.construction_price_index.calculation_variables
+                              .debt_free_price_m2
+                        : maxPriceData?.calculations.construction_price_index.calculation_variables.debt_free_price_m2,
+                    debtFreePurchasePrice: maxPriceCalculation
+                        ? maxPriceCalculation.calculations.construction_price_index.calculation_variables
+                              .debt_free_price
+                        : maxPriceData?.calculations.construction_price_index.calculation_variables.debt_free_price,
                     index: maxPriceData ? maxPriceData.index : maxPriceCalculation?.index,
                 });
                 setIsModalVisible(true);
@@ -127,7 +128,7 @@ const LoadedApartmentSalesPage = ({
     };
     const handleSaveButton = () => {
         if (formOwnershipsList.length < 1) {
-            hitasToast("Kaupalla täytyy olla ainakin yksi omistaja!", "error");
+            hitasToast("Asunnolla täytyy olla ainakin yksi omistaja!", "error");
             setHasNoOwnershipsError(true);
         } else {
             const saleData = {
@@ -166,6 +167,7 @@ const LoadedApartmentSalesPage = ({
                             setFormData={setFormData}
                             error={error}
                             required
+                            maxDate={new Date()}
                         />
                         <FormInputField
                             inputType="date"
@@ -175,6 +177,7 @@ const LoadedApartmentSalesPage = ({
                             setFormData={setFormData}
                             error={error}
                             required
+                            maxDate={new Date()}
                         />
                     </div>
                     <div className="row">
@@ -202,7 +205,7 @@ const LoadedApartmentSalesPage = ({
                                 inputType="number"
                                 label="Osuus yhtiön lainoista"
                                 unit="€"
-                                fractionDigits={2}
+                                fractionDigits={0}
                                 fieldPath="apartment_share_of_housing_company_loans"
                                 formData={formData}
                                 setFormData={setFormData}

--- a/frontend/src/features/apartment/ApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentSalesPage.tsx
@@ -214,6 +214,13 @@ const LoadedApartmentSalesPage = ({
                                 error={error}
                                 required
                             />
+                            <div className="error-message error-text">
+                                <span style={{display: isLoanValueChanged ? "block" : "none"}}>
+                                    Enimmäishintalaskelmassa{" "}
+                                    {maxPriceCalculation?.calculations.construction_price_index.calculation_variables
+                                        .apartment_share_of_housing_company_loans + " €"}
+                                </span>
+                            </div>
                         </div>
                     </div>
                     <Checkbox
@@ -222,6 +229,16 @@ const LoadedApartmentSalesPage = ({
                         checked={isExcludedFromStats}
                         onChange={(event) => onCheckboxChange(event)}
                     />
+                </Fieldset>
+                <Fieldset
+                    heading={`Enimmäishintalaskelma ${
+                        maxPriceCalculation
+                            ? `(vahvistettu ${formatDate(
+                                  apartment.prices.maximum_prices.confirmed?.confirmed_at as string
+                              )})`
+                            : ""
+                    } *`}
+                >
                     {maxPriceCalculation ? (
                         <div className="max-prices">
                             <div className="row row--max-prices">
@@ -243,24 +260,26 @@ const LoadedApartmentSalesPage = ({
                             <div className="row row--prompt">
                                 {isLoanValueChanged ? (
                                     <p>
-                                        <span>Yhtiön lainaosuus on muuttunut, ole hyvä ja tee uusi laskelma.</span>
+                                        <span>Osuus yhtiön lainoista</span> on muuttunut, ole hyvä ja
+                                        <span> tee uusi enimmäishintalaskelma</span>.
                                     </p>
                                 ) : (
                                     <p>
-                                        Enimmäishinnat{" "}
-                                        <span>
-                                            {formatDate(
-                                                apartment.prices.maximum_prices.confirmed?.confirmed_at as string
-                                            )}
-                                        </span>{" "}
-                                        vahvistetusta enimmäishintalaskelmasta (perustuen
+                                        Enimmäishinnoissa on käytetty
                                         <span>
                                             {` ${formatIndex(
                                                 maxPriceData ? maxPriceData.index : maxPriceCalculation.index
-                                            )}in`}
-                                        </span>
-                                        ).
-                                        <br />
+                                            )}ä`}
+                                        </span>{" "}
+                                        ja{" "}
+                                        <span>
+                                            {
+                                                maxPriceCalculation?.calculations[maxPriceCalculation.index]
+                                                    .calculation_variables.apartment_share_of_housing_company_loans
+                                            }
+                                            €
+                                        </span>{" "}
+                                        lainaosuutta.
                                     </p>
                                 )}
                                 <Button

--- a/frontend/src/features/apartment/ApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentSalesPage.tsx
@@ -15,7 +15,7 @@ import {
 import {FormInputField, Heading, NavigateBackButton, QueryStateHandler, SaveButton} from "../../common/components";
 import OwnershipsList from "../../common/components/OwnershipsList";
 import {IApartmentDetails, IApartmentMaximumPrice, IOwnership} from "../../common/models";
-import {formatAddress, formatDate, formatIndex, formatMoney, hitasToast, today} from "../../common/utils";
+import {formatDate, formatIndex, formatMoney, hitasToast, today} from "../../common/utils";
 import MaximumPriceModalContent from "./components/ApartmentMaximumPriceBreakdownModal";
 
 const MaximumPriceModalError = ({error, setIsModalVisible}) => {
@@ -368,6 +368,15 @@ const MaxPriceCalculationLoader = ({apartment}) => {
         priceId: apartment.prices.maximum_prices.confirmed?.id as string,
     });
 
+    const SalesHeading = () => (
+        <Heading type="main">
+            Kauppatapahtuma
+            <span>
+                {`(${apartment.address.street_address} ${apartment.address.stair} ${apartment.address.apartment_number})`}
+            </span>
+        </Heading>
+    );
+
     if (hasValidCalculation) {
         return (
             <QueryStateHandler
@@ -375,10 +384,7 @@ const MaxPriceCalculationLoader = ({apartment}) => {
                 error={error}
                 isLoading={isLoading}
             >
-                <Heading type="main">
-                    Uusi kauppa
-                    <span>({formatAddress(apartment.address)})</span>
-                </Heading>
+                <SalesHeading />
                 <LoadedApartmentSalesPage
                     maxPriceCalculation={data as IApartmentMaximumPrice}
                     apartment={apartment}
@@ -388,10 +394,7 @@ const MaxPriceCalculationLoader = ({apartment}) => {
     } else
         return (
             <>
-                <Heading type="main">
-                    Uusi kauppa
-                    <span>({formatAddress(apartment.address)})</span>
-                </Heading>
+                <SalesHeading />
                 <LoadedApartmentSalesPage
                     maxPriceCalculation={null}
                     apartment={apartment}

--- a/frontend/src/features/apartment/ApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentSalesPage.tsx
@@ -214,11 +214,6 @@ const LoadedApartmentSalesPage = ({
                                 error={error}
                                 required
                             />
-                            <div className="error-message error-text">
-                                <span style={{display: isLoanValueChanged ? "block" : "none"}}>
-                                    Lainaosuus muuttui, tee uusi laskelma!
-                                </span>
-                            </div>
                         </div>
                     </div>
                     <Checkbox
@@ -230,40 +225,44 @@ const LoadedApartmentSalesPage = ({
                     {maxPriceCalculation ? (
                         <div className="max-prices">
                             <div className="row row--max-prices">
-                                <div className="fieldset--max-prices__value">
+                                <div className={`fieldset--max-prices__value ${isLoanValueChanged ? " expired" : ""}`}>
                                     <legend>Enimmäishinta (€)</legend>
                                     <span className={isTooHighPrice ? "error-text" : ""}>
                                         {formatMoney(maxPrices.maximumPrice as number)}
                                     </span>
                                 </div>
-                                <div className="fieldset--max-prices__value">
+                                <div className={`fieldset--max-prices__value ${isLoanValueChanged ? " expired" : ""}`}>
                                     <legend>Enimmäishinta per m² (€)</legend>
                                     <span>{formatMoney(maxPrices.maxPricePerSquare)}</span>
                                 </div>
-                                <div className="fieldset--max-prices__value">
+                                <div className={`fieldset--max-prices__value ${isLoanValueChanged ? " expired" : ""}`}>
                                     <legend>Velaton enimmäishinta (€)</legend>
                                     <span>{formatMoney(maxPrices.debtFreePurchasePrice)}</span>
                                 </div>
                             </div>
-                            <div className="row row--buttons">
-                                <p>
-                                    Enimmäishinnat{" "}
-                                    <span>
-                                        {formatDate(apartment.prices.maximum_prices.confirmed?.confirmed_at as string)}
-                                    </span>{" "}
-                                    vahvistetusta enimmäishintalaskelmasta (peruste:
-                                    <span>
-                                        {" "}
-                                        {formatIndex(maxPriceData ? maxPriceData.index : maxPriceCalculation.index)}
-                                    </span>
-                                    ).
-                                    {isLoanValueChanged && (
+                            <div className="row row--prompt">
+                                {isLoanValueChanged ? (
+                                    <p>
+                                        <span>Yhtiön lainaosuus on muuttunut, ole hyvä ja tee uusi laskelma.</span>
+                                    </p>
+                                ) : (
+                                    <p>
+                                        Enimmäishinnat{" "}
                                         <span>
-                                            <br />
-                                            Lainaosuus eri kuin laskelmassa!
+                                            {formatDate(
+                                                apartment.prices.maximum_prices.confirmed?.confirmed_at as string
+                                            )}
+                                        </span>{" "}
+                                        vahvistetusta enimmäishintalaskelmasta (perustuen
+                                        <span>
+                                            {` ${formatIndex(
+                                                maxPriceData ? maxPriceData.index : maxPriceCalculation.index
+                                            )}in`}
                                         </span>
-                                    )}
-                                </p>
+                                        ).
+                                        <br />
+                                    </p>
+                                )}
                                 <Button
                                     theme="black"
                                     variant={isLoanValueChanged ? "primary" : "secondary"}

--- a/frontend/src/features/apartment/ApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentSalesPage.tsx
@@ -14,7 +14,7 @@ import {
 import {FormInputField, Heading, NavigateBackButton, QueryStateHandler, SaveButton} from "../../common/components";
 import OwnershipsList from "../../common/components/OwnershipsList";
 import {IApartmentAddress, IApartmentDetails, IApartmentMaximumPrice, IOwnership} from "../../common/models";
-import {formatAddress, formatDate, formatIndex, formatMoney} from "../../common/utils";
+import {formatAddress, formatDate, formatIndex, formatMoney, hitasToast, today} from "../../common/utils";
 import MaximumPriceModalContent from "./components/ApartmentMaximumPriceBreakdownModal";
 
 const MaximumPriceModalError = ({error, setIsModalVisible}) => {
@@ -43,12 +43,12 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
     const hasValidCalculation = apartment.prices.maximum_prices.confirmed?.valid.is_valid;
     const [hasNoOwnershipsError, setHasNoOwnershipsError] = useState(false);
     const initialFormData = {
-        notificationDate: null,
-        apartmentSaleDate:
+        notification_date: today(),
+        purchase_date:
             apartment.prices.maximum_prices.confirmed !== null && hasValidCalculation
                 ? apartment.prices.maximum_prices.confirmed.calculation_date
-                : null,
-        purchasePrice: null,
+                : "",
+        purchase_price: null,
         apartment_share_of_housing_company_loans: hasValidCalculation ? apartment.prices.primary_loan_amount : null,
         isExcludedFromStatistics: false,
     };

--- a/frontend/src/features/apartment/ApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentSalesPage.tsx
@@ -293,9 +293,11 @@ const LoadedApartmentSalesPage = ({
                             <Button
                                 theme="black"
                                 onClick={handleCalculateButton}
+                                /* TODO: implement proper front end form validation and apply it here
                                 disabled={
                                     !(formData.purchase_date && formData.apartment_share_of_housing_company_loans)
                                 }
+                                */
                             >
                                 Tee enimmäishintalaskelma
                             </Button>

--- a/frontend/src/features/apartment/ApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentSalesPage.tsx
@@ -1,19 +1,20 @@
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 
 import {FetchBaseQueryError} from "@reduxjs/toolkit/query";
 import {Button, Checkbox, Dialog, Fieldset, IconAlertCircleFill} from "hds-react";
-import {useParams} from "react-router-dom";
+import {useNavigate, useParams} from "react-router-dom";
 import {useImmer} from "use-immer";
 import {v4 as uuidv4} from "uuid";
 
 import {
+    useCreateSaleMutation,
     useGetApartmentDetailQuery,
     useGetApartmentMaximumPriceQuery,
     useSaveApartmentMaximumPriceMutation,
 } from "../../app/services";
 import {FormInputField, Heading, NavigateBackButton, QueryStateHandler, SaveButton} from "../../common/components";
 import OwnershipsList from "../../common/components/OwnershipsList";
-import {IApartmentAddress, IApartmentDetails, IApartmentMaximumPrice, IOwnership} from "../../common/models";
+import {IApartmentDetails, IApartmentMaximumPrice, IOwnership} from "../../common/models";
 import {formatAddress, formatDate, formatIndex, formatMoney, hitasToast, today} from "../../common/utils";
 import MaximumPriceModalContent from "./components/ApartmentMaximumPriceBreakdownModal";
 
@@ -38,73 +39,125 @@ const MaximumPriceModalError = ({error, setIsModalVisible}) => {
     );
 };
 
-const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) => {
+const LoadedApartmentSalesPage = ({
+    apartment,
+    maxPriceCalculation,
+}: {
+    apartment: IApartmentDetails;
+    maxPriceCalculation: IApartmentMaximumPrice | null;
+}) => {
+    const navigate = useNavigate();
+
     const [isModalVisible, setIsModalVisible] = useState(false);
-    const hasValidCalculation = apartment.prices.maximum_prices.confirmed?.valid.is_valid;
     const [hasNoOwnershipsError, setHasNoOwnershipsError] = useState(false);
+    const [isExcludedFromStats, setIsExcludedFromStats] = useState(false);
+    const [isLoanValueChanged, setIsLoanValueChanged] = useState(false);
+
+    const [saveSale, {data, error, isLoading}] = useCreateSaleMutation();
+    const [saveMaximumPrice, {data: maxPriceData, error: maxPriceError, isLoading: isMaxPriceLoading}] =
+        useSaveApartmentMaximumPriceMutation();
+
     const initialFormData = {
         notification_date: today(),
-        purchase_date:
-            apartment.prices.maximum_prices.confirmed !== null && hasValidCalculation
-                ? apartment.prices.maximum_prices.confirmed.calculation_date
-                : "",
+        purchase_date: apartment.prices.maximum_prices.confirmed?.valid.is_valid
+            ? apartment.prices.maximum_prices.confirmed.calculation_date
+            : "",
         purchase_price: null,
-        apartment_share_of_housing_company_loans: hasValidCalculation ? apartment.prices.primary_loan_amount : null,
-        isExcludedFromStatistics: false,
+        apartment_share_of_housing_company_loans: maxPriceCalculation
+            ? maxPriceCalculation.calculations.construction_price_index.calculation_variables
+                  .apartment_share_of_housing_company_loans
+            : null,
     };
-    const [isExcludedFromStatistics, setIsExcludedFromStatistics] = useState(false);
     const [formData, setFormData] = useImmer(initialFormData);
     const [formOwnershipsList, setFormOwnershipsList] = useImmer<(IOwnership & {key: string})[]>(
         apartment !== undefined ? apartment.ownerships.map((o) => ({...o, key: uuidv4()})) : []
     );
-    const [saveMaximumPrice, {data, error, isLoading}] = useSaveApartmentMaximumPriceMutation();
-    const {data: maxPriceQuery} = useGetApartmentMaximumPriceQuery({
-        housingCompanyId: apartment.links.housing_company.id,
-        apartmentId: apartment.id,
-        priceId: apartment.prices.maximum_prices.confirmed?.id as string,
-    });
     const [maxPrices, setMaxPrices] = useState({
         maximumPrice: apartment.prices.maximum_prices.confirmed?.maximum_price,
         maxPricePerSquare: apartment.prices.maximum_prices.confirmed?.maximum_price
             ? apartment.prices.maximum_prices.confirmed?.maximum_price / apartment.surface_area
             : 0,
         debtFreePurchasePrice: apartment.prices.debt_free_purchase_price,
-        primaryLoanAmount: apartment.prices.primary_loan_amount,
-        index: data ? data.index : maxPriceQuery?.index,
+        primaryLoanAmount: maxPriceCalculation
+            ? maxPriceCalculation?.calculations.construction_price_index.calculation_variables
+                  .apartment_share_of_housing_company_loans
+            : null,
+        index: maxPriceData ? maxPriceData.index : maxPriceCalculation?.index,
     });
-    const isTooHighPrice = Number(maxPrices.maximumPrice) < Number(formData.purchasePrice);
+    const isTooHighPrice = Number(maxPrices.maximumPrice) < Number(formData.purchase_price);
+
     const onCheckboxChange = (event) => {
-        setIsExcludedFromStatistics((previous) => !previous);
+        setIsExcludedFromStats(event.target.checked);
     };
     const handleCalculateButton = () => {
         saveMaximumPrice({
             data: {
-                calculation_date: formData.apartmentSaleDate,
+                calculation_date: formData.purchase_date,
                 apartment_share_of_housing_company_loans: formData.apartment_share_of_housing_company_loans || 0,
-                apartment_share_of_housing_company_loans_date: formData.apartmentSaleDate,
+                apartment_share_of_housing_company_loans_date: formData.purchase_date,
                 additional_info: "",
             },
             id: undefined,
             apartmentId: apartment.id,
             housingCompanyId: apartment.links.housing_company.id,
+        }).then(() => {
+            setMaxPrices({
+                maximumPrice: apartment.prices.maximum_prices.confirmed?.maximum_price,
+                maxPricePerSquare: apartment.prices.maximum_prices.confirmed?.maximum_price
+                    ? apartment.prices.maximum_prices.confirmed?.maximum_price / apartment.surface_area
+                    : 0,
+                debtFreePurchasePrice: apartment.prices.debt_free_purchase_price,
+                primaryLoanAmount: apartment.prices.primary_loan_amount,
+                index: maxPriceData ? maxPriceData.index : maxPriceCalculation?.index,
+            });
+            setIsModalVisible(true);
         });
-        setMaxPrices({
-            maximumPrice: apartment.prices.maximum_prices.confirmed?.maximum_price,
-            maxPricePerSquare: apartment.prices.maximum_prices.confirmed?.maximum_price
-                ? apartment.prices.maximum_prices.confirmed?.maximum_price / apartment.surface_area
-                : 0,
-            debtFreePurchasePrice: apartment.prices.debt_free_purchase_price,
-            primaryLoanAmount: apartment.prices.primary_loan_amount,
-            index: data ? data.index : maxPriceQuery?.index,
-        });
-        setIsModalVisible(true);
     };
     const handleSaveButton = () => {
         if (formOwnershipsList.length < 1) {
             hitasToast("Kaupalla täytyy olla ainakin yksi omistaja!", "error");
             setHasNoOwnershipsError(true);
+        } else {
+            const saleData = {
+                ...formData,
+                ownerships: formOwnershipsList,
+                exclude_from_statistics: isExcludedFromStats,
+            };
+            saveSale({
+                data: saleData,
+                apartmentId: apartment.id,
+                housingCompanyId: apartment.links.housing_company.id,
+            });
         }
     };
+
+    // Handle saving flow
+    useEffect(() => {
+        if (!isLoading && !error && data && data.id) {
+            hitasToast("Kauppa tallennettu onnistuneesti!");
+            navigate(`/housing-companies/${apartment.links.housing_company.id}/apartments/${apartment.id}`);
+        } else if (error) {
+            hitasToast("Kaupan tallentaminen epäonnistui.", "error");
+        }
+    }, [isLoading, error, data, navigate, apartment.links.housing_company.id, apartment.id]);
+    // Handle alert for changed loan value
+    useEffect(() => {
+        if (
+            Number(formData.apartment_share_of_housing_company_loans) !==
+                maxPriceCalculation?.calculations[maxPriceCalculation.index].calculation_variables
+                    .apartment_share_of_housing_company_loans &&
+            maxPriceCalculation
+        )
+            setIsLoanValueChanged(true);
+        else setIsLoanValueChanged(false);
+    }, [
+        formData.apartment_share_of_housing_company_loans,
+        maxPriceCalculation,
+        setIsLoanValueChanged,
+        isLoanValueChanged,
+    ]);
+    console.log(maxPriceCalculation);
+    console.log(formData);
     return (
         <>
             <div className="field-sets">
@@ -113,18 +166,20 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
                         <FormInputField
                             inputType="date"
                             label="Ilmoituspäivämäärä"
-                            fieldPath="notificationDate"
+                            fieldPath="notification_date"
                             formData={formData}
                             setFormData={setFormData}
                             error={error}
+                            required
                         />
                         <FormInputField
                             inputType="date"
                             label="Kauppakirjan päivämäärä"
-                            fieldPath="apartmentSaleDate"
+                            fieldPath="purchase_date"
                             formData={formData}
                             setFormData={setFormData}
                             error={error}
+                            required
                         />
                     </div>
                     <div className="row">
@@ -134,10 +189,11 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
                                 label="Kauppahinta"
                                 unit="€"
                                 fractionDigits={2}
-                                fieldPath="purchasePrice"
+                                fieldPath="purchase_price"
                                 formData={formData}
                                 setFormData={setFormData}
                                 error={error}
+                                required
                             />
                             <div className="error-message error-text">
                                 <span style={{display: isTooHighPrice ? "block" : "none"}}>
@@ -146,24 +202,32 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
                                 </span>
                             </div>
                         </div>
-                        <FormInputField
-                            inputType="number"
-                            label="Osuus yhtiön lainoista"
-                            unit="€"
-                            fractionDigits={2}
-                            fieldPath="apartment_share_of_housing_company_loans"
-                            formData={formData}
-                            setFormData={setFormData}
-                            error={error}
-                        />
+                        <div>
+                            <FormInputField
+                                inputType="number"
+                                label="Osuus yhtiön lainoista"
+                                unit="€"
+                                fractionDigits={2}
+                                fieldPath="apartment_share_of_housing_company_loans"
+                                formData={formData}
+                                setFormData={setFormData}
+                                error={error}
+                                required
+                            />
+                            <div className="error-message error-text">
+                                <span style={{display: isLoanValueChanged ? "block" : "none"}}>
+                                    Lainaosuus muuttui, tee uusi laskelma!
+                                </span>
+                            </div>
+                        </div>
                     </div>
                     <Checkbox
                         id="exclude-from-stats"
                         label="Ei tilastoihin (esim. sukulaiskauppa)"
-                        checked={isExcludedFromStatistics}
-                        onChange={onCheckboxChange}
+                        checked={isExcludedFromStats}
+                        onChange={(event) => onCheckboxChange(event)}
                     />
-                    {hasValidCalculation ? (
+                    {maxPriceCalculation ? (
                         <div className="max-prices">
                             <div className="row row--max-prices">
                                 <div className="fieldset--max-prices__value">
@@ -183,16 +247,26 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
                             </div>
                             <div className="row row--buttons">
                                 <p>
-                                    Enimmäishinnat
+                                    Enimmäishinnat{" "}
                                     <span>
                                         {formatDate(apartment.prices.maximum_prices.confirmed?.confirmed_at as string)}
-                                    </span>
+                                    </span>{" "}
                                     vahvistetusta enimmäishintalaskelmasta (peruste:
-                                    <span> {formatIndex(data ? data.index : maxPriceQuery?.index)}</span>).
+                                    <span>
+                                        {" "}
+                                        {formatIndex(maxPriceData ? maxPriceData.index : maxPriceCalculation.index)}
+                                    </span>
+                                    ).
+                                    {isLoanValueChanged && (
+                                        <span>
+                                            <br />
+                                            Lainaosuus eri kuin laskelmassa!
+                                        </span>
+                                    )}
                                 </p>
                                 <Button
                                     theme="black"
-                                    variant="secondary"
+                                    variant={isLoanValueChanged ? "primary" : "secondary"}
                                     onClick={handleCalculateButton}
                                 >
                                     Tee uusi enimmäishintalaskelma
@@ -246,18 +320,18 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
                     title="Vahvistetaanko enimmäishintalaskelma?"
                 />
                 <QueryStateHandler
-                    data={data}
-                    error={error}
-                    isLoading={isLoading}
+                    data={maxPriceData}
+                    error={maxPriceError}
+                    isLoading={isMaxPriceLoading}
                     errorComponent={
                         <MaximumPriceModalError
-                            error={error}
+                            error={maxPriceError}
                             setIsModalVisible={setIsModalVisible}
                         />
                     }
                 >
                     <MaximumPriceModalContent
-                        calculation={data as IApartmentMaximumPrice}
+                        calculation={maxPriceData as IApartmentMaximumPrice}
                         apartment={apartment}
                         setIsModalVisible={setIsModalVisible}
                     />
@@ -265,6 +339,47 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
             </Dialog>
         </>
     );
+};
+
+const MaxPriceCalculationLoader = ({apartment}) => {
+    const hasValidCalculation = apartment.prices.maximum_prices.confirmed?.valid.is_valid;
+
+    const {data, error, isLoading} = useGetApartmentMaximumPriceQuery({
+        housingCompanyId: apartment.links.housing_company.id,
+        apartmentId: apartment.id,
+        priceId: apartment.prices.maximum_prices.confirmed?.id as string,
+    });
+
+    if (hasValidCalculation) {
+        return (
+            <QueryStateHandler
+                data={data}
+                error={error}
+                isLoading={isLoading}
+            >
+                <Heading type="main">
+                    Uusi kauppa
+                    <span>({formatAddress(apartment.address)})</span>
+                </Heading>
+                <LoadedApartmentSalesPage
+                    maxPriceCalculation={data as IApartmentMaximumPrice}
+                    apartment={apartment}
+                />
+            </QueryStateHandler>
+        );
+    } else
+        return (
+            <>
+                <Heading type="main">
+                    Uusi kauppa
+                    <span>({formatAddress(apartment.address)})</span>
+                </Heading>
+                <LoadedApartmentSalesPage
+                    maxPriceCalculation={null}
+                    apartment={apartment}
+                />
+            </>
+        );
 };
 
 const ApartmentSalesPage = () => {
@@ -281,11 +396,7 @@ const ApartmentSalesPage = () => {
                 error={error}
                 isLoading={isLoading}
             >
-                <Heading type="main">
-                    Uusi kauppa
-                    <span>({data && formatAddress(data.address as IApartmentAddress)})</span>
-                </Heading>
-                <LoadedApartmentSalesPage apartment={data as IApartmentDetails} />
+                <MaxPriceCalculationLoader apartment={data as IApartmentDetails} />
             </QueryStateHandler>
         </div>
     );

--- a/frontend/src/styles/base/_general.sass
+++ b/frontend/src/styles/base/_general.sass
@@ -63,7 +63,7 @@ ul, ol
   gap: 10px
 
 .error-text
-  color: var(--color-error)
+  color: var(--color-error) !important
 
 [class*="checkbox_hds-checkbox"]
   --background-unselected: white

--- a/frontend/src/styles/base/_general.sass
+++ b/frontend/src/styles/base/_general.sass
@@ -68,3 +68,6 @@ ul, ol
 [class*="checkbox_hds-checkbox"]
   --background-unselected: white
   --background-selected: black
+
+[class*="notification_hds-notification--error"] span
+  font-weight: 700

--- a/frontend/src/styles/components/_ApartmentSalesPage.sass
+++ b/frontend/src/styles/components/_ApartmentSalesPage.sass
@@ -31,9 +31,11 @@
           span
             font-weight: bold
             font-size: $fontsize-body-xl
-
           &.expired span
-            color: $color-black-20 !important
+            color: $color-black-40 !important
+            text-decoration: line-through
+        .error-text
+          margin: -1rem 0 0
       &.ownerships-fieldset
         grid-row: 1 / span 2
         grid-column: 2

--- a/frontend/src/styles/components/_ApartmentSalesPage.sass
+++ b/frontend/src/styles/components/_ApartmentSalesPage.sass
@@ -28,9 +28,15 @@
           justify-content: space-between
         p > span
           font-weight: bold
-        .fieldset--max-prices__value span
-          font-weight: bold
-          font-size: $fontsize-body-xl
+        .fieldset--max-prices__value
+          span
+            font-weight: bold
+            font-size: $fontsize-body-xl
+          &.expired
+            color: $color-black-30
+          &.expired span
+            text-decoration: line-through
+            color: $color-black-30 !important
       &.ownerships-fieldset
         @include flexbox()
         @include flex-flow(column nowrap)

--- a/frontend/src/styles/components/_ApartmentSalesPage.sass
+++ b/frontend/src/styles/components/_ApartmentSalesPage.sass
@@ -13,6 +13,7 @@
     grid-template-columns: 55% 45%
     gap: 1em
     fieldset
+      position: relative
       background-color: $color-engel-medium-light
       padding: $spacing-s
       width: 100%
@@ -21,6 +22,8 @@
         padding-top: $spacing-s
         .row--buttons
           margin-bottom: 0
+          button
+            min-width: 300px
         .row--max-prices
           justify-content: space-between
         p > span
@@ -28,6 +31,13 @@
         .fieldset--max-prices__value span
           font-weight: bold
           font-size: $fontsize-body-xl
+      &.ownerships-fieldset
+        @include flexbox()
+        @include flex-flow(column nowrap)
+        @include justify-content(space-between)
+        .error-text
+          text-align: center
+          margin-bottom: $spacing-s
     legend[class*="hds"]
       background-color: $color-engel-medium-light
       padding: $spacing-s
@@ -43,7 +53,7 @@
         svg
           position: absolute
           right: 1rem
-          top: 2.25rem
+          top: 2.5rem
           transform: translateY(2px)
       &--prompt
         flex-flow: column nowrap

--- a/frontend/src/styles/components/_ApartmentSalesPage.sass
+++ b/frontend/src/styles/components/_ApartmentSalesPage.sass
@@ -17,9 +17,8 @@
       background-color: $color-engel-medium-light
       padding: $spacing-s
       width: 100%
-      grid-row: 1
+      grid-column: 1
       .max-prices
-        padding-top: $spacing-s
         .row--buttons
           margin-bottom: 0
           button
@@ -32,12 +31,12 @@
           span
             font-weight: bold
             font-size: $fontsize-body-xl
-          &.expired
-            color: $color-black-30
+
           &.expired span
-            text-decoration: line-through
-            color: $color-black-30 !important
+            color: $color-black-20 !important
       &.ownerships-fieldset
+        grid-row: 1 / span 2
+        grid-column: 2
         @include flexbox()
         @include flex-flow(column nowrap)
         @include justify-content(space-between)

--- a/frontend/src/styles/components/_CreatePage.sass
+++ b/frontend/src/styles/components/_CreatePage.sass
@@ -36,8 +36,7 @@
       height: 20px
       z-index: 1
 
-    .input-field--required label
-      font-weight: 700
+
 
     .input-field--date
       position: relative
@@ -66,15 +65,6 @@
     @include flexbox()
     position: relative
     gap: 1em
-
-    label
-      height: 21px
-      white-space: nowrap
-      position: absolute
-      top: 0
-
-      & + div
-        padding-top: 25px
 
     .owner
       @include flex-grow(1)

--- a/frontend/src/styles/components/_Forms.sass
+++ b/frontend/src/styles/components/_Forms.sass
@@ -1,6 +1,9 @@
 @use "../imports" as *
 
-[class*="input-field--invalid"]
+.input-field--invalid
   [class*="text-input_hds-text-input"]
     border-color: $color-error !important
+
+.input-field--required label
+  font-weight: 700
 

--- a/frontend/src/styles/components/_OwnershipsList.sass
+++ b/frontend/src/styles/components/_OwnershipsList.sass
@@ -1,0 +1,14 @@
+@use "../imports" as *
+
+.ownership
+  &-headings
+    font-weight: 700
+  &s-list > div
+    svg
+      display: none
+    &.error-text svg
+      display: inline-block
+      margin: 0 $spacing-s
+      vertical-align: middle
+  &-item label
+    display: none

--- a/frontend/src/styles/components/index.sass
+++ b/frontend/src/styles/components/index.sass
@@ -9,3 +9,4 @@
 @forward "HousingCompanyList"
 @forward "HousingCompanyPage"
 @forward "ImprovementsTable"
+@forward "OwnershipsList"


### PR DESCRIPTION
# Hitas Pull Request

# Description

Integrates the sales page mockup to the API, for full functionality. Populates the form with relevant values where possible, and implements requested checks on the form values. 
Adds improvements/features to existing components (e.g. adds the `disabled` property to our custom Button elements, adds/moves functions to utils.js, allows for passing a JSX element into hitasToast as message etc).
Also improves on the FormOwnershipInputField with an error message in natural language, and fixes a bug where the success hitasToast for adding an owner was triggered when it shouldn't have been.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [X] Changes have been tested

## Test plan

Go to the detail page of an apartment which doesn't have a valid maximum price calculation, and click "Kauppatapahtuma". 
The date in the first field should be today's date, and the "Enimmäishintalaskelma" box should display a text, prompting the user to fill in the required fields and make a maximum price calculation. 
If the calculation button is clicked, but the requested fields aren't filled there is a hitasToast prompt informing the user about the error (there's also a possibility to have the button disabled until said fields are populated - but this needs to be checked/tested by the PO). Otherwise the maximum price calculation breakdown dialog shows, like in the maximum price view.
After saving the calculation, the "Enimmäishintalaskelma" box displays the maximum price values, and a text with the index and debt amount used for the calculation. If you now change the value in "Osuus yhtiön lainoista", the input field should show an error text informing the user that the debt amount does not match the one used in the max price calculation. In the box below, the values should be grayed out, and there's an added text in red, prompting the user to make a new calculation. The button should be highlighted. Making a new max price calculation (or changing the debt amount value to the one used in the calculation) gets rid of the error notifications.
If the value in "Kauppahinta" exceeds the "Enimmäishinta" in the box below, the input field shows an error, and a text is displayed below it. Also, the value in "Enimmäishinta" is highlighted with the error color.
If there are no owners and the user tries to save the sale, the "Omistajuudet" box shows an error notification, and there is a hitasToast with an error message. A sale can also not be saved without a value in the "Kauppahinta" input field.
Upon a successful save, the user is taken back to the apartment's detail page, and there is a success hitasToast. The page should be updated with new values from the sale (ownerships).

The ownership addition error message should now be more informative, as it shows the error message in natural language. I also noticed a bug where after you added a user in the ownerships dialog, the hitasToast for successfully adding a user was triggering every time you added an empty ownership line. Now it also checks that the added ownership line contains the new owner data, thus not triggering on empty ownership lines.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-54, HT-390, HT-382, HT-365, HT-385