### PR TITLE
Display conditions of sale

### DIFF
--- a/backend/hitas/models/condition_of_sale.py
+++ b/backend/hitas/models/condition_of_sale.py
@@ -75,6 +75,15 @@ def condition_of_sale_queryset() -> models.QuerySet[ConditionOfSale]:
             "new_ownership__apartment",
             "old_ownership__owner",
             "old_ownership__apartment",
+            # New stuff
+            "new_ownership__apartment__building",
+            "old_ownership__apartment__building",
+            "new_ownership__apartment__building__real_estate",
+            "old_ownership__apartment__building__real_estate",
+            "new_ownership__apartment__building__real_estate__housing_company",
+            "old_ownership__apartment__building__real_estate__housing_company",
+            "new_ownership__apartment__building__real_estate__housing_company__postal_code",
+            "old_ownership__apartment__building__real_estate__housing_company__postal_code",
         )
         .only(
             "id",
@@ -113,5 +122,15 @@ def condition_of_sale_queryset() -> models.QuerySet[ConditionOfSale]:
             "old_ownership__owner__name",
             "old_ownership__owner__identifier",
             "old_ownership__owner__email",
+            # Housing company info
+            "new_ownership__apartment__building__real_estate__housing_company__uuid",
+            "old_ownership__apartment__building__real_estate__housing_company__uuid",
+            "new_ownership__apartment__building__real_estate__housing_company__display_name",
+            "old_ownership__apartment__building__real_estate__housing_company__display_name",
+            # Address info
+            "new_ownership__apartment__building__real_estate__housing_company__postal_code__value",
+            "old_ownership__apartment__building__real_estate__housing_company__postal_code__value",
+            "new_ownership__apartment__building__real_estate__housing_company__postal_code__city",
+            "old_ownership__apartment__building__real_estate__housing_company__postal_code__city",
         )
     )

--- a/backend/hitas/models/condition_of_sale.py
+++ b/backend/hitas/models/condition_of_sale.py
@@ -75,7 +75,6 @@ def condition_of_sale_queryset() -> models.QuerySet[ConditionOfSale]:
             "new_ownership__apartment",
             "old_ownership__owner",
             "old_ownership__apartment",
