### PR TITLE
Create conditions of sale on apartment sale

### DIFF
--- a/backend/hitas/tests/apis/test_api_apartment_sale.py
+++ b/backend/hitas/tests/apis/test_api_apartment_sale.py
@@ -161,27 +161,30 @@ def test__api__apartment_sale__create(api_client: HitasAPIClient):
         },
     )
     response_1 = api_client.post(url_1, data=data, format="json")
+    response_data = response_1.json()
+
+    assert response_1.status_code == status.HTTP_201_CREATED, response_data
+
+    assert response_data.pop("conditions_of_sale_created", None) is False
 
     sales: list[ApartmentSale] = list(ApartmentSale.objects.all())
     assert len(sales) == 1
-    assert sales[0].uuid.hex == response_1.json()["id"]
+    assert sales[0].uuid.hex == response_data["id"]
 
     ownerships: list[Ownership] = list(Ownership.objects.all())
     assert len(ownerships) == 1
-
-    assert response_1.status_code == status.HTTP_201_CREATED, response_1.json()
 
     url_2 = reverse(
         "hitas:apartment-sale-detail",
         kwargs={
             "housing_company_uuid": apartment.housing_company.uuid.hex,
             "apartment_uuid": apartment.uuid.hex,
-            "uuid": response_1.json()["id"],
+            "uuid": response_data["id"],
         },
     )
     response_2 = api_client.get(url_2)
     assert response_2.status_code == status.HTTP_200_OK, response_2.json()
-    assert response_2.json() == response_1.json()
+    assert response_2.json() == response_data
 
 
 @pytest.mark.django_db
@@ -220,27 +223,30 @@ def test__api__apartment_sale__create__multiple_owners(api_client: HitasAPIClien
         },
     )
     response_1 = api_client.post(url_1, data=data, format="json")
+    response_data = response_1.json()
+
+    assert response_1.status_code == status.HTTP_201_CREATED, response_data
+
+    assert response_data.pop("conditions_of_sale_created", None) is False
 
     sales: list[ApartmentSale] = list(ApartmentSale.objects.all())
     assert len(sales) == 1
-    assert sales[0].uuid.hex == response_1.json()["id"]
+    assert sales[0].uuid.hex == response_data["id"]
 
     ownerships: list[Ownership] = list(Ownership.objects.all())
     assert len(ownerships) == 2
-
-    assert response_1.status_code == status.HTTP_201_CREATED, response_1.json()
 
     url_2 = reverse(
         "hitas:apartment-sale-detail",
         kwargs={
             "housing_company_uuid": apartment.housing_company.uuid.hex,
             "apartment_uuid": apartment.uuid.hex,
-            "uuid": response_1.json()["id"],
+            "uuid": response_data["id"],
         },
     )
     response_2 = api_client.get(url_2)
     assert response_2.status_code == status.HTTP_200_OK, response_2.json()
