### PR TITLE
Add sale by date to apartment list endpoint

### DIFF
--- a/backend/hitas/models/apartment.py
+++ b/backend/hitas/models/apartment.py
@@ -133,6 +133,7 @@ class Apartment(ExternalHitasModel):
 
         return no_first_purchase_or_in_the_future and no_first_sale_or_in_the_future
 
+    @property
     def sell_by_date(self):
         sell_by_dates: set[datetime.date] = set()
 
@@ -157,7 +158,8 @@ class Apartment(ExternalHitasModel):
 
         return min(sell_by_dates)
 
-    def on_grace_period(self) -> bool:
+    @property
+    def has_grace_period(self) -> bool:
         for ownership in self.ownerships.all():
             for cos in chain(ownership.conditions_of_sale_new.all(), ownership.conditions_of_sale_old.all()):
                 if cos.fulfilled:

--- a/backend/hitas/models/apartment.py
+++ b/backend/hitas/models/apartment.py
@@ -157,6 +157,15 @@ class Apartment(ExternalHitasModel):
 
         return min(sell_by_dates)
 
+    def on_grace_period(self) -> bool:
+        for ownership in self.ownerships.all():
+            for cos in chain(ownership.conditions_of_sale_new.all(), ownership.conditions_of_sale_old.all()):
+                if cos.fulfilled:
+                    continue
+                if cos.grace_period != GracePeriod.NOT_GIVEN:
+                    return True
+        return False
+
     class Meta:
         verbose_name = _("Apartment")
         verbose_name_plural = _("Apartments")

--- a/backend/hitas/tests/apis/test_api_apartment_list.py
+++ b/backend/hitas/tests/apis/test_api_apartment_list.py
@@ -1,3 +1,4 @@
+from datetime import date
 from uuid import UUID
 
 import pytest
@@ -5,10 +6,17 @@ from django.urls import reverse
 from django.utils.http import urlencode
 from rest_framework import status
 
-from hitas.models import Apartment, ConditionOfSale, HousingCompany, Ownership
+from hitas.models import Apartment, ConditionOfSale, HousingCompany, Owner, Ownership
 from hitas.models.apartment import ApartmentState
+from hitas.models.condition_of_sale import GracePeriod
 from hitas.tests.apis.helpers import HitasAPIClient
-from hitas.tests.factories import ApartmentFactory, ConditionOfSaleFactory, HousingCompanyFactory, OwnershipFactory
+from hitas.tests.factories import (
+    ApartmentFactory,
+    ConditionOfSaleFactory,
+    HousingCompanyFactory,
+    OwnerFactory,
+    OwnershipFactory,
+)
 
 # List tests
 
@@ -102,6 +110,7 @@ def test__api__apartment__list(api_client: HitasAPIClient):
                     "link": f"/api/v1/housing-companies/{hc1.uuid.hex}/apartments/{ap1.uuid.hex}",
                 },
             },
+            "sell_by_date": None,
         },
         {
             "id": ap2.uuid.hex,
@@ -144,6 +153,157 @@ def test__api__apartment__list(api_client: HitasAPIClient):
             },
             "completion_date": str(ap2.completion_date),
             "ownerships": [],
