### PR TITLE
Fix latest sales migration

### DIFF
--- a/backend/hitas/oracle_migration/runner.py
+++ b/backend/hitas/oracle_migration/runner.py
@@ -972,7 +972,7 @@ def create_apartment_sales(connection: Connection, converted_data: ConvertedData
                 owner=buyer,
                 sale=new,
                 percentage=100 / len(buyers),  # Assume equal split, as there is no way to know the real percentages
-                deleted=timezone.now() if is_latest_sale else None,  # We only want the latest sale to be non-deleted
+                deleted=timezone.now() if not is_latest_sale else None,  # Delete all but the latest ownerships
             )
             for buyer in buyers
         ]

--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -72,18 +72,6 @@ def test__api__housing_company__list(api_client: HitasAPIClient):
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert response.json()["contents"] == [
         {
-            "id": hc1.uuid.hex,
-            "name": hc1.display_name,
-            "state": hc1.state.value,
-            "address": {
-                "street_address": hc1.street_address,
-                "postal_code": hc1.postal_code.value,
-                "city": hc1.postal_code.city,
-            },
-            "area": {"name": hc1.postal_code.city, "cost_area": hc1.postal_code.cost_area},
-            "date": str(ap2.completion_date),
-        },
-        {
             "id": hc2.uuid.hex,
             "name": hc2.display_name,
             "state": hc2.state.value,
@@ -94,6 +82,18 @@ def test__api__housing_company__list(api_client: HitasAPIClient):
             },
             "area": {"name": hc2.postal_code.city, "cost_area": hc2.postal_code.cost_area},
             "date": None,
+        },
+        {
+            "id": hc1.uuid.hex,
+            "name": hc1.display_name,
+            "state": hc1.state.value,
+            "address": {
+                "street_address": hc1.street_address,
+                "postal_code": hc1.postal_code.value,
+                "city": hc1.postal_code.city,
+            },
+            "area": {"name": hc1.postal_code.city, "cost_area": hc1.postal_code.cost_area},
+            "date": str(ap2.completion_date),
         },
     ]
     assert response.json()["page"] == {
@@ -1012,8 +1012,8 @@ def test__api__housing_company__filter__new_hitas__false(api_client: HitasAPICli
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert len(response.json()["contents"]) == 3, response.json()
     assert response.json()["contents"][0]["id"] == apartment_just_before_2011.housing_company.uuid.hex
-    assert response.json()["contents"][1]["id"] == apartment_2009.housing_company.uuid.hex
-    assert response.json()["contents"][2]["id"] == hc_both_old_and_new.uuid.hex
+    assert response.json()["contents"][1]["id"] == hc_both_old_and_new.uuid.hex
+    assert response.json()["contents"][2]["id"] == apartment_2009.housing_company.uuid.hex
 
 
 @pytest.mark.django_db

--- a/backend/hitas/views/housing_company.py
+++ b/backend/hitas/views/housing_company.py
@@ -262,17 +262,8 @@ class HousingCompanyViewSet(HitasModelViewSet):
     def get_list_queryset(self):
         return (
             HousingCompany.objects.select_related("postal_code")
-            .only(
-                "uuid",
-                "display_name",
-                "state",
-                "street_address",
-                "postal_code__value",
-                "postal_code__city",
-                "postal_code__cost_area",
-            )
             .annotate(date=Min("real_estates__buildings__apartments__completion_date"))
-            .order_by("id")
+            .order_by("-date")
         )
 
     def get_detail_queryset(self):


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Add a missing `not` to the conditional, which was incorrectly deleting new ownerships and keeping the old ones.
- Order Housing Companies in the API by completed on date instead of ID. This way newest companies are listed first by default which is the preferred behaviour

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [x] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- Run the migration on your local pc to find that no duplicate ownerships are created anymore :)

## Tickets

This pull request resolves all or part of the following ticket(s): -