-    assert response_2.json() == response_1.json()
+    assert response_2.json() == response_data
 
 
 @pytest.mark.parametrize(
@@ -621,6 +627,199 @@ def test__api__apartment_sale__create__condition_of_sale_fulfilled(api_client: H
 
     condition_of_sale.refresh_from_db()
     assert condition_of_sale.fulfilled is not None
+
+
+@pytest.mark.django_db
+def test__api__apartment_sale__create__new_apartment__create_condition_of_sale(api_client: HitasAPIClient):
+    owner: Owner = OwnerFactory.create()
+    apartment_1: Apartment = ApartmentFactory.create()
+    OwnershipFactory.create(apartment=apartment_1, owner=owner)
+
+    apartment_2: Apartment = ApartmentFactory.create(completion_date=None)
+
+    data = {
+        "ownerships": [
+            {
+                "owner": {
+                    "id": owner.uuid.hex,
+                },
+                "percentage": 100.0,
+            },
+        ],
+        "notification_date": "2023-01-01",
+        "purchase_date": "2023-01-01",
+        "purchase_price": 100_000,
+        "apartment_share_of_housing_company_loans": 50_000,
+        "exclude_in_statistics": True,
+    }
+
+    url_1 = reverse(
+        "hitas:apartment-sale-list",
+        kwargs={
+            "housing_company_uuid": apartment_2.housing_company.uuid.hex,
+            "apartment_uuid": apartment_2.uuid.hex,
+        },
+    )
+    response_1 = api_client.post(url_1, data=data, format="json")
+    response_data = response_1.json()
+
+    assert response_1.status_code == status.HTTP_201_CREATED, response_data
+
+    assert response_data.pop("conditions_of_sale_created", None) is True
+
+    sales: list[ApartmentSale] = list(ApartmentSale.objects.all())
+    assert len(sales) == 1
+    assert sales[0].uuid.hex == response_data["id"]
+
+    ownerships: list[Ownership] = list(Ownership.objects.all())
+    assert len(ownerships) == 2
+
+    conditions_of_sale: list[ConditionOfSale] = list(ConditionOfSale.objects.all())
+    assert len(conditions_of_sale) == 1
+    assert conditions_of_sale[0].new_ownership.apartment == apartment_2
+    assert conditions_of_sale[0].old_ownership.apartment == apartment_1
+
+    url_2 = reverse(
+        "hitas:apartment-sale-detail",
+        kwargs={
+            "housing_company_uuid": apartment_2.housing_company.uuid.hex,
+            "apartment_uuid": apartment_2.uuid.hex,
+            "uuid": response_data["id"],
+        },
+    )
+    response_2 = api_client.get(url_2)
+    assert response_2.status_code == status.HTTP_200_OK, response_2.json()
+    assert response_2.json() == response_data
+
+
+@pytest.mark.django_db
+def test__api__apartment_sale__create__new_apartment__no_other_apartments(api_client: HitasAPIClient):
+    owner: Owner = OwnerFactory.create()
+    apartment: Apartment = ApartmentFactory.create(completion_date=None)
+
+    data = {
+        "ownerships": [
+            {
+                "owner": {
+                    "id": owner.uuid.hex,
+                },
+                "percentage": 100.0,
+            },
+        ],
+        "notification_date": "2023-01-01",
+        "purchase_date": "2023-01-01",
+        "purchase_price": 100_000,
+        "apartment_share_of_housing_company_loans": 50_000,
+        "exclude_in_statistics": True,
+    }
+
+    url_1 = reverse(
+        "hitas:apartment-sale-list",
+        kwargs={
+            "housing_company_uuid": apartment.housing_company.uuid.hex,
+            "apartment_uuid": apartment.uuid.hex,
+        },
+    )
+    response_1 = api_client.post(url_1, data=data, format="json")
+    response_data = response_1.json()
+
+    assert response_1.status_code == status.HTTP_201_CREATED, response_data
+
+    assert response_data.pop("conditions_of_sale_created", None) is False
+
+    sales: list[ApartmentSale] = list(ApartmentSale.objects.all())
+    assert len(sales) == 1
+    assert sales[0].uuid.hex == response_data["id"]
+
+    ownerships: list[Ownership] = list(Ownership.objects.all())
+    assert len(ownerships) == 1
+
+    conditions_of_sale: list[ConditionOfSale] = list(ConditionOfSale.objects.all())
+    assert len(conditions_of_sale) == 0  # No conditions of sale created
+
+    url_2 = reverse(
+        "hitas:apartment-sale-detail",
+        kwargs={
+            "housing_company_uuid": apartment.housing_company.uuid.hex,
+            "apartment_uuid": apartment.uuid.hex,
+            "uuid": response_data["id"],
+        },
+    )
+    response_2 = api_client.get(url_2)
+    assert response_2.status_code == status.HTTP_200_OK, response_2.json()
+    assert response_2.json() == response_data
+
+
+@pytest.mark.django_db
+def test__api__apartment_sale__create__multiple_owners__new_apartment(api_client: HitasAPIClient):
+    owner_1: Owner = OwnerFactory.create()
+    owner_2: Owner = OwnerFactory.create()
+
+    # One owner has an old apartment
+    apartment_1: Apartment = ApartmentFactory.create()
+    OwnershipFactory.create(apartment=apartment_1, owner=owner_1)
+
+    apartment_2: Apartment = ApartmentFactory.create(completion_date=None)
+
+    data = {
+        "ownerships": [
+            {
+                "owner": {
+                    "id": owner_1.uuid.hex,
+                },
+                "percentage": 40.0,
+            },
+            {
+                "owner": {
+                    "id": owner_2.uuid.hex,
+                },
+                "percentage": 60.0,
+            },
+        ],
+        "notification_date": "2023-01-01",
+        "purchase_date": "2023-01-01",
+        "purchase_price": 100_000,
+        "apartment_share_of_housing_company_loans": 50_000,
+        "exclude_in_statistics": True,
+    }
+
+    url_1 = reverse(
+        "hitas:apartment-sale-list",
+        kwargs={
+            "housing_company_uuid": apartment_2.housing_company.uuid.hex,
+            "apartment_uuid": apartment_2.uuid.hex,
+        },
+    )
+    response_1 = api_client.post(url_1, data=data, format="json")
+    response_data = response_1.json()
+
+    assert response_1.status_code == status.HTTP_201_CREATED, response_data
+
+    assert response_data.pop("conditions_of_sale_created", None) is True
+
+    sales: list[ApartmentSale] = list(ApartmentSale.objects.all())
+    assert len(sales) == 1
+    assert sales[0].uuid.hex == response_data["id"]
+
+    ownerships: list[Ownership] = list(Ownership.objects.all())
+    assert len(ownerships) == 3
+
+    conditions_of_sale: list[ConditionOfSale] = list(ConditionOfSale.objects.all())
+    assert len(conditions_of_sale) == 1
+    assert conditions_of_sale[0].new_ownership.apartment == apartment_2
+    assert conditions_of_sale[0].old_ownership.apartment == apartment_1
+
+    url_2 = reverse(
+        "hitas:apartment-sale-detail",
+        kwargs={
+            "housing_company_uuid": apartment_2.housing_company.uuid.hex,
+            "apartment_uuid": apartment_2.uuid.hex,
+            "uuid": response_data["id"],
+        },
+    )
+    response_2 = api_client.get(url_2)
+    assert response_2.status_code == status.HTTP_200_OK, response_2.json()
+    assert response_2.json() == response_data
 
 
 # Update tests

--- a/backend/hitas/tests/apis/test_api_apartment_sale.py
+++ b/backend/hitas/tests/apis/test_api_apartment_sale.py
@@ -822,6 +822,137 @@ def test__api__apartment_sale__create__multiple_owners__new_apartment(api_client
     assert response_2.json() == response_data
 
 
+@pytest.mark.django_db
+def test__api__apartment_sale__create__new_apartment__no_longer_new_after_sold(api_client: HitasAPIClient):
+    owner: Owner = OwnerFactory.create()
+    old_apartment: Apartment = ApartmentFactory.create()
+    OwnershipFactory.create(apartment=old_apartment, owner=owner)
+
+    new_apartment: Apartment = ApartmentFactory.create(first_purchase_date=None)
+
+    assert new_apartment.is_new is True
+
+    data = {
+        "ownerships": [
+            {
+                "owner": {
+                    "id": owner.uuid.hex,
+                },
+                "percentage": 100.0,
+            },
+        ],
+        "notification_date": "2023-01-01",
+        "purchase_date": "2023-01-01",
+        "purchase_price": 100_000,
+        "apartment_share_of_housing_company_loans": 50_000,
+        "exclude_in_statistics": True,
+    }
+
+    url_1 = reverse(
+        "hitas:apartment-sale-list",
+        kwargs={
+            "housing_company_uuid": new_apartment.housing_company.uuid.hex,
+            "apartment_uuid": new_apartment.uuid.hex,
+        },
+    )
+    response_1 = api_client.post(url_1, data=data, format="json")
+    response_data = response_1.json()
+
+    assert response_1.status_code == status.HTTP_201_CREATED, response_data
+
+    assert response_data.pop("conditions_of_sale_created", None) is True
+
+    sales: list[ApartmentSale] = list(ApartmentSale.objects.all())
+    assert len(sales) == 1
+    assert sales[0].uuid.hex == response_data["id"]
+
+    ownerships: list[Ownership] = list(Ownership.objects.all())
+    assert len(ownerships) == 2
+
+    conditions_of_sale: list[ConditionOfSale] = list(ConditionOfSale.objects.all())
+    assert len(conditions_of_sale) == 1
+    assert conditions_of_sale[0].new_ownership.apartment == new_apartment
+    assert conditions_of_sale[0].old_ownership.apartment == old_apartment
+
+    new_apartment.refresh_from_db()
+    assert new_apartment.is_new is False
+
+    url_2 = reverse(
+        "hitas:apartment-sale-detail",
+        kwargs={
+            "housing_company_uuid": new_apartment.housing_company.uuid.hex,
+            "apartment_uuid": new_apartment.uuid.hex,
+            "uuid": response_data["id"],
+        },
+    )
+    response_2 = api_client.get(url_2)
+    assert response_2.status_code == status.HTTP_200_OK, response_2.json()
+    assert response_2.json() == response_data
+
+
+@pytest.mark.django_db
+def test__api__apartment_sale__create__second_sale_sets_last_latest_purchase_date(api_client: HitasAPIClient):
+    owner: Owner = OwnerFactory.create()
+    apartment: Apartment = ApartmentFactory.create(first_purchase_date=None, latest_purchase_date=None)
+
+    data = {
+        "ownerships": [
+            {
+                "owner": {
+                    "id": owner.uuid.hex,
+                },
+                "percentage": 100.0,
+            },
+        ],
+        "notification_date": "2023-01-01",
+        "purchase_date": "2023-01-01",
+        "purchase_price": 100_000,
+        "apartment_share_of_housing_company_loans": 50_000,
+        "exclude_in_statistics": True,
+    }
+
+    url_1 = reverse(
+        "hitas:apartment-sale-list",
+        kwargs={
+            "housing_company_uuid": apartment.housing_company.uuid.hex,
+            "apartment_uuid": apartment.uuid.hex,
+        },
+    )
+
+    # First sale sets 'first_purchase_date'
+    response_1 = api_client.post(url_1, data=data, format="json")
+    response_data_1 = response_1.json()
+
+    assert response_1.status_code == status.HTTP_201_CREATED, response_data_1
+
+    assert response_data_1.pop("conditions_of_sale_created", None) is False
+
+    sales: list[ApartmentSale] = list(ApartmentSale.objects.all())
+    assert len(sales) == 1
+    assert sales[0].uuid.hex == response_data_1["id"]
+
+    apartment.refresh_from_db()
+    assert apartment.first_purchase_date is not None
+    assert apartment.latest_purchase_date is None
+
+    # Second sale sets 'latest_purchase_date'
+    response_2 = api_client.post(url_1, data=data, format="json")
+    response_data_2 = response_2.json()
+
+    assert response_2.status_code == status.HTTP_201_CREATED, response_data_2
+
+    assert response_data_2.pop("conditions_of_sale_created", None) is False
+
+    sales: list[ApartmentSale] = list(ApartmentSale.objects.all())
+    assert len(sales) == 2
+    assert sales[0].uuid.hex == response_data_1["id"]
+    assert sales[1].uuid.hex == response_data_2["id"]
+
+    apartment.refresh_from_db()
+    assert apartment.first_purchase_date is not None
+    assert apartment.latest_purchase_date is not None
+
+
 # Update tests
 
 

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -660,7 +660,6 @@ class ApartmentListSerializer(ApartmentDetailSerializer):
 
 class ApartmentViewSet(HitasModelViewSet):
     serializer_class = ApartmentDetailSerializer
-    detail_serializer_class = ApartmentDetailSerializer
     list_serializer_class = ApartmentListSerializer
     model_class = Apartment
 

--- a/backend/hitas/views/apartment_sale.py
+++ b/backend/hitas/views/apartment_sale.py
@@ -1,11 +1,15 @@
 from typing import Any
 
 from django.core.exceptions import ValidationError
-from django.db.models import Prefetch
+from django.db.models import Prefetch, prefetch_related_objects
+from rest_framework import serializers
 
+from hitas.exceptions import HitasModelNotFound
 from hitas.models import Apartment, ApartmentSale
+from hitas.models.apartment import prefetch_first_sale
+from hitas.models.condition_of_sale import create_conditions_of_sale
 from hitas.models.ownership import Ownership, OwnershipLike, check_ownership_percentages
-from hitas.utils import lookup_model_id_by_uuid
+from hitas.utils import lookup_id_to_uuid
 from hitas.views.ownership import OwnershipSerializer
 from hitas.views.utils import HitasModelSerializer, HitasModelViewSet
 
@@ -19,38 +23,11 @@ class ApartmentSaleSerializer(HitasModelSerializer):
         data.setdefault("ownerships", [])
         return super().to_internal_value(data)
 
-    def validate_ownerships(self, ownerships: list[OwnershipLike]) -> list[OwnershipLike]:
-        if self.context["view"].action != "create":
-            if ownerships:
-                raise ValidationError("Can't update ownerships.")
-            return ownerships
-
-        if not ownerships:
-            raise ValidationError("Sale must have ownerships.")
-
-        if len(ownerships) != len({ownership["owner"] for ownership in ownerships}):
-            raise ValidationError("All ownerships must be for different owners.")
-
-        check_ownership_percentages(ownerships)
+    @staticmethod
+    def validate_ownerships(ownerships: list[OwnershipLike]) -> list[OwnershipLike]:
+        if ownerships:
+            raise ValidationError("Can't update ownerships.")
         return ownerships
-
-    def create(self, validated_data: dict[str, Any]) -> ApartmentSale:
-        ownership_data: list[OwnershipLike] = validated_data.pop("ownerships")
-        apartment_id = lookup_model_id_by_uuid(
-            lookup_id=self.context["view"].kwargs.get("apartment_uuid"),
-            model_class=Apartment,
-        )
-        validated_data["apartment_id"] = apartment_id
-
-        instance: ApartmentSale = super().create(validated_data)
-
-        # Mark current ownerships for the apartment as "past"
-        Ownership.objects.filter(apartment_id=apartment_id).delete()
-        # Replace with the new ownerships
-        for entry in ownership_data:
-            Ownership.objects.create(apartment_id=apartment_id, sale=instance, **entry)
-
-        return instance
 
     def update(self, instance: ApartmentSale, validated_data: dict[str, Any]) -> ApartmentSale:
         validated_data.pop("ownerships")
@@ -69,11 +46,82 @@ class ApartmentSaleSerializer(HitasModelSerializer):
         ]
 
 
+class ApartmentSaleCreateSerializer(HitasModelSerializer):
+
+    ownerships = OwnershipSerializer(many=True)
+    conditions_of_sale_created = serializers.ReadOnlyField(default=False)
+
+    @staticmethod
+    def validate_ownerships(ownerships: list[OwnershipLike]) -> list[OwnershipLike]:
+        if not ownerships:
+            raise ValidationError("Sale must have ownerships.")
+
+        if len(ownerships) != len({ownership["owner"] for ownership in ownerships}):
+            raise ValidationError("All ownerships must be for different owners.")
+
+        check_ownership_percentages(ownerships)
+        return ownerships
+
+    def create(self, validated_data: dict[str, Any]) -> ApartmentSale:
+        ownership_data: list[OwnershipLike] = validated_data.pop("ownerships")
+        apartment_uuid = lookup_id_to_uuid(self.context["view"].kwargs.get("apartment_uuid"), Apartment)
+
+        try:
+            apartment = Apartment.objects.prefetch_related(prefetch_first_sale()).get(uuid=apartment_uuid)
+        except Apartment.DoesNotExist as error:
+            raise HitasModelNotFound(model=Apartment) from error
+
+        validated_data["apartment"] = apartment
+
+        instance: ApartmentSale = super().create(validated_data)
+
+        ownerships = apartment.change_ownerships(ownership_data, sale=instance)
+        self.context["conditions_of_sale_created"] = False
+
+        if apartment.is_new:
+            owners = [ownership.owner for ownership in ownerships]
+            prefetch_related_objects(
+                owners,
+                Prefetch(
+                    "ownerships",
+                    Ownership.objects.select_related("apartment"),
+                ),
+                # Limit the fetched sales to only the first sale,
+                # as we only need that to figure out if the apartment is new
+                prefetch_first_sale("ownerships__apartment__"),
+            )
+            for owner in owners:
+                cos = create_conditions_of_sale(owners=[owner])
+                if cos:
+                    self.context["conditions_of_sale_created"] = True
+
+        return instance
+
+    def to_representation(self, validated_data: ApartmentSale) -> dict[str, Any]:
+        ret = super().to_representation(validated_data)
+        ret["conditions_of_sale_created"] = self.context.pop("conditions_of_sale_created", False)
+        return ret
+
+    class Meta:
+        model = ApartmentSale
+        fields = [
+            "id",
+            "ownerships",
+            "notification_date",
+            "purchase_date",
+            "purchase_price",
+            "apartment_share_of_housing_company_loans",
+            "exclude_in_statistics",
+            "conditions_of_sale_created",
+        ]
+
+
 class ApartmentSaleViewSet(HitasModelViewSet):
     serializer_class = ApartmentSaleSerializer
+    create_serializer_class = ApartmentSaleCreateSerializer
     model_class = ApartmentSale
 
-    def get_queryset(self):
+    def get_default_queryset(self):
         return ApartmentSale.objects.prefetch_related(
             Prefetch(
                 "ownerships",

--- a/backend/hitas/views/housing_company.py
+++ b/backend/hitas/views/housing_company.py
@@ -246,7 +246,6 @@ class HousingCompanyListSerializer(HousingCompanyDetailSerializer):
 
 class HousingCompanyViewSet(HitasModelViewSet):
     serializer_class = HousingCompanyDetailSerializer
-    detail_serializer_class = HousingCompanyDetailSerializer
     list_serializer_class = HousingCompanyListSerializer
     model_class = HousingCompany
 

--- a/backend/hitas/views/utils/viewsets.py
+++ b/backend/hitas/views/utils/viewsets.py
@@ -19,14 +19,14 @@ class HitasModelMixin:
     lookup_field = "uuid"
     pagination_class = HitasPagination
 
-    def get_list_queryset(self):
+    def get_default_queryset(self):
         return self.model_class.objects.all()
 
-    def get_retrieve_queryset(self):
-        return self.get_list_queryset()
+    def get_list_queryset(self):
+        return self.get_default_queryset()
 
     def get_detail_queryset(self):
-        return self.model_class.objects.all()
+        return self.get_default_queryset()
 
     def get_create_queryset(self):
         return self.get_detail_queryset()
@@ -71,31 +71,21 @@ class HitasModelMixin:
         if self.action == "list" and self.list_serializer_class is not None:
             return self.list_serializer_class
 
-        if self.action == "retrieve":
-            if self.detail_serializer_class is not None:
-                return self.detail_serializer_class
-            if self.list_serializer_class is not None:
-                return self.list_serializer_class
+        if self.action == "retrieve" and self.detail_serializer_class is not None:
+            return self.detail_serializer_class
 
-        if self.action == "create":
-            if self.create_serializer_class is not None:
-                return self.create_serializer_class
-            if self.detail_serializer_class is not None:
-                return self.detail_serializer_class
+        if self.action == "create" and self.create_serializer_class is not None:
+            return self.create_serializer_class
 
         if self.action == "update":
             if self.update_serializer_class is not None:
                 return self.update_serializer_class
-            if self.detail_serializer_class is not None:
-                return self.detail_serializer_class
 
         if self.action == "partial_update":
             if self.partial_update_serializer_class is not None:
                 return self.partial_update_serializer_class
             if self.update_serializer_class is not None:
                 return self.update_serializer_class
-            if self.detail_serializer_class is not None:
-                return self.detail_serializer_class
 
         return self.serializer_class
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1626,7 +1626,7 @@ paths:
             application/json:
               schema:
                 additionalProperties: false
-                $ref: '#/components/schemas/ApartmentSale'
+                $ref: '#/components/schemas/ApartmentSaleCreated'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -6155,7 +6155,7 @@ components:
           example: false
 
     ApartmentSaleCreate:
-      description: Apartment sale
+      description: Apartment sale create data
       type: object
       additionalProperties: false
       required:
@@ -6196,8 +6196,60 @@ components:
           type: boolean
           example: false
 
+    ApartmentSaleCreated:
+      description: Apartment sale created
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - ownerships
+        - notification_date
+        - purchase_date
+        - purchase_price
+        - apartment_share_of_housing_company_loans
+        - exclude_in_statistics
+        - conditions_of_sale_created
+      properties:
+        id:
+          description: Apartment sale ID
+          type: string
+          example: b477389cb3514fb1b444052a39bfb65d
+        ownerships:
+          description: List of ownerships resulting from this sale
+          type: array
+          items:
+            $ref: '#/components/schemas/Ownership'
+        notification_date:
+          description: Sale notification date
+          type: string
+          format: date
+          example: 1985-12-10
+        purchase_date:
+          description: Sale purchase date
+          type: string
+          format: date
+          example: 1985-12-10
+        purchase_price:
+          description: Sale purchase price
+          type: number
+          minimum: 0
+          example: 51222
+        apartment_share_of_housing_company_loans:
+          description: Apartment share of housing company loans
+          type: number
+          minimum: 0
+          example: 51222
+        exclude_in_statistics:
+          description: Should sale be excluded from statistics?
+          type: boolean
+          example: false
+        conditions_of_sale_created:
+          description: Were any conditions of sale created with this sale?
+          type: boolean
+          example: false
+
     ApartmentSaleUpdate:
-      description: Apartment sale
+      description: Apartment sale update data
       type: object
       additionalProperties: false
       required:


### PR DESCRIPTION
# Hitas Pull Request

# Description

Now making a sale for a new apartment for an owner with previous ownerships will automatically create conditions of sale between the owner's apartments.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- [x] Automatic tests
- [x] Create a sale for a new apartment with an owner that also owns other apartments. Conditions of sale should be created between those apartments with the sale, and a flag set in the sale response to indicate this.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-74