+            "sell_by_date": None,
+        },
+    ]
+    assert response.json()["page"] == {
+        "size": 2,
+        "current_page": 1,
+        "total_items": 2,
+        "total_pages": 1,
+        "links": {
+            "next": None,
+            "previous": None,
+        },
+    }
+
+
+@pytest.mark.django_db
+def test__api__apartment__list__condition_of_sale(api_client: HitasAPIClient):
+    ap1: Apartment = ApartmentFactory.create(
+        apartment_number=1,
+        completion_date=date(2022, 1, 1),
+    )
+    ap2: Apartment = ApartmentFactory.create(
+        apartment_number=2,
+        completion_date=date(2023, 1, 1),
+        first_purchase_date=None,
+    )
+    hc1: HousingCompany = ap1.housing_company
+    hc2: HousingCompany = ap2.housing_company
+    owner: Owner = OwnerFactory.create()
+    o1: Ownership = OwnershipFactory.create(owner=owner, apartment=ap1, percentage=50)
+    o2: Ownership = OwnershipFactory.create(apartment=ap1, percentage=50)
+    o3: Ownership = OwnershipFactory.create(owner=owner, apartment=ap2)
+    ConditionOfSaleFactory.create(new_ownership=o3, old_ownership=o1, grace_period=GracePeriod.NOT_GIVEN)
+
+    response = api_client.get(reverse("hitas:apartment-list"))
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json()["contents"] == [
+        {
+            "id": ap1.uuid.hex,
+            "state": ap1.state.value,
+            "type": ap1.apartment_type.value,
+            "surface_area": float(ap1.surface_area),
+            "address": {
+                "street_address": ap1.street_address,
+                "postal_code": hc1.postal_code.value,
+                "city": hc1.postal_code.city,
+                "apartment_number": ap1.apartment_number,
+                "stair": ap1.stair,
+                "floor": ap1.floor,
+            },
+            "completion_date": str(ap1.completion_date),
+            "ownerships": [
+                {
+                    "owner": {
+                        "id": o1.owner.uuid.hex,
+                        "name": o1.owner.name,
+                        "identifier": o1.owner.identifier,
+                        "email": o1.owner.email,
+                    },
+                    "percentage": float(o1.percentage),
+                },
+                {
+                    "owner": {
+                        "id": o2.owner.uuid.hex,
+                        "name": o2.owner.name,
+                        "identifier": o2.owner.identifier,
+                        "email": o2.owner.email,
+                    },
+                    "percentage": float(o2.percentage),
+                },
+            ],
+            "links": {
+                "housing_company": {
+                    "id": hc1.uuid.hex,
+                    "display_name": hc1.display_name,
+                    "link": f"/api/v1/housing-companies/{hc1.uuid.hex}",
+                },
+                "real_estate": {
+                    "id": ap1.building.real_estate.uuid.hex,
+                    "link": (
+                        f"/api/v1/housing-companies/{hc1.uuid.hex}/real-estates/{ap1.building.real_estate.uuid.hex}"
+                    ),
+                },
+                "building": {
+                    "id": ap1.building.uuid.hex,
+                    "street_address": ap1.building.street_address,
+                    "link": (
+                        f"/api/v1/housing-companies/{hc1.uuid.hex}"
+                        f"/real-estates/{ap1.building.real_estate.uuid.hex}"
+                        f"/buildings/{ap1.building.uuid.hex}"
+                    ),
+                },
+                "apartment": {
+                    "id": ap1.uuid.hex,
+                    "link": f"/api/v1/housing-companies/{hc1.uuid.hex}/apartments/{ap1.uuid.hex}",
+                },
+            },
+            "sell_by_date": str(ap2.completion_date),
+        },
+        {
+            "id": ap2.uuid.hex,
+            "state": ap2.state.value,
+            "type": ap2.apartment_type.value,
+            "surface_area": float(ap2.surface_area),
+            "address": {
+                "street_address": ap2.street_address,
+                "postal_code": hc2.postal_code.value,
+                "city": hc2.postal_code.city,
+                "apartment_number": ap2.apartment_number,
+                "stair": ap2.stair,
+                "floor": ap2.floor,
+            },
+            "links": {
+                "housing_company": {
+                    "id": hc2.uuid.hex,
+                    "display_name": hc2.display_name,
+                    "link": f"/api/v1/housing-companies/{hc2.uuid.hex}",
+                },
+                "real_estate": {
+                    "id": ap2.building.real_estate.uuid.hex,
+                    "link": (
+                        f"/api/v1/housing-companies/{hc2.uuid.hex}/real-estates/{ap2.building.real_estate.uuid.hex}"
+                    ),
+                },
+                "building": {
+                    "id": ap2.building.uuid.hex,
+                    "street_address": ap2.building.street_address,
+                    "link": (
+                        f"/api/v1/housing-companies/{hc2.uuid.hex}"
+                        f"/real-estates/{ap2.building.real_estate.uuid.hex}"
+                        f"/buildings/{ap2.building.uuid.hex}"
+                    ),
+                },
+                "apartment": {
+                    "id": ap2.uuid.hex,
+                    "link": f"/api/v1/housing-companies/{hc2.uuid.hex}/apartments/{ap2.uuid.hex}",
+                },
+            },
+            "completion_date": str(ap2.completion_date),
+            "ownerships": [
+                {
+                    "owner": {
+                        "id": o3.owner.uuid.hex,
+                        "name": o3.owner.name,
+                        "identifier": o3.owner.identifier,
+                        "email": o3.owner.email,
+                    },
+                    "percentage": float(o3.percentage),
+                }
+            ],
+            "sell_by_date": str(ap2.completion_date),
         },
     ]
     assert response.json()["page"] == {

--- a/backend/hitas/tests/apis/test_api_apartment_list.py
+++ b/backend/hitas/tests/apis/test_api_apartment_list.py
@@ -111,7 +111,7 @@ def test__api__apartment__list(api_client: HitasAPIClient):
                 },
             },
             "sell_by_date": None,
