### PR TITLE
Add sell_by_date to apartment endpoint based on its conditions of sale

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3740,6 +3740,7 @@ components:
         - ownerships
         - links
         - conditions_of_sale
+        - sell_by_date
       properties:
         id:
           description: Apartment ID
@@ -3785,6 +3786,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ConditionOfSale'
+        sell_by_date:
+          description: |-
+            The date when this apartment needs to be sold to fulfill a condition of sale linked to this apartment's
+            ownership(s). In case of multiple conditions of sale, use the first one in chronological order.
+            The value will be null if there are no current conditions of sale for this apartment's ownerships.
+          type: string
+          format: date
+          nullable: true
+          readOnly: true
 
     ApartmentList:
       description: Single apartment
@@ -3856,6 +3866,7 @@ components:
         - notes
         - improvements
         - conditions_of_sale
+        - sell_by_date
       properties:
         id:
           description: Apartment ID
@@ -4015,6 +4026,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ConditionOfSale'
+        sell_by_date:
+          description: |-
+            The date when this apartment needs to be sold to fulfill a condition of sale linked to this apartment's
+            ownership(s). In case of multiple conditions of sale, use the first one in chronological order.
+            The value will be null if there are no current conditions of sale for this apartment's ownerships.
+          type: string
+          format: date
+          nullable: true
+          readOnly: true
 
     ApartmentMaximumPriceCalculation:
       description: Calculations for particular index


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds `sell_by_date` to apartment endpoint based on its conditions of sale.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [x] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- [x] Automatic tests
- [x] Create conditions of sale for apartments with different grace periods and look at the `sell_by_date` on apartment endpoints. `sell_by_date` should always be determined based on the new apartment in the condition of sale.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-420