-            # New stuff
             "new_ownership__apartment__building",
             "old_ownership__apartment__building",
             "new_ownership__apartment__building__real_estate",

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -167,10 +167,14 @@ def test__api__apartment__list(api_client: HitasAPIClient):
                         "fulfilled": cos.fulfilled,
                         "apartment": {
                             "id": ap3.uuid.hex,
-                            "street_address": ap3.street_address,
-                            "apartment_number": ap3.apartment_number,
-                            "floor": ap3.floor,
-                            "stair": ap3.stair,
+                            "address": {
+                                "street_address": ap3.street_address,
+                                "apartment_number": ap3.apartment_number,
+                                "floor": ap3.floor,
+                                "stair": ap3.stair,
+                                "city": "Helsinki",
+                                "postal_code": ap3.postal_code.value,
+                            },
                             "housing_company": {
                                 "id": ap3.housing_company.uuid.hex,
                                 "display_name": ap3.housing_company.display_name,
@@ -674,10 +678,14 @@ def test__api__apartment__retrieve(api_client: HitasAPIClient):
                 "fulfilled": cos.fulfilled,
                 "apartment": {
                     "id": ap2.uuid.hex,
-                    "street_address": ap2.street_address,
-                    "apartment_number": ap2.apartment_number,
-                    "floor": ap2.floor,
-                    "stair": ap2.stair,
+                    "address": {
+                        "street_address": ap2.street_address,
+                        "apartment_number": ap2.apartment_number,
+                        "floor": ap2.floor,
+                        "stair": ap2.stair,
+                        "city": "Helsinki",
+                        "postal_code": ap2.postal_code.value,
+                    },
                     "housing_company": {
                         "id": ap2.housing_company.uuid.hex,
                         "display_name": ap2.housing_company.display_name,

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -171,6 +171,10 @@ def test__api__apartment__list(api_client: HitasAPIClient):
                             "apartment_number": ap3.apartment_number,
                             "floor": ap3.floor,
                             "stair": ap3.stair,
+                            "housing_company": {
+                                "id": ap3.housing_company.uuid.hex,
+                                "display_name": ap3.housing_company.display_name,
+                            },
                         },
                         "owner": {
                             "id": o3.owner.uuid.hex,
@@ -674,6 +678,10 @@ def test__api__apartment__retrieve(api_client: HitasAPIClient):
                     "apartment_number": ap2.apartment_number,
                     "floor": ap2.floor,
                     "stair": ap2.stair,
+                    "housing_company": {
+                        "id": ap2.housing_company.uuid.hex,
+                        "display_name": ap2.housing_company.display_name,
+                    },
                 },
                 "owner": {
                     "id": os2.owner.uuid.hex,

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -165,37 +165,18 @@ def test__api__apartment__list(api_client: HitasAPIClient):
                         "id": cos.uuid.hex,
                         "grace_period": str(cos.grace_period.value),
                         "fulfilled": cos.fulfilled,
-                        "new_ownership": {
-                            "percentage": float(o3.percentage),
-                            "apartment": {
-                                "id": ap3.uuid.hex,
-                                "street_address": ap3.street_address,
-                                "apartment_number": ap3.apartment_number,
-                                "floor": ap3.floor,
-                                "stair": ap3.stair,
-                            },
-                            "owner": {
-                                "id": o3.owner.uuid.hex,
-                                "name": o3.owner.name,
-                                "identifier": o3.owner.identifier,
-                                "email": o3.owner.email,
-                            },
+                        "apartment": {
+                            "id": ap3.uuid.hex,
+                            "street_address": ap3.street_address,
+                            "apartment_number": ap3.apartment_number,
+                            "floor": ap3.floor,
+                            "stair": ap3.stair,
                         },
-                        "old_ownership": {
-                            "percentage": float(o2.percentage),
-                            "apartment": {
-                                "id": ap1.uuid.hex,
-                                "street_address": ap1.street_address,
-                                "apartment_number": ap1.apartment_number,
-                                "floor": ap1.floor,
-                                "stair": ap1.stair,
-                            },
-                            "owner": {
-                                "id": o2.owner.uuid.hex,
-                                "name": o2.owner.name,
-                                "identifier": o2.owner.identifier,
-                                "email": o2.owner.email,
-                            },
+                        "owner": {
+                            "id": o3.owner.uuid.hex,
+                            "name": o3.owner.name,
+                            "identifier": o3.owner.identifier,
+                            "email": o3.owner.email,
                         },
                     }
                 ],
@@ -687,37 +668,18 @@ def test__api__apartment__retrieve(api_client: HitasAPIClient):
                 "id": cos.uuid.hex,
                 "grace_period": str(cos.grace_period.value),
                 "fulfilled": cos.fulfilled,
-                "new_ownership": {
-                    "percentage": float(os2.percentage),
-                    "apartment": {
-                        "id": ap2.uuid.hex,
-                        "street_address": ap2.street_address,
-                        "apartment_number": ap2.apartment_number,
-                        "floor": ap2.floor,
-                        "stair": ap2.stair,
-                    },
-                    "owner": {
-                        "id": os2.owner.uuid.hex,
-                        "name": os2.owner.name,
-                        "identifier": os2.owner.identifier,
-                        "email": os2.owner.email,
-                    },
+                "apartment": {
+                    "id": ap2.uuid.hex,
+                    "street_address": ap2.street_address,
+                    "apartment_number": ap2.apartment_number,
+                    "floor": ap2.floor,
+                    "stair": ap2.stair,
                 },
-                "old_ownership": {
-                    "percentage": float(os1.percentage),
-                    "apartment": {
-                        "id": ap1.uuid.hex,
-                        "street_address": ap1.street_address,
-                        "apartment_number": ap1.apartment_number,
-                        "floor": ap1.floor,
-                        "stair": ap1.stair,
-                    },
-                    "owner": {
-                        "id": os1.owner.uuid.hex,
-                        "name": os1.owner.name,
-                        "identifier": os1.owner.identifier,
-                        "email": os1.owner.email,
-                    },
+                "owner": {
+                    "id": os2.owner.uuid.hex,
+                    "name": os2.owner.name,
+                    "identifier": os2.owner.identifier,
+                    "email": os2.owner.email,
                 },
             }
         ],

--- a/backend/hitas/tests/apis/test_api_condition_of_sale.py
+++ b/backend/hitas/tests/apis/test_api_condition_of_sale.py
@@ -43,46 +43,54 @@ def test__api__condition_of_sale__list__empty(api_client: HitasAPIClient):
 
 @pytest.mark.django_db
 def test__api__condition_of_sale__list__single(api_client: HitasAPIClient):
-    condition_of_sale: ConditionOfSale = ConditionOfSaleFactory.create()
+    cos: ConditionOfSale = ConditionOfSaleFactory.create()
 
     url = reverse("hitas:conditions-of-sale-list")
     response = api_client.get(url)
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert response.json()["contents"] == [
         {
-            "id": condition_of_sale.uuid.hex,
-            "grace_period": str(condition_of_sale.grace_period.value),
-            "fulfilled": condition_of_sale.fulfilled,
+            "id": cos.uuid.hex,
+            "grace_period": str(cos.grace_period.value),
+            "fulfilled": cos.fulfilled,
             "new_ownership": {
-                "percentage": float(condition_of_sale.new_ownership.percentage),
+                "percentage": float(cos.new_ownership.percentage),
                 "apartment": {
-                    "id": condition_of_sale.new_ownership.apartment.uuid.hex,
-                    "street_address": condition_of_sale.new_ownership.apartment.street_address,
-                    "apartment_number": condition_of_sale.new_ownership.apartment.apartment_number,
-                    "floor": condition_of_sale.new_ownership.apartment.floor,
-                    "stair": condition_of_sale.new_ownership.apartment.stair,
+                    "id": cos.new_ownership.apartment.uuid.hex,
+                    "street_address": cos.new_ownership.apartment.street_address,
+                    "apartment_number": cos.new_ownership.apartment.apartment_number,
+                    "floor": cos.new_ownership.apartment.floor,
+                    "stair": cos.new_ownership.apartment.stair,
+                    "housing_company": {
+                        "id": cos.new_ownership.apartment.housing_company.uuid.hex,
+                        "display_name": cos.new_ownership.apartment.housing_company.display_name,
+                    },
                 },
                 "owner": {
-                    "id": condition_of_sale.new_ownership.owner.uuid.hex,
-                    "name": condition_of_sale.new_ownership.owner.name,
-                    "identifier": condition_of_sale.new_ownership.owner.identifier,
-                    "email": condition_of_sale.new_ownership.owner.email,
+                    "id": cos.new_ownership.owner.uuid.hex,
+                    "name": cos.new_ownership.owner.name,
+                    "identifier": cos.new_ownership.owner.identifier,
+                    "email": cos.new_ownership.owner.email,
                 },
             },
             "old_ownership": {
-                "percentage": float(condition_of_sale.old_ownership.percentage),
+                "percentage": float(cos.old_ownership.percentage),
                 "apartment": {
-                    "id": condition_of_sale.old_ownership.apartment.uuid.hex,
-                    "street_address": condition_of_sale.old_ownership.apartment.street_address,
-                    "apartment_number": condition_of_sale.old_ownership.apartment.apartment_number,
-                    "floor": condition_of_sale.old_ownership.apartment.floor,
-                    "stair": condition_of_sale.old_ownership.apartment.stair,
+                    "id": cos.old_ownership.apartment.uuid.hex,
+                    "street_address": cos.old_ownership.apartment.street_address,
+                    "apartment_number": cos.old_ownership.apartment.apartment_number,
+                    "floor": cos.old_ownership.apartment.floor,
+                    "stair": cos.old_ownership.apartment.stair,
+                    "housing_company": {
+                        "id": cos.old_ownership.apartment.housing_company.uuid.hex,
+                        "display_name": cos.old_ownership.apartment.housing_company.display_name,
+                    },
                 },
                 "owner": {
-                    "id": condition_of_sale.old_ownership.owner.uuid.hex,
-                    "name": condition_of_sale.old_ownership.owner.name,
-                    "identifier": condition_of_sale.old_ownership.owner.identifier,
-                    "email": condition_of_sale.old_ownership.owner.email,
+                    "id": cos.old_ownership.owner.uuid.hex,
+                    "name": cos.old_ownership.owner.name,
+                    "identifier": cos.old_ownership.owner.identifier,
+                    "email": cos.old_ownership.owner.email,
                 },
             },
         }
@@ -101,84 +109,100 @@ def test__api__condition_of_sale__list__single(api_client: HitasAPIClient):
 
 @pytest.mark.django_db
 def test__api__condition_of_sale__list__multiple(api_client: HitasAPIClient):
-    condition_of_sale_1: ConditionOfSale = ConditionOfSaleFactory.create()
-    condition_of_sale_2: ConditionOfSale = ConditionOfSaleFactory.create()
+    cos_1: ConditionOfSale = ConditionOfSaleFactory.create()
+    cos_2: ConditionOfSale = ConditionOfSaleFactory.create()
 
     url = reverse("hitas:conditions-of-sale-list")
     response = api_client.get(url)
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert response.json()["contents"] == [
         {
-            "id": condition_of_sale_1.uuid.hex,
-            "grace_period": str(condition_of_sale_1.grace_period.value),
-            "fulfilled": condition_of_sale_1.fulfilled,
+            "id": cos_1.uuid.hex,
+            "grace_period": str(cos_1.grace_period.value),
+            "fulfilled": cos_1.fulfilled,
             "new_ownership": {
-                "percentage": float(condition_of_sale_1.new_ownership.percentage),
+                "percentage": float(cos_1.new_ownership.percentage),
                 "apartment": {
-                    "id": condition_of_sale_1.new_ownership.apartment.uuid.hex,
-                    "street_address": condition_of_sale_1.new_ownership.apartment.street_address,
-                    "apartment_number": condition_of_sale_1.new_ownership.apartment.apartment_number,
-                    "floor": condition_of_sale_1.new_ownership.apartment.floor,
-                    "stair": condition_of_sale_1.new_ownership.apartment.stair,
+                    "id": cos_1.new_ownership.apartment.uuid.hex,
+                    "street_address": cos_1.new_ownership.apartment.street_address,
+                    "apartment_number": cos_1.new_ownership.apartment.apartment_number,
+                    "floor": cos_1.new_ownership.apartment.floor,
+                    "stair": cos_1.new_ownership.apartment.stair,
+                    "housing_company": {
+                        "id": cos_1.new_ownership.apartment.housing_company.uuid.hex,
+                        "display_name": cos_1.new_ownership.apartment.housing_company.display_name,
+                    },
                 },
                 "owner": {
-                    "id": condition_of_sale_1.new_ownership.owner.uuid.hex,
-                    "name": condition_of_sale_1.new_ownership.owner.name,
-                    "identifier": condition_of_sale_1.new_ownership.owner.identifier,
-                    "email": condition_of_sale_1.new_ownership.owner.email,
+                    "id": cos_1.new_ownership.owner.uuid.hex,
+                    "name": cos_1.new_ownership.owner.name,
+                    "identifier": cos_1.new_ownership.owner.identifier,
+                    "email": cos_1.new_ownership.owner.email,
                 },
             },
             "old_ownership": {
-                "percentage": float(condition_of_sale_1.old_ownership.percentage),
+                "percentage": float(cos_1.old_ownership.percentage),
                 "apartment": {
-                    "id": condition_of_sale_1.old_ownership.apartment.uuid.hex,
-                    "street_address": condition_of_sale_1.old_ownership.apartment.street_address,
-                    "apartment_number": condition_of_sale_1.old_ownership.apartment.apartment_number,
-                    "floor": condition_of_sale_1.old_ownership.apartment.floor,
-                    "stair": condition_of_sale_1.old_ownership.apartment.stair,
+                    "id": cos_1.old_ownership.apartment.uuid.hex,
+                    "street_address": cos_1.old_ownership.apartment.street_address,
+                    "apartment_number": cos_1.old_ownership.apartment.apartment_number,
+                    "floor": cos_1.old_ownership.apartment.floor,
+                    "stair": cos_1.old_ownership.apartment.stair,
+                    "housing_company": {
+                        "id": cos_1.old_ownership.apartment.housing_company.uuid.hex,
+                        "display_name": cos_1.old_ownership.apartment.housing_company.display_name,
+                    },
                 },
                 "owner": {
-                    "id": condition_of_sale_1.old_ownership.owner.uuid.hex,
-                    "name": condition_of_sale_1.old_ownership.owner.name,
-                    "identifier": condition_of_sale_1.old_ownership.owner.identifier,
-                    "email": condition_of_sale_1.old_ownership.owner.email,
+                    "id": cos_1.old_ownership.owner.uuid.hex,
+                    "name": cos_1.old_ownership.owner.name,
+                    "identifier": cos_1.old_ownership.owner.identifier,
+                    "email": cos_1.old_ownership.owner.email,
                 },
             },
         },
         {
-            "id": condition_of_sale_2.uuid.hex,
-            "grace_period": str(condition_of_sale_2.grace_period.value),
-            "fulfilled": condition_of_sale_2.fulfilled,
+            "id": cos_2.uuid.hex,
+            "grace_period": str(cos_2.grace_period.value),
+            "fulfilled": cos_2.fulfilled,
             "new_ownership": {
-                "percentage": float(condition_of_sale_2.new_ownership.percentage),
+                "percentage": float(cos_2.new_ownership.percentage),
                 "apartment": {
-                    "id": condition_of_sale_2.new_ownership.apartment.uuid.hex,
-                    "street_address": condition_of_sale_2.new_ownership.apartment.street_address,
-                    "apartment_number": condition_of_sale_2.new_ownership.apartment.apartment_number,
-                    "floor": condition_of_sale_2.new_ownership.apartment.floor,
-                    "stair": condition_of_sale_2.new_ownership.apartment.stair,
+                    "id": cos_2.new_ownership.apartment.uuid.hex,
+                    "street_address": cos_2.new_ownership.apartment.street_address,
+                    "apartment_number": cos_2.new_ownership.apartment.apartment_number,
+                    "floor": cos_2.new_ownership.apartment.floor,
+                    "stair": cos_2.new_ownership.apartment.stair,
+                    "housing_company": {
+                        "id": cos_2.new_ownership.apartment.housing_company.uuid.hex,
+                        "display_name": cos_2.new_ownership.apartment.housing_company.display_name,
+                    },
                 },
                 "owner": {
-                    "id": condition_of_sale_2.new_ownership.owner.uuid.hex,
-                    "name": condition_of_sale_2.new_ownership.owner.name,
-                    "identifier": condition_of_sale_2.new_ownership.owner.identifier,
-                    "email": condition_of_sale_2.new_ownership.owner.email,
+                    "id": cos_2.new_ownership.owner.uuid.hex,
+                    "name": cos_2.new_ownership.owner.name,
+                    "identifier": cos_2.new_ownership.owner.identifier,
+                    "email": cos_2.new_ownership.owner.email,
                 },
             },
             "old_ownership": {
-                "percentage": float(condition_of_sale_2.old_ownership.percentage),
+                "percentage": float(cos_2.old_ownership.percentage),
                 "apartment": {
-                    "id": condition_of_sale_2.old_ownership.apartment.uuid.hex,
-                    "street_address": condition_of_sale_2.old_ownership.apartment.street_address,
-                    "apartment_number": condition_of_sale_2.old_ownership.apartment.apartment_number,
-                    "floor": condition_of_sale_2.old_ownership.apartment.floor,
-                    "stair": condition_of_sale_2.old_ownership.apartment.stair,
+                    "id": cos_2.old_ownership.apartment.uuid.hex,
+                    "street_address": cos_2.old_ownership.apartment.street_address,
+                    "apartment_number": cos_2.old_ownership.apartment.apartment_number,
+                    "floor": cos_2.old_ownership.apartment.floor,
+                    "stair": cos_2.old_ownership.apartment.stair,
+                    "housing_company": {
+                        "id": cos_2.old_ownership.apartment.housing_company.uuid.hex,
+                        "display_name": cos_2.old_ownership.apartment.housing_company.display_name,
+                    },
                 },
                 "owner": {
-                    "id": condition_of_sale_2.old_ownership.owner.uuid.hex,
-                    "name": condition_of_sale_2.old_ownership.owner.name,
-                    "identifier": condition_of_sale_2.old_ownership.owner.identifier,
-                    "email": condition_of_sale_2.old_ownership.owner.email,
+                    "id": cos_2.old_ownership.owner.uuid.hex,
+                    "name": cos_2.old_ownership.owner.name,
+                    "identifier": cos_2.old_ownership.owner.identifier,
+                    "email": cos_2.old_ownership.owner.email,
                 },
             },
         },
@@ -246,50 +270,58 @@ def test__api__condition_of_sale__list__fulfilled_over_x_months(api_client: Hita
 
 @pytest.mark.django_db
 def test__api__condition_of_sale__retrieve(api_client: HitasAPIClient):
-    condition_of_sale: ConditionOfSale = ConditionOfSaleFactory.create()
+    cos: ConditionOfSale = ConditionOfSaleFactory.create()
 
     url = reverse(
         "hitas:conditions-of-sale-detail",
         kwargs={
-            "uuid": condition_of_sale.uuid.hex,
+            "uuid": cos.uuid.hex,
         },
     )
     response = api_client.get(url)
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert response.json() == {
-        "id": condition_of_sale.uuid.hex,
-        "grace_period": str(condition_of_sale.grace_period.value),
-        "fulfilled": condition_of_sale.fulfilled,
+        "id": cos.uuid.hex,
+        "grace_period": str(cos.grace_period.value),
+        "fulfilled": cos.fulfilled,
         "new_ownership": {
-            "percentage": float(condition_of_sale.new_ownership.percentage),
+            "percentage": float(cos.new_ownership.percentage),
             "apartment": {
-                "id": condition_of_sale.new_ownership.apartment.uuid.hex,
-                "street_address": condition_of_sale.new_ownership.apartment.street_address,
-                "apartment_number": condition_of_sale.new_ownership.apartment.apartment_number,
-                "floor": condition_of_sale.new_ownership.apartment.floor,
-                "stair": condition_of_sale.new_ownership.apartment.stair,
+                "id": cos.new_ownership.apartment.uuid.hex,
+                "street_address": cos.new_ownership.apartment.street_address,
+                "apartment_number": cos.new_ownership.apartment.apartment_number,
+                "floor": cos.new_ownership.apartment.floor,
+                "stair": cos.new_ownership.apartment.stair,
+                "housing_company": {
+                    "id": cos.new_ownership.apartment.housing_company.uuid.hex,
+                    "display_name": cos.new_ownership.apartment.housing_company.display_name,
+                },
             },
             "owner": {
-                "id": condition_of_sale.new_ownership.owner.uuid.hex,
-                "name": condition_of_sale.new_ownership.owner.name,
-                "identifier": condition_of_sale.new_ownership.owner.identifier,
-                "email": condition_of_sale.new_ownership.owner.email,
+                "id": cos.new_ownership.owner.uuid.hex,
+                "name": cos.new_ownership.owner.name,
+                "identifier": cos.new_ownership.owner.identifier,
+                "email": cos.new_ownership.owner.email,
             },
         },
         "old_ownership": {
-            "percentage": float(condition_of_sale.old_ownership.percentage),
+            "percentage": float(cos.old_ownership.percentage),
             "apartment": {
-                "id": condition_of_sale.old_ownership.apartment.uuid.hex,
-                "street_address": condition_of_sale.old_ownership.apartment.street_address,
-                "apartment_number": condition_of_sale.old_ownership.apartment.apartment_number,
-                "floor": condition_of_sale.old_ownership.apartment.floor,
-                "stair": condition_of_sale.old_ownership.apartment.stair,
+                "id": cos.old_ownership.apartment.uuid.hex,
+                "street_address": cos.old_ownership.apartment.street_address,
+                "apartment_number": cos.old_ownership.apartment.apartment_number,
+                "floor": cos.old_ownership.apartment.floor,
+                "stair": cos.old_ownership.apartment.stair,
+                "housing_company": {
+                    "id": cos.old_ownership.apartment.housing_company.uuid.hex,
+                    "display_name": cos.old_ownership.apartment.housing_company.display_name,
+                },
             },
             "owner": {
-                "id": condition_of_sale.old_ownership.owner.uuid.hex,
-                "name": condition_of_sale.old_ownership.owner.name,
-                "identifier": condition_of_sale.old_ownership.owner.identifier,
-                "email": condition_of_sale.old_ownership.owner.email,
+                "id": cos.old_ownership.owner.uuid.hex,
+                "name": cos.old_ownership.owner.name,
+                "identifier": cos.old_ownership.owner.identifier,
+                "email": cos.old_ownership.owner.email,
             },
         },
     }

--- a/backend/hitas/tests/apis/test_api_condition_of_sale.py
+++ b/backend/hitas/tests/apis/test_api_condition_of_sale.py
@@ -57,10 +57,14 @@ def test__api__condition_of_sale__list__single(api_client: HitasAPIClient):
                 "percentage": float(cos.new_ownership.percentage),
                 "apartment": {
                     "id": cos.new_ownership.apartment.uuid.hex,
-                    "street_address": cos.new_ownership.apartment.street_address,
-                    "apartment_number": cos.new_ownership.apartment.apartment_number,
-                    "floor": cos.new_ownership.apartment.floor,
-                    "stair": cos.new_ownership.apartment.stair,
+                    "address": {
+                        "street_address": cos.new_ownership.apartment.street_address,
+                        "apartment_number": cos.new_ownership.apartment.apartment_number,
+                        "floor": cos.new_ownership.apartment.floor,
+                        "stair": cos.new_ownership.apartment.stair,
+                        "city": "Helsinki",
+                        "postal_code": cos.new_ownership.apartment.postal_code.value,
+                    },
                     "housing_company": {
                         "id": cos.new_ownership.apartment.housing_company.uuid.hex,
                         "display_name": cos.new_ownership.apartment.housing_company.display_name,
@@ -77,10 +81,14 @@ def test__api__condition_of_sale__list__single(api_client: HitasAPIClient):
                 "percentage": float(cos.old_ownership.percentage),
                 "apartment": {
                     "id": cos.old_ownership.apartment.uuid.hex,
-                    "street_address": cos.old_ownership.apartment.street_address,
-                    "apartment_number": cos.old_ownership.apartment.apartment_number,
-                    "floor": cos.old_ownership.apartment.floor,
-                    "stair": cos.old_ownership.apartment.stair,
+                    "address": {
+                        "street_address": cos.old_ownership.apartment.street_address,
+                        "apartment_number": cos.old_ownership.apartment.apartment_number,
+                        "floor": cos.old_ownership.apartment.floor,
+                        "stair": cos.old_ownership.apartment.stair,
+                        "city": "Helsinki",
+                        "postal_code": cos.old_ownership.apartment.postal_code.value,
+                    },
                     "housing_company": {
                         "id": cos.old_ownership.apartment.housing_company.uuid.hex,
                         "display_name": cos.old_ownership.apartment.housing_company.display_name,
@@ -124,10 +132,14 @@ def test__api__condition_of_sale__list__multiple(api_client: HitasAPIClient):
                 "percentage": float(cos_1.new_ownership.percentage),
                 "apartment": {
                     "id": cos_1.new_ownership.apartment.uuid.hex,
-                    "street_address": cos_1.new_ownership.apartment.street_address,
-                    "apartment_number": cos_1.new_ownership.apartment.apartment_number,
-                    "floor": cos_1.new_ownership.apartment.floor,
-                    "stair": cos_1.new_ownership.apartment.stair,
+                    "address": {
+                        "street_address": cos_1.new_ownership.apartment.street_address,
+                        "apartment_number": cos_1.new_ownership.apartment.apartment_number,
+                        "floor": cos_1.new_ownership.apartment.floor,
+                        "stair": cos_1.new_ownership.apartment.stair,
+                        "city": "Helsinki",
+                        "postal_code": cos_1.new_ownership.apartment.postal_code.value,
+                    },
                     "housing_company": {
                         "id": cos_1.new_ownership.apartment.housing_company.uuid.hex,
                         "display_name": cos_1.new_ownership.apartment.housing_company.display_name,
@@ -144,10 +156,14 @@ def test__api__condition_of_sale__list__multiple(api_client: HitasAPIClient):
                 "percentage": float(cos_1.old_ownership.percentage),
                 "apartment": {
                     "id": cos_1.old_ownership.apartment.uuid.hex,
-                    "street_address": cos_1.old_ownership.apartment.street_address,
-                    "apartment_number": cos_1.old_ownership.apartment.apartment_number,
-                    "floor": cos_1.old_ownership.apartment.floor,
-                    "stair": cos_1.old_ownership.apartment.stair,
+                    "address": {
+                        "street_address": cos_1.old_ownership.apartment.street_address,
+                        "apartment_number": cos_1.old_ownership.apartment.apartment_number,
+                        "floor": cos_1.old_ownership.apartment.floor,
+                        "stair": cos_1.old_ownership.apartment.stair,
+                        "city": "Helsinki",
+                        "postal_code": cos_1.old_ownership.apartment.postal_code.value,
+                    },
                     "housing_company": {
                         "id": cos_1.old_ownership.apartment.housing_company.uuid.hex,
                         "display_name": cos_1.old_ownership.apartment.housing_company.display_name,
@@ -169,10 +185,14 @@ def test__api__condition_of_sale__list__multiple(api_client: HitasAPIClient):
                 "percentage": float(cos_2.new_ownership.percentage),
                 "apartment": {
                     "id": cos_2.new_ownership.apartment.uuid.hex,
-                    "street_address": cos_2.new_ownership.apartment.street_address,
-                    "apartment_number": cos_2.new_ownership.apartment.apartment_number,
-                    "floor": cos_2.new_ownership.apartment.floor,
-                    "stair": cos_2.new_ownership.apartment.stair,
+                    "address": {
+                        "street_address": cos_2.new_ownership.apartment.street_address,
+                        "apartment_number": cos_2.new_ownership.apartment.apartment_number,
+                        "floor": cos_2.new_ownership.apartment.floor,
+                        "stair": cos_2.new_ownership.apartment.stair,
+                        "city": "Helsinki",
+                        "postal_code": cos_2.new_ownership.apartment.postal_code.value,
+                    },
                     "housing_company": {
                         "id": cos_2.new_ownership.apartment.housing_company.uuid.hex,
                         "display_name": cos_2.new_ownership.apartment.housing_company.display_name,
@@ -189,10 +209,14 @@ def test__api__condition_of_sale__list__multiple(api_client: HitasAPIClient):
                 "percentage": float(cos_2.old_ownership.percentage),
                 "apartment": {
                     "id": cos_2.old_ownership.apartment.uuid.hex,
-                    "street_address": cos_2.old_ownership.apartment.street_address,
-                    "apartment_number": cos_2.old_ownership.apartment.apartment_number,
-                    "floor": cos_2.old_ownership.apartment.floor,
-                    "stair": cos_2.old_ownership.apartment.stair,
+                    "address": {
+                        "street_address": cos_2.old_ownership.apartment.street_address,
+                        "apartment_number": cos_2.old_ownership.apartment.apartment_number,
+                        "floor": cos_2.old_ownership.apartment.floor,
+                        "stair": cos_2.old_ownership.apartment.stair,
+                        "city": "Helsinki",
+                        "postal_code": cos_2.old_ownership.apartment.postal_code.value,
+                    },
                     "housing_company": {
                         "id": cos_2.old_ownership.apartment.housing_company.uuid.hex,
                         "display_name": cos_2.old_ownership.apartment.housing_company.display_name,
@@ -288,10 +312,14 @@ def test__api__condition_of_sale__retrieve(api_client: HitasAPIClient):
             "percentage": float(cos.new_ownership.percentage),
             "apartment": {
                 "id": cos.new_ownership.apartment.uuid.hex,
-                "street_address": cos.new_ownership.apartment.street_address,
-                "apartment_number": cos.new_ownership.apartment.apartment_number,
-                "floor": cos.new_ownership.apartment.floor,
-                "stair": cos.new_ownership.apartment.stair,
+                "address": {
+                    "street_address": cos.new_ownership.apartment.street_address,
+                    "apartment_number": cos.new_ownership.apartment.apartment_number,
+                    "floor": cos.new_ownership.apartment.floor,
+                    "stair": cos.new_ownership.apartment.stair,
+                    "city": "Helsinki",
+                    "postal_code": cos.new_ownership.apartment.postal_code.value,
+                },
                 "housing_company": {
                     "id": cos.new_ownership.apartment.housing_company.uuid.hex,
                     "display_name": cos.new_ownership.apartment.housing_company.display_name,
@@ -308,10 +336,14 @@ def test__api__condition_of_sale__retrieve(api_client: HitasAPIClient):
             "percentage": float(cos.old_ownership.percentage),
             "apartment": {
                 "id": cos.old_ownership.apartment.uuid.hex,
-                "street_address": cos.old_ownership.apartment.street_address,
-                "apartment_number": cos.old_ownership.apartment.apartment_number,
-                "floor": cos.old_ownership.apartment.floor,
-                "stair": cos.old_ownership.apartment.stair,
+                "address": {
+                    "street_address": cos.old_ownership.apartment.street_address,
+                    "apartment_number": cos.old_ownership.apartment.apartment_number,
+                    "floor": cos.old_ownership.apartment.floor,
+                    "stair": cos.old_ownership.apartment.stair,
+                    "city": "Helsinki",
+                    "postal_code": cos.old_ownership.apartment.postal_code.value,
+                },
                 "housing_company": {
                     "id": cos.old_ownership.apartment.housing_company.uuid.hex,
                     "display_name": cos.old_ownership.apartment.housing_company.display_name,

--- a/backend/hitas/tests/apis/test_api_condition_of_sale.py
+++ b/backend/hitas/tests/apis/test_api_condition_of_sale.py
@@ -714,25 +714,22 @@ def test__api__condition_of_sale__create__household_of_two__both_have_new(api_cl
     response = api_client.post(url, data=data, format="json")
 
     # then:
-    # - The response contains four conditions of sale
-    # - The database contains four conditions of sale
+    # - The response contains three conditions of sale
+    # - The database contains three conditions of sale
     # - The conditions of sale are between:
     #   - The new ownership of Owner 1 and the old ownership of Owner 1
     #   - The new ownership of Owner 1 and the new ownership of Owner 2
     #   - The new ownership of Owner 2 and the old ownership of Owner 1
-    #   - The new ownership of Owner 2 and the new ownership of Owner 1
     assert response.status_code == status.HTTP_201_CREATED, response.json()
-    assert len(response.json().get("conditions_of_sale", [])) == 4, response.json()
+    assert len(response.json().get("conditions_of_sale", [])) == 3, response.json()
     conditions_of_sale: list[ConditionOfSale] = list(ConditionOfSale.objects.all())
-    assert len(conditions_of_sale) == 4
+    assert len(conditions_of_sale) == 3
     assert conditions_of_sale[0].new_ownership == new_ownership_1
     assert conditions_of_sale[0].old_ownership == old_ownership
     assert conditions_of_sale[1].new_ownership == new_ownership_1
     assert conditions_of_sale[1].old_ownership == new_ownership_2
     assert conditions_of_sale[2].new_ownership == new_ownership_2
     assert conditions_of_sale[2].old_ownership == old_ownership
-    assert conditions_of_sale[3].new_ownership == new_ownership_2
-    assert conditions_of_sale[3].old_ownership == new_ownership_1
 
 
 @pytest.mark.django_db
@@ -757,26 +754,23 @@ def test__api__condition_of_sale__create__household_of_two__one_has_multiple_new
     response = api_client.post(url, data=data, format="json")
 
     # then:
-    # - The response contains four conditions of sale
-    # - The database contains four conditions of sale
+    # - The response contains three conditions of sale
+    # - The database contains three conditions of sale
     # - The conditions of sale are between:
     #   - The new ownership of Owner 1 and the old ownership of Owner 1
     #   - The new ownership of Owner 1 and the new ownership of Owner 2
     #   - The new ownership of Owner 2 and the old ownership of Owner 1
-    #   - The new ownership of Owner 2 and the new ownership of Owner 1
     assert response.status_code == status.HTTP_201_CREATED, response.json()
     assert "conditions_of_sale" in response.json(), response.json()
-    assert len(response.json().get("conditions_of_sale", [])) == 4, response.json()
+    assert len(response.json().get("conditions_of_sale", [])) == 3, response.json()
     conditions_of_sale: list[ConditionOfSale] = list(ConditionOfSale.objects.all())
-    assert len(conditions_of_sale) == 4
+    assert len(conditions_of_sale) == 3
     assert conditions_of_sale[0].new_ownership == new_ownership_1
     assert conditions_of_sale[0].old_ownership == old_ownership
     assert conditions_of_sale[1].new_ownership == new_ownership_1
     assert conditions_of_sale[1].old_ownership == new_ownership_2
     assert conditions_of_sale[2].new_ownership == new_ownership_2
     assert conditions_of_sale[2].old_ownership == old_ownership
-    assert conditions_of_sale[3].new_ownership == new_ownership_2
-    assert conditions_of_sale[3].old_ownership == new_ownership_1
 
 
 @pytest.mark.django_db

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -51,7 +51,7 @@ from hitas.views.utils import (
 )
 from hitas.views.utils.merge import merge_model
 from hitas.views.utils.pdf import get_pdf_response
-from hitas.views.utils.serializers import ReadOnlySerializer, YearMonthSerializer
+from hitas.views.utils.serializers import ReadOnlySerializer, YearMonthSerializer, ApartmentHitasAddressSerializer
 
 
 class MarketPriceImprovementSerializer(serializers.ModelSerializer):
@@ -115,15 +115,6 @@ class ConstructionPriceImprovementSerializer(MarketPriceImprovementSerializer):
             "value",
             "depreciation_percentage",
         ]
-
-
-class ApartmentHitasAddressSerializer(serializers.Serializer):
-    street_address = serializers.CharField()
-    postal_code = serializers.CharField(source="building.real_estate.housing_company.postal_code.value", read_only=True)
-    city = serializers.CharField(source="building.real_estate.housing_company.city", read_only=True)
-    apartment_number = serializers.IntegerField(min_value=0)
-    floor = serializers.CharField(max_length=50, required=False, allow_null=True, allow_blank=True)
-    stair = serializers.CharField(max_length=16)
 
 
 class SharesSerializer(serializers.Serializer):

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -536,6 +536,8 @@ class ApartmentDetailSerializer(EnumSupportSerializerMixin, HitasModelSerializer
                     continue
 
                 completion_date = cos.new_ownership.apartment.completion_date
+                if completion_date is None:
+                    continue
 
                 if cos.grace_period == GracePeriod.NOT_GIVEN:
                     sell_by_dates.add(completion_date)

--- a/backend/hitas/views/apartment_list.py
+++ b/backend/hitas/views/apartment_list.py
@@ -8,9 +8,10 @@ from rest_framework import mixins, serializers, viewsets
 
 from hitas.models import Apartment, ConditionOfSale, Ownership
 from hitas.models.apartment import ApartmentState
-from hitas.views.apartment import ApartmentHitasAddressSerializer, create_links
+from hitas.views.apartment import create_links
 from hitas.views.ownership import OwnershipSerializer
 from hitas.views.utils import (
+    ApartmentHitasAddressSerializer,
     HitasCharFilter,
     HitasDecimalField,
     HitasEnumField,

--- a/backend/hitas/views/condition_of_sale.py
+++ b/backend/hitas/views/condition_of_sale.py
@@ -17,7 +17,8 @@ class MinimalApartmentSerializer(HitasModelSerializer):
     housing_company = serializers.SerializerMethodField()
     address = ApartmentHitasAddressSerializer(source="*")
 
-    def get_housing_company(self, instance: Apartment):
+    @staticmethod
+    def get_housing_company(instance: Apartment):
         return {
             "id": instance.housing_company.uuid.hex,
             "display_name": instance.housing_company.display_name,
@@ -99,7 +100,7 @@ class ConditionOfSaleCreateSerializer(serializers.Serializer):
             ownership for owner in owners for ownership in owner.ownerships.all() if not owner.bypass_conditions_of_sale
         ]
 
-        to_save: list[ConditionOfSale] = []
+        to_save: dict[tuple[int, int], ConditionOfSale] = {}
 
         # Create conditions of sale for all ownerships to new apartments this owner has,
         # and all the additional ownerships given (if they are for new apartments)
@@ -112,13 +113,18 @@ class ConditionOfSaleCreateSerializer(serializers.Serializer):
                     if ownership.id == other_ownership.id:
                         continue
 
-                    to_save.append(ConditionOfSale(new_ownership=ownership, old_ownership=other_ownership))
+                    # Only one condition of sale between two new apartments
+                    key: tuple[int, int] = tuple(sorted([ownership.id, other_ownership.id]))  # type: ignore
+                    if key in to_save:
+                        continue
+
+                    to_save[key] = ConditionOfSale(new_ownership=ownership, old_ownership=other_ownership)
 
         if not to_save:
             return []
 
         # 'ignore_conflicts' so that we can create all missing conditions of sale if some already exist
-        ConditionOfSale.objects.bulk_create(to_save, ignore_conflicts=True)
+        ConditionOfSale.objects.bulk_create(to_save.values(), ignore_conflicts=True)
 
         # We have to fetch ownerships separately, since if only some conditions of sale in 'to_save' were created,
         # the ids or conditions of sale in the returned list from 'bulk_create' are not correct.

--- a/backend/hitas/views/condition_of_sale.py
+++ b/backend/hitas/views/condition_of_sale.py
@@ -10,11 +10,12 @@ from rest_framework.serializers import ModelSerializer
 
 from hitas.models import Apartment, ApartmentSale, ConditionOfSale, Owner, Ownership
 from hitas.models.condition_of_sale import GracePeriod, condition_of_sale_queryset
-from hitas.views.utils import HitasModelSerializer, HitasModelViewSet, UUIDField
+from hitas.views.utils import ApartmentHitasAddressSerializer, HitasModelSerializer, HitasModelViewSet, UUIDField
 
 
 class MinimalApartmentSerializer(HitasModelSerializer):
     housing_company = serializers.SerializerMethodField()
+    address = ApartmentHitasAddressSerializer(source="*")
 
     def get_housing_company(self, instance: Apartment):
         return {
@@ -26,10 +27,7 @@ class MinimalApartmentSerializer(HitasModelSerializer):
         model = Apartment
         fields = [
             "id",
-            "street_address",
-            "apartment_number",
-            "floor",
-            "stair",
+            "address",
             "housing_company",
         ]
 

--- a/backend/hitas/views/condition_of_sale.py
+++ b/backend/hitas/views/condition_of_sale.py
@@ -14,6 +14,14 @@ from hitas.views.utils import HitasModelSerializer, HitasModelViewSet, UUIDField
 
 
 class MinimalApartmentSerializer(HitasModelSerializer):
+    housing_company = serializers.SerializerMethodField()
+
+    def get_housing_company(self, instance: Apartment):
+        return {
+            "id": instance.housing_company.uuid.hex,
+            "display_name": instance.housing_company.display_name,
+        }
+
     class Meta:
         model = Apartment
         fields = [
@@ -22,6 +30,7 @@ class MinimalApartmentSerializer(HitasModelSerializer):
             "apartment_number",
             "floor",
             "stair",
+            "housing_company",
         ]
 
 

--- a/backend/hitas/views/utils/__init__.py
+++ b/backend/hitas/views/utils/__init__.py
@@ -17,5 +17,10 @@ from hitas.views.utils.filters import (
     HitasUUIDFilter,
 )
 from hitas.views.utils.paginator import HitasPagination
-from hitas.views.utils.serializers import AddressSerializer, HitasAddressSerializer, HitasModelSerializer
+from hitas.views.utils.serializers import (
+    AddressSerializer,
+    ApartmentHitasAddressSerializer,
+    HitasAddressSerializer,
+    HitasModelSerializer,
+)
 from hitas.views.utils.viewsets import HitasModelMixin, HitasModelViewSet

--- a/backend/hitas/views/utils/serializers.py
+++ b/backend/hitas/views/utils/serializers.py
@@ -64,7 +64,7 @@ class YearMonthSerializer(serializers.DateField):
 class ApartmentHitasAddressSerializer(serializers.Serializer):
     street_address = serializers.CharField()
     postal_code = serializers.CharField(source="building.real_estate.housing_company.postal_code.value", read_only=True)
-    city = serializers.CharField(source="building.real_estate.housing_company.city", read_only=True)
+    city = serializers.CharField(source="building.real_estate.housing_company.postal_code.city", read_only=True)
     apartment_number = serializers.IntegerField(min_value=0)
     floor = serializers.CharField(max_length=50, required=False, allow_null=True, allow_blank=True)
     stair = serializers.CharField(max_length=16)

--- a/backend/hitas/views/utils/serializers.py
+++ b/backend/hitas/views/utils/serializers.py
@@ -59,3 +59,12 @@ class AddressSerializer(serializers.Serializer):
 class YearMonthSerializer(serializers.DateField):
     format = "%Y-%m"
     input_formats = [format]
+
+
+class ApartmentHitasAddressSerializer(serializers.Serializer):
+    street_address = serializers.CharField()
+    postal_code = serializers.CharField(source="building.real_estate.housing_company.postal_code.value", read_only=True)
+    city = serializers.CharField(source="building.real_estate.housing_company.city", read_only=True)
+    apartment_number = serializers.IntegerField(min_value=0)
+    floor = serializers.CharField(max_length=50, required=False, allow_null=True, allow_blank=True)
+    stair = serializers.CharField(max_length=16)

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -6293,7 +6293,7 @@ components:
         - street_address
         - apartment_number
         - floor
-        - stair
+        - housing_company
       properties:
         id:
           description: ID of this apartment
@@ -6320,6 +6320,22 @@ components:
           type: string
           maxLength: 16
           example: A
+        housing_company:
+          description: Links to apartment's housing company
+          type: object
+          additionalProperties: false
+          required:
+            - id
+            - display_name
+          properties:
+            id:
+              description: Housing company ID
+              type: string
+              example: a3181b8fa60b47df8ccba0d554a913bb
+            display_name:
+              description: Housing company's display name
+              type: string
+              example: Taloyhtiö Helmi
 
     GracePeriod:
       description: |-

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -6290,9 +6290,7 @@ components:
       additionalProperties: false
       required:
         - id
-        - street_address
-        - apartment_number
-        - floor
+        - address
         - housing_company
       properties:
         id:
@@ -6300,26 +6298,8 @@ components:
           type: string
           readOnly: true
           example: dc1072975bab4ba69f64814f021c6785
-        street_address:
-          description: Street address
-          type: string
-          example: Hannunkatu 24
-        apartment_number:
-          description: Apartment number
-          type: number
-          minimum: 0
-          example: 14
-        floor:
-          description: Apartment floor
-          type: string
-          maxLength: 50
-          nullable: true
-          example: "5"
-        stair:
-          description: Apartment stair
-          type: string
-          maxLength: 16
-          example: A
+        address:
+          $ref: '#/components/schemas/ApartmentAddress'
         housing_company:
           description: Links to apartment's housing company
           type: object

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3848,7 +3848,7 @@ components:
           readOnly: true
           type: array
           items:
-            $ref: '#/components/schemas/ConditionOfSale'
+            $ref: '#/components/schemas/ApartmentConditionOfSale'
         sell_by_date:
           description: |-
             The date when this apartment needs to be sold to fulfill a condition of sale linked to this apartment's
@@ -4088,7 +4088,7 @@ components:
           readOnly: true
           type: array
           items:
-            $ref: '#/components/schemas/ConditionOfSale'
+            $ref: '#/components/schemas/ApartmentConditionOfSale'
         sell_by_date:
           description: |-
             The date when this apartment needs to be sold to fulfill a condition of sale linked to this apartment's
@@ -6181,6 +6181,38 @@ components:
           description: Should sale be excluded from statistics?
           type: boolean
           example: false
+
+    ApartmentConditionOfSale:
+      description: Condition of Sale under an apartment
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - owner
+        - apartment
+        - grace_period
+        - fulfilled
+      properties:
+        id:
+          description: ID of this condition of sale
+          type: string
+          readOnly: true
+          example: dc1072975bab4ba69f64814f021c6785
+        owner:
+          readOnly: true
+          $ref: '#/components/schemas/ReadOnlyOwner'
+        apartment:
+          readOnly: true
+          $ref: '#/components/schemas/ConditionOfSaleApartment'
+        grace_period:
+          $ref: '#/components/schemas/GracePeriod'
+        fulfilled:
+          description: When this condition of sale was fulfilled, null if not fulfilled yet
+          type: string
+          nullable: true
+          readOnly: true
+          format: date-time
+          example: 1985-12-10T00:00:00+00:00
 
     ConditionOfSale:
       description: Condition of sale between two ownerships

--- a/frontend/src/common/models.ts
+++ b/frontend/src/common/models.ts
@@ -238,6 +238,17 @@ export interface IApartment {
     readonly links: IApartmentLinkedModels;
 }
 
+export interface IConditionOfSale {
+    id: string;
+    owner: Omit<IOwner, "id"> & {id: string};
+    apartment: {
+        id: string;
+        address: IApartmentAddress;
+        housing_company: IApartmentLinkedModel & {display_name: string};
+    };
+    grace_period: "not_given" | "three_months" | "six_months";
+    fulfilled: string | null;
+}
 export interface IApartmentDetails {
     readonly id: string;
     state: ApartmentState;
@@ -255,6 +266,7 @@ export interface IApartmentDetails {
         construction_price_index: IApartmentConstructionPriceIndexImprovement[];
     };
     readonly links: IApartmentLinkedModels;
+    readonly conditions_of_sale: IConditionOfSale[];
 }
 
 export interface IApartmentWritable {

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -21,26 +21,45 @@ import {
 } from "../../common/models";
 import {formatAddress, formatDate, formatMoney} from "../../common/utils";
 
-const SingleApartmentConditionOfSale = ({conditionOfSale}: {conditionOfSale: IConditionOfSale}) => {
+const SingleApartmentConditionOfSale = ({conditionsOfSale}: {conditionsOfSale: IConditionOfSale[]}) => {
     return (
         <li>
             <h3>
-                {conditionOfSale.owner.name} ({conditionOfSale.owner.identifier})
+                {conditionsOfSale[0].owner.name} ({conditionsOfSale[0].owner.identifier})
             </h3>
             <ul>
-                <li className={conditionOfSale.fulfilled ? "resolved" : "unresolved"}>
-                    <Link
-                        to={`/housing-companies/${conditionOfSale.apartment.housing_company.id}/apartments/${conditionOfSale.apartment.id}`}
+                {conditionsOfSale.map((cos) => (
+                    <li
+                        key={cos.id}
+                        className={cos.fulfilled ? "resolved" : "unresolved"}
                     >
-                        {conditionOfSale.fulfilled ? <IconLockOpen /> : <IconLock />}
-                        {formatAddress(conditionOfSale.apartment.address)}
-                    </Link>
-                </li>
+                        <Link
+                            to={`/housing-companies/${cos.apartment.housing_company.id}/apartments/${cos.apartment.id}`}
+                        >
+                            {cos.fulfilled ? <IconLockOpen /> : <IconLock />}
+                            {formatAddress(cos.apartment.address)}
+                        </Link>
+                    </li>
+                ))}
             </ul>
         </li>
     );
 };
+
 const ApartmentConditionsOfSaleCard = ({conditionsOfSale}: {conditionsOfSale: IConditionOfSale[]}) => {
+    // Create a dict with owner id as key, and all of their conditions of sale in a list as value
+    interface IGroupedConditionsOfSale {
+        [ownerId: string]: IConditionOfSale[];
+    }
+    const groupedConditionsOfSale: IGroupedConditionsOfSale = conditionsOfSale.reduce((acc, obj) => {
+        if (obj.owner.id in acc) {
+            acc[obj.owner.id].push(obj);
+        } else {
+            acc[obj.owner.id] = [obj];
+        }
+        return acc;
+    }, {});
+
     return (
         <Card>
             <div className="row row--buttons">
@@ -63,10 +82,10 @@ const ApartmentConditionsOfSaleCard = ({conditionsOfSale}: {conditionsOfSale: IC
             </div>
             <label className="card-heading">Myyntiehdot</label>
             <ul>
-                {conditionsOfSale.map((cos) => (
+                {Object.entries(groupedConditionsOfSale).map(([ownerId, cos]) => (
                     <SingleApartmentConditionOfSale
-                        key={cos.id}
-                        conditionOfSale={cos}
+                        key={ownerId}
+                        conditionsOfSale={cos}
                     />
                 ))}
             </ul>

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -15,12 +15,32 @@ import {
     IApartmentConfirmedMaximumPrice,
     IApartmentDetails,
     IApartmentUnconfirmedMaximumPrice,
+    IConditionOfSale,
     IHousingCompanyDetails,
     IOwnership,
 } from "../../common/models";
 import {formatAddress, formatDate, formatMoney} from "../../common/utils";
 
-const ApartmentSalesConditionCard = ({apartment}: {apartment: IApartmentDetails}) => {
+const SingleApartmentConditionOfSale = ({conditionOfSale}: {conditionOfSale: IConditionOfSale}) => {
+    return (
+        <li>
+            <h3>
+                {conditionOfSale.owner.name} ({conditionOfSale.owner.identifier})
+            </h3>
+            <ul>
+                <li className={conditionOfSale.fulfilled ? "resolved" : "unresolved"}>
+                    <Link
+                        to={`/housing-companies/${conditionOfSale.apartment.housing_company.id}/apartments/${conditionOfSale.apartment.id}`}
+                    >
+                        {conditionOfSale.fulfilled ? <IconLockOpen /> : <IconLock />}
+                        {formatAddress(conditionOfSale.apartment.address)}
+                    </Link>
+                </li>
+            </ul>
+        </li>
+    );
+};
+const ApartmentConditionsOfSaleCard = ({conditionsOfSale}: {conditionsOfSale: IConditionOfSale[]}) => {
     return (
         <Card>
             <div className="row row--buttons">
@@ -43,34 +63,12 @@ const ApartmentSalesConditionCard = ({apartment}: {apartment: IApartmentDetails}
             </div>
             <label className="card-heading">Myyntiehdot</label>
             <ul>
-                <li>
-                    <h3>Daniel Demola (010101-101A)</h3>
-                    <ul>
-                        <li className="unresolved">
-                            <Link to="#">
-                                <IconLock />
-                                Jokukatu 4, 00500
-                            </Link>
-                        </li>
-                        <li className="resolved">
-                            <Link to="#">
-                                <IconLockOpen />
-                                Umpikuja 0, 00404 - (myyty 3.1.2023)
-                            </Link>
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    <h3>Erkki Esimerkki (101099-666B)</h3>
-                    <ul>
-                        <li className="unresolved">
-                            <Link to="#">
-                                <IconLock />
-                                Peruskatu 1, 00820
-                            </Link>
-                        </li>
-                    </ul>
-                </li>
+                {conditionsOfSale.map((cos) => (
+                    <SingleApartmentConditionOfSale
+                        key={cos.id}
+                        conditionOfSale={cos}
+                    />
+                ))}
             </ul>
         </Card>
     );
@@ -273,7 +271,7 @@ const LoadedApartmentDetails = ({data}: {data: IApartmentDetails}): JSX.Element 
             </h2>
             <div className="apartment-action-cards">
                 <ApartmentMaximumPricesCard apartment={data} />
-                <ApartmentSalesConditionCard apartment={data} />
+                <ApartmentConditionsOfSaleCard conditionsOfSale={data.conditions_of_sale} />
             </div>
             <div className="apartment-details">
                 <div className="tab-area">


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Display conditions of sale on apartment details page
- Upgrade apartment endpoint conditions of sale field to be more manageable by the frontend, remove duplicate data and use our standardised address format

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [x] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [x] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- [ ] Create some conditions for sale for any apartment(s)
- [ ] See that they are correctly listed in the apartment details page

## Tickets

This pull request resolves all or part of the following ticket(s): HT-442

![image](https://user-images.githubusercontent.com/50950050/217413968-6bc00c52-9d3e-4f4f-a942-6cfbc9e8f8d7.png)