-            "on_grace_period": False,
+            "has_grace_period": False,
         },
         {
             "id": ap2.uuid.hex,
@@ -155,7 +155,7 @@ def test__api__apartment__list(api_client: HitasAPIClient):
             "completion_date": str(ap2.completion_date),
             "ownerships": [],
             "sell_by_date": None,
-            "on_grace_period": False,
+            "has_grace_period": False,
         },
     ]
     assert response.json()["page"] == {

--- a/backend/hitas/tests/apis/test_api_apartment_list.py
+++ b/backend/hitas/tests/apis/test_api_apartment_list.py
@@ -111,6 +111,7 @@ def test__api__apartment__list(api_client: HitasAPIClient):
                 },
             },
             "sell_by_date": None,
+            "on_grace_period": False,
         },
         {
             "id": ap2.uuid.hex,
@@ -154,6 +155,7 @@ def test__api__apartment__list(api_client: HitasAPIClient):
             "completion_date": str(ap2.completion_date),
             "ownerships": [],
             "sell_by_date": None,
+            "on_grace_period": False,
         },
     ]
     assert response.json()["page"] == {
@@ -185,7 +187,7 @@ def test__api__apartment__list__condition_of_sale(api_client: HitasAPIClient):
     o1: Ownership = OwnershipFactory.create(owner=owner, apartment=ap1, percentage=50)
     o2: Ownership = OwnershipFactory.create(apartment=ap1, percentage=50)
     o3: Ownership = OwnershipFactory.create(owner=owner, apartment=ap2)
-    ConditionOfSaleFactory.create(new_ownership=o3, old_ownership=o1, grace_period=GracePeriod.NOT_GIVEN)
+    ConditionOfSaleFactory.create(new_ownership=o3, old_ownership=o1, grace_period=GracePeriod.THREE_MONTHS)
 
     response = api_client.get(reverse("hitas:apartment-list"))
     assert response.status_code == status.HTTP_200_OK, response.json()
@@ -250,7 +252,8 @@ def test__api__apartment__list__condition_of_sale(api_client: HitasAPIClient):
                     "link": f"/api/v1/housing-companies/{hc1.uuid.hex}/apartments/{ap1.uuid.hex}",
                 },
             },
-            "sell_by_date": str(ap2.completion_date),
+            "sell_by_date": str(date(2023, 4, 1)),
+            "on_grace_period": True,
         },
         {
             "id": ap2.uuid.hex,
@@ -303,7 +306,8 @@ def test__api__apartment__list__condition_of_sale(api_client: HitasAPIClient):
                     "percentage": float(o3.percentage),
                 }
             ],
