### PR TITLE
Add condition of sale filter to apartment list

### DIFF
--- a/backend/hitas/tests/apis/test_api_apartment_list.py
+++ b/backend/hitas/tests/apis/test_api_apartment_list.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from django.utils.http import urlencode
 from rest_framework import status
 
-from hitas.models import Apartment, HousingCompany, Ownership
+from hitas.models import Apartment, ConditionOfSale, HousingCompany, Ownership
 from hitas.models.apartment import ApartmentState
 from hitas.tests.apis.helpers import HitasAPIClient
 from hitas.tests.factories import ApartmentFactory, ConditionOfSaleFactory, HousingCompanyFactory, OwnershipFactory
@@ -192,9 +192,17 @@ def test__api__apartment__filter(api_client: HitasAPIClient, selected_filter, nu
     hc = HousingCompanyFactory.create(postal_code__value="99999")
     ApartmentFactory.create(building__real_estate__housing_company=hc)
 
-    old_apartment = ApartmentFactory.create(state=ApartmentState.FREE)
-    new_apartment = ApartmentFactory.create(state=ApartmentState.FREE, first_purchase_date=None)
-    ConditionOfSaleFactory(new_ownership__apartment=new_apartment, old_ownership__apartment=old_apartment)
+    old_apartment_1: Apartment = ApartmentFactory.create(state=ApartmentState.FREE)
+    new_apartment_1: Apartment = ApartmentFactory.create(state=ApartmentState.FREE, first_purchase_date=None)
+    ConditionOfSaleFactory(new_ownership__apartment=new_apartment_1, old_ownership__apartment=old_apartment_1)
+
+    old_apartment_2: Apartment = ApartmentFactory.create(state=ApartmentState.FREE)
+    new_apartment_2: Apartment = ApartmentFactory.create(state=ApartmentState.FREE, first_purchase_date=None)
+    cos: ConditionOfSale = ConditionOfSaleFactory(
+        new_ownership__apartment=new_apartment_2,
+        old_ownership__apartment=old_apartment_2,
+    )
+    cos.delete()  # fulfill condition of sale
 
     url = reverse("hitas:apartment-list") + "?" + urlencode(selected_filter)
     response = api_client.get(url)

--- a/backend/hitas/views/apartment_list.py
+++ b/backend/hitas/views/apartment_list.py
@@ -104,7 +104,14 @@ class ApartmentListViewSet(HitasModelMixin, mixins.ListModelMixin, viewsets.Gene
             )
             .alias(
                 number_of_conditions_of_sale=(
-                    Count("ownerships__conditions_of_sale_new") + Count("ownerships__conditions_of_sale_old")
+                    Count(
+                        "ownerships__conditions_of_sale_new",
+                        filter=Q(ownerships__conditions_of_sale_new__deleted__isnull=True),
+                    )
+                    + Count(
+                        "ownerships__conditions_of_sale_old",
+                        filter=Q(ownerships__conditions_of_sale_old__deleted__isnull=True),
+                    )
                 ),
             )
             .annotate(

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1736,6 +1736,13 @@ paths:
             type: string
             maxLength: 11
             example: 131052-308T
+        - name: sales_condition
+          description: Filter apartments based on whether there are conditions of sale for its ownerships or not
+          required: false
+          in: query
+          schema:
+            type: boolean
+            example: true
       responses:
         '200':
           description: Successfully fetched list of apartments


### PR DESCRIPTION
# Hitas Pull Request

# Description

Add a filter to the apartments list endpoint for filtering apartments based on whether there are conditions of sale for its ownerships or not.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [x] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- [x] Automatic tests
- [x] Create conditions of sale and then use the new filter through the API directly

## Tickets

This pull request resolves all or part of the following ticket(s): HT-171