-            "sell_by_date": str(ap2.completion_date),
+            "sell_by_date": str(date(2023, 4, 1)),
+            "on_grace_period": True,
         },
     ]
     assert response.json()["page"] == {

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -528,7 +528,7 @@ class ApartmentDetailSerializer(EnumSupportSerializerMixin, HitasModelSerializer
 
     @staticmethod
     def get_sell_by_date(instance: Apartment) -> Optional[datetime.date]:
-        return instance.sell_by_date()
+        return instance.sell_by_date
 
     @staticmethod
     def get_links(instance: Apartment):

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -528,28 +528,7 @@ class ApartmentDetailSerializer(EnumSupportSerializerMixin, HitasModelSerializer
 
     @staticmethod
     def get_sell_by_date(instance: Apartment) -> Optional[datetime.date]:
-        sell_by_dates: set[datetime.date] = set()
-
-        for ownership in instance.ownerships.all():
-            for cos in chain(ownership.conditions_of_sale_new.all(), ownership.conditions_of_sale_old.all()):
-                if cos.fulfilled:
-                    continue
-
-                completion_date = cos.new_ownership.apartment.completion_date
-                if completion_date is None:
-                    continue
-
-                if cos.grace_period == GracePeriod.NOT_GIVEN:
-                    sell_by_dates.add(completion_date)
-                elif cos.grace_period == GracePeriod.THREE_MONTHS:
-                    sell_by_dates.add(completion_date + relativedelta(months=3))
-                elif cos.grace_period == GracePeriod.SIX_MONTHS:
-                    sell_by_dates.add(completion_date + relativedelta(months=6))
-
-        if not sell_by_dates:
-            return None
-
-        return min(sell_by_dates)
+        return instance.sell_by_date()
 
     @staticmethod
     def get_links(instance: Apartment):

--- a/backend/hitas/views/apartment_list.py
+++ b/backend/hitas/views/apartment_list.py
@@ -56,7 +56,7 @@ class ApartmentListSerializer(EnumSupportSerializerMixin, HitasModelSerializer):
     ownerships = OwnershipSerializer(many=True, read_only=False)
     links = serializers.SerializerMethodField()
     sell_by_date = serializers.SerializerMethodField()
-    on_grace_period = serializers.SerializerMethodField()
+    has_grace_period = serializers.SerializerMethodField()
 
     @staticmethod
     def get_type(instance: Apartment) -> Optional[str]:
@@ -68,11 +68,11 @@ class ApartmentListSerializer(EnumSupportSerializerMixin, HitasModelSerializer):
 
     @staticmethod
     def get_sell_by_date(instance: Apartment) -> Optional[datetime.date]:
-        return instance.sell_by_date()
+        return instance.sell_by_date
 
     @staticmethod
-    def get_on_grace_period(instance: Apartment) -> Optional[datetime.date]:
-        return instance.on_grace_period()
+    def get_has_grace_period(instance: Apartment) -> Optional[datetime.date]:
+        return instance.has_grace_period
 
     class Meta:
         model = Apartment
@@ -85,7 +85,7 @@ class ApartmentListSerializer(EnumSupportSerializerMixin, HitasModelSerializer):
             "address",
             "completion_date",
             "sell_by_date",
-            "on_grace_period",
+            "has_grace_period",
             "ownerships",
         ]
 

--- a/backend/hitas/views/apartment_list.py
+++ b/backend/hitas/views/apartment_list.py
@@ -56,6 +56,7 @@ class ApartmentListSerializer(EnumSupportSerializerMixin, HitasModelSerializer):
     ownerships = OwnershipSerializer(many=True, read_only=False)
     links = serializers.SerializerMethodField()
     sell_by_date = serializers.SerializerMethodField()
+    on_grace_period = serializers.SerializerMethodField()
 
     @staticmethod
     def get_type(instance: Apartment) -> Optional[str]:
@@ -69,6 +70,10 @@ class ApartmentListSerializer(EnumSupportSerializerMixin, HitasModelSerializer):
     def get_sell_by_date(instance: Apartment) -> Optional[datetime.date]:
         return instance.sell_by_date()
 
+    @staticmethod
+    def get_on_grace_period(instance: Apartment) -> Optional[datetime.date]:
+        return instance.on_grace_period()
+
     class Meta:
         model = Apartment
         fields = [
@@ -80,6 +85,7 @@ class ApartmentListSerializer(EnumSupportSerializerMixin, HitasModelSerializer):
             "address",
             "completion_date",
             "sell_by_date",
+            "on_grace_period",
             "ownerships",
         ]
 

--- a/backend/hitas/views/apartment_list.py
+++ b/backend/hitas/views/apartment_list.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Optional
 
 from django.db import models
@@ -54,13 +55,19 @@ class ApartmentListSerializer(EnumSupportSerializerMixin, HitasModelSerializer):
     completion_date = serializers.DateField(required=False, allow_null=True)
     ownerships = OwnershipSerializer(many=True, read_only=False)
     links = serializers.SerializerMethodField()
+    sell_by_date = serializers.SerializerMethodField()
 
     @staticmethod
     def get_type(instance: Apartment) -> Optional[str]:
         return getattr(getattr(instance, "apartment_type", None), "value", None)
 
-    def get_links(self, instance: Apartment):
+    @staticmethod
+    def get_links(instance: Apartment):
         return create_links(instance)
+
+    @staticmethod
+    def get_sell_by_date(instance: Apartment) -> Optional[datetime.date]:
+        return instance.sell_by_date()
 
     class Meta:
         model = Apartment
@@ -72,6 +79,7 @@ class ApartmentListSerializer(EnumSupportSerializerMixin, HitasModelSerializer):
             "surface_area",
             "address",
             "completion_date",
+            "sell_by_date",
             "ownerships",
         ]
 
@@ -89,17 +97,23 @@ class ApartmentListViewSet(HitasModelMixin, mixins.ListModelMixin, viewsets.Gene
                 ),
                 Prefetch(
                     "ownerships__conditions_of_sale_new",
-                    ConditionOfSale.objects.all(),
+                    ConditionOfSale.objects.select_related(
+                        "new_ownership__apartment",
+                        "old_ownership__apartment",
+                    ).all(),
                 ),
                 Prefetch(
                     "ownerships__conditions_of_sale_old",
-                    ConditionOfSale.objects.all(),
+                    ConditionOfSale.objects.select_related(
+                        "new_ownership__apartment",
+                        "old_ownership__apartment",
+                    ).all(),
                 ),
             )
             .select_related(
+                "apartment_type",
                 "building",
                 "building__real_estate",
-                "apartment_type",
                 "building__real_estate__housing_company",
                 "building__real_estate__housing_company__postal_code",
             )

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3872,7 +3872,7 @@ components:
         - ownerships
         - links
         - sell_by_date
-        - on_grace_period
+        - has_grace_period
       properties:
         id:
           description: Apartment ID
@@ -3922,7 +3922,7 @@ components:
           format: date
           nullable: true
           readOnly: true
-        on_grace_period:
+        has_grace_period:
           description: Do any of the conditions of sale related to this apartment have a grace period set?
           type: boolean
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3872,6 +3872,7 @@ components:
         - ownerships
         - links
         - sell_by_date
+        - on_grace_period
       properties:
         id:
           description: Apartment ID
@@ -3921,6 +3922,9 @@ components:
           format: date
           nullable: true
           readOnly: true
+        on_grace_period:
+          description: Do any of the conditions of sale related to this apartment have a grace period set?
+          type: boolean
 
     ApartmentDetails:
       description: Single apartment details

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3871,6 +3871,7 @@ components:
         - completion_date
         - ownerships
         - links
+        - sell_by_date
       properties:
         id:
           description: Apartment ID
@@ -3911,6 +3912,15 @@ components:
         links:
           readOnly: true
           $ref: '#/components/schemas/ApartmentLinks'
+        sell_by_date:
+          description: |-
+            The date when this apartment needs to be sold to fulfill a condition of sale linked to this apartment's
+            ownership(s). In case of multiple conditions of sale, use the first one in chronological order.
+            The value will be null if there are no current conditions of sale for this apartment's ownerships.
+          type: string
+          format: date
+          nullable: true
+          readOnly: true
 
     ApartmentDetails:
       description: Single apartment details


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds two fields: `sell_by_date` and `on_grace_period` to the apartment list/search endpoint.
- Without conditions of sale on any of the apartments, the value for `sell_by_date` should be null, and `on_grace_period` False
- With conditions of sale on any of the apartments, the value for `sell_by_date` will be the earliest of them (taking the grace period into account), and `on_grace_period` will be True if any of the conditions of sale for an apartment have one set, and false otherwise.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [x] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- [x] Automated tests

## Tickets

This pull request resolves all or part of the following ticket(s): HT-443
