### PR TITLE
Fix edge case for new apartment sell by dates

### DIFF
--- a/backend/hitas/models/condition_of_sale.py
+++ b/backend/hitas/models/condition_of_sale.py
@@ -1,18 +1,11 @@
 import datetime
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
-from django.conf import settings
 from django.db import models
-from django.db.models import Q
-from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from enumfields import Enum, EnumField
 
 from hitas.models._base import ExternalHitasModel
-
-if TYPE_CHECKING:
-    from hitas.models.owner import Owner
-    from hitas.models.ownership import Ownership
 
 
 class GracePeriod(Enum):
@@ -69,112 +62,9 @@ class ConditionOfSale(ExternalHitasModel):
         )
 
 
-def condition_of_sale_queryset() -> models.QuerySet[ConditionOfSale]:
-    return (
-        ConditionOfSale.all_objects.filter(
-            models.Q(deleted__isnull=True)
-            | models.Q(deleted__gte=timezone.now() - settings.SHOW_FULFILLED_CONDITIONS_OF_SALE_FOR_MONTHS)
-        )
-        .select_related(
-            "new_ownership__owner",
-            "new_ownership__apartment",
-            "old_ownership__owner",
-            "old_ownership__apartment",
-            "new_ownership__apartment__building",
-            "old_ownership__apartment__building",
-            "new_ownership__apartment__building__real_estate",
-            "old_ownership__apartment__building__real_estate",
-            "new_ownership__apartment__building__real_estate__housing_company",
-            "old_ownership__apartment__building__real_estate__housing_company",
-            "new_ownership__apartment__building__real_estate__housing_company__postal_code",
-            "old_ownership__apartment__building__real_estate__housing_company__postal_code",
-        )
-        .only(
-            "id",
-            "uuid",
-            "grace_period",
-            "deleted",
-            "new_ownership__id",
-            "new_ownership__percentage",
-            "old_ownership__id",
-            "old_ownership__percentage",
-            # New ownership apartment
-            "new_ownership__apartment__id",
-            "new_ownership__apartment__uuid",
-            "new_ownership__apartment__street_address",
-            "new_ownership__apartment__apartment_number",
-            "new_ownership__apartment__floor",
-            "new_ownership__apartment__stair",
-            "new_ownership__apartment__completion_date",
-            # Old ownership apartment
-            "old_ownership__apartment__id",
-            "old_ownership__apartment__uuid",
-            "old_ownership__apartment__street_address",
-            "old_ownership__apartment__apartment_number",
-            "old_ownership__apartment__floor",
-            "old_ownership__apartment__stair",
-            "old_ownership__apartment__completion_date",
-            # New ownership owner
-            "new_ownership__owner__id",
-            "new_ownership__owner__uuid",
-            "new_ownership__owner__name",
-            "new_ownership__owner__identifier",
-            "new_ownership__owner__email",
-            # Old ownership owner
-            "old_ownership__owner__id",
-            "old_ownership__owner__uuid",
-            "old_ownership__owner__name",
-            "old_ownership__owner__identifier",
-            "old_ownership__owner__email",
-            # Housing company info
-            "new_ownership__apartment__building__real_estate__housing_company__uuid",
-            "old_ownership__apartment__building__real_estate__housing_company__uuid",
-            "new_ownership__apartment__building__real_estate__housing_company__display_name",
-            "old_ownership__apartment__building__real_estate__housing_company__display_name",
-            # Address info
-            "new_ownership__apartment__building__real_estate__housing_company__postal_code__value",
-            "old_ownership__apartment__building__real_estate__housing_company__postal_code__value",
-            "new_ownership__apartment__building__real_estate__housing_company__postal_code__city",
-            "old_ownership__apartment__building__real_estate__housing_company__postal_code__city",
-        )
-    )
+# this is only for typing
+class ConditionOfSaleAnnotated(ConditionOfSale):
+    first_purchase_date: Optional[datetime.date]
 
-
-def create_conditions_of_sale(owners: list["Owner"]) -> list[ConditionOfSale]:
-    ownerships: list[Ownership] = [
-        ownership for owner in owners for ownership in owner.ownerships.all() if not owner.bypass_conditions_of_sale
-    ]
-
-    to_save: dict[tuple[int, int], ConditionOfSale] = {}
-
-    # Create conditions of sale for all ownerships to new apartments this owner has,
-    # and all the additional ownerships given (if they are for new apartments)
-    for ownership in ownerships:
-        apartment = ownership.apartment
-
-        if apartment.is_new:
-            for other_ownership in ownerships:
-                # Don't create circular conditions of sale
-                if ownership.id == other_ownership.id:
-                    continue
-
-                # Only one condition of sale between two new apartments
-                key: tuple[int, int] = tuple(sorted([ownership.id, other_ownership.id]))  # type: ignore
-                if key in to_save:
-                    continue
-
-                to_save[key] = ConditionOfSale(new_ownership=ownership, old_ownership=other_ownership)
-
-    if not to_save:
-        return []
-
-    # 'ignore_conflicts' so that we can create all missing conditions of sale if some already exist
-    ConditionOfSale.objects.bulk_create(to_save.values(), ignore_conflicts=True)
-
-    # We have to fetch ownerships separately, since if only some conditions of sale in 'to_save' were created,
-    # the ids or conditions of sale in the returned list from 'bulk_create' are not correct.
-    return list(
-        condition_of_sale_queryset()
-        .filter(Q(new_ownership__owner__in=owners) | Q(old_ownership__owner__in=owners))
-        .all()
-    )
+    class Meta:
+        abstract = True

--- a/backend/hitas/services/apartment.py
+++ b/backend/hitas/services/apartment.py
@@ -1,0 +1,89 @@
+from typing import Collection
+
+from django.db import models
+from django.db.models import OuterRef, Prefetch, Subquery
+
+from hitas.models._base import HitasModelDecimalField
+from hitas.models.apartment_sale import ApartmentSale
+from hitas.utils import subquery_first_id
+
+
+def prefetch_first_sale(lookup_prefix: str = "", ignore: Collection[int] = ()) -> Prefetch:
+    """Prefetch only the first sale of an apartment.
+
+    :param lookup_prefix: Add prefix to lookup, e.g. 'ownerships__apartment__'
+                          depending on the prefix context. Should end with '__'.
+    :param ignore: These sale ID's should be ignored.
+    """
+    return Prefetch(
+        f"{lookup_prefix}sales",
+        ApartmentSale.objects.filter(
+            id__in=Subquery(
+                ApartmentSale.objects.filter(apartment_id=OuterRef("apartment_id"))
+                .exclude(id__in=ignore)
+                .order_by("purchase_date")
+                .values_list("id", flat=True)[:1]
+            )
+        ),
+    )
+
+
+def subquery_first_sale_purchase_price(outer_ref: str) -> Subquery:
+    return Subquery(
+        queryset=(
+            ApartmentSale.objects.filter(apartment_id=OuterRef(outer_ref))
+            .order_by("purchase_date")
+            .values_list("purchase_price", flat=True)[:1]
+        ),
+        output_field=HitasModelDecimalField(null=True),
+    )
+
+
+def subquery_first_sale_loan_amount(outer_ref: str) -> Subquery:
+    return Subquery(
+        queryset=(
+            ApartmentSale.objects.filter(apartment_id=OuterRef(outer_ref))
+            .order_by("purchase_date")
+            .values_list("apartment_share_of_housing_company_loans", flat=True)[:1]
+        ),
+        output_field=HitasModelDecimalField(null=True),
+    )
+
+
+def subquery_latest_sale_purchase_price(outer_ref: str) -> Subquery:
+    return Subquery(
+        queryset=(
+            ApartmentSale.objects.filter(apartment_id=OuterRef(outer_ref))
+            .exclude(
+                id__in=subquery_first_id(ApartmentSale, "apartment_id", order_by="-purchase_date"),
+            )
+            .order_by("-purchase_date")
+            .values_list("purchase_price", flat=True)[:1]
+        ),
+        output_field=HitasModelDecimalField(null=True),
+    )
+
+
+def subquery_first_purchase_date(outer_ref: str) -> Subquery:
+    return Subquery(
+        queryset=(
+            ApartmentSale.objects.filter(apartment_id=OuterRef(outer_ref))
+            .order_by("purchase_date")
+            .values_list("purchase_date", flat=True)[:1]
+        ),
+        output_field=models.DateField(null=True),
+    )
+
+
+def subquery_latest_purchase_date(outer_ref: str) -> Subquery:
+    return Subquery(
+        queryset=(
+            ApartmentSale.objects.filter(apartment_id=OuterRef(outer_ref))
+            .exclude(
+                id__in=subquery_first_id(ApartmentSale, "apartment_id", order_by="-purchase_date"),
+            )
+            .order_by("-purchase_date")
+            .values_list("purchase_date", flat=True)[:1]
+        ),
+        output_field=models.DateField(null=True),
+    )

--- a/backend/hitas/services/condition_of_sale.py
+++ b/backend/hitas/services/condition_of_sale.py
@@ -1,0 +1,122 @@
+from django.conf import settings
+from django.db import models
+from django.db.models import Q
+from django.utils import timezone
+
+from hitas.models import ConditionOfSale, Owner, Ownership
+from hitas.models.condition_of_sale import ConditionOfSaleAnnotated
+from hitas.services.apartment import subquery_first_purchase_date
+
+
+def condition_of_sale_queryset() -> models.QuerySet[ConditionOfSaleAnnotated]:
+    return (
+        ConditionOfSale.all_objects.filter(
+            models.Q(deleted__isnull=True)
+            | models.Q(deleted__gte=timezone.now() - settings.SHOW_FULFILLED_CONDITIONS_OF_SALE_FOR_MONTHS)
+        )
+        .select_related(
+            "new_ownership__owner",
+            "new_ownership__apartment",
+            "old_ownership__owner",
+            "old_ownership__apartment",
+            "new_ownership__apartment__building",
+            "old_ownership__apartment__building",
+            "new_ownership__apartment__building__real_estate",
+            "old_ownership__apartment__building__real_estate",
+            "new_ownership__apartment__building__real_estate__housing_company",
+            "old_ownership__apartment__building__real_estate__housing_company",
+            "new_ownership__apartment__building__real_estate__housing_company__postal_code",
+            "old_ownership__apartment__building__real_estate__housing_company__postal_code",
+        )
+        .annotate(
+            first_purchase_date=subquery_first_purchase_date("new_ownership__apartment__id"),
+        )
+        .only(
+            "id",
+            "uuid",
+            "grace_period",
+            "deleted",
+            "new_ownership__id",
+            "new_ownership__percentage",
+            "old_ownership__id",
+            "old_ownership__percentage",
+            # New ownership apartment
+            "new_ownership__apartment__id",
+            "new_ownership__apartment__uuid",
+            "new_ownership__apartment__street_address",
+            "new_ownership__apartment__apartment_number",
+            "new_ownership__apartment__floor",
+            "new_ownership__apartment__stair",
+            "new_ownership__apartment__completion_date",
+            # Old ownership apartment
+            "old_ownership__apartment__id",
+            "old_ownership__apartment__uuid",
+            "old_ownership__apartment__street_address",
+            "old_ownership__apartment__apartment_number",
+            "old_ownership__apartment__floor",
+            "old_ownership__apartment__stair",
+            "old_ownership__apartment__completion_date",
+            # New ownership owner
+            "new_ownership__owner__id",
+            "new_ownership__owner__uuid",
+            "new_ownership__owner__name",
+            "new_ownership__owner__identifier",
+            "new_ownership__owner__email",
+            # Old ownership owner
+            "old_ownership__owner__id",
+            "old_ownership__owner__uuid",
+            "old_ownership__owner__name",
+            "old_ownership__owner__identifier",
+            "old_ownership__owner__email",
+            # Housing company info
+            "new_ownership__apartment__building__real_estate__housing_company__uuid",
+            "old_ownership__apartment__building__real_estate__housing_company__uuid",
+            "new_ownership__apartment__building__real_estate__housing_company__display_name",
+            "old_ownership__apartment__building__real_estate__housing_company__display_name",
+            # Address info
+            "new_ownership__apartment__building__real_estate__housing_company__postal_code__value",
+            "old_ownership__apartment__building__real_estate__housing_company__postal_code__value",
+            "new_ownership__apartment__building__real_estate__housing_company__postal_code__city",
+            "old_ownership__apartment__building__real_estate__housing_company__postal_code__city",
+        )
+    )
+
+
+def create_conditions_of_sale(owners: list["Owner"]) -> list[ConditionOfSale]:
+    ownerships: list[Ownership] = [
+        ownership for owner in owners for ownership in owner.ownerships.all() if not owner.bypass_conditions_of_sale
+    ]
+
+    to_save: dict[tuple[int, int], ConditionOfSale] = {}
+
+    # Create conditions of sale for all ownerships to new apartments this owner has,
+    # and all the additional ownerships given (if they are for new apartments)
+    for ownership in ownerships:
+        apartment = ownership.apartment
+
+        if apartment.is_new:
+            for other_ownership in ownerships:
+                # Don't create circular conditions of sale
+                if ownership.id == other_ownership.id:
+                    continue
+
+                # Only one condition of sale between two new apartments
+                key: tuple[int, int] = tuple(sorted([ownership.id, other_ownership.id]))  # type: ignore
+                if key in to_save:
+                    continue
+
+                to_save[key] = ConditionOfSale(new_ownership=ownership, old_ownership=other_ownership)
+
+    if not to_save:
+        return []
+
+    # 'ignore_conflicts' so that we can create all missing conditions of sale if some already exist
+    ConditionOfSale.objects.bulk_create(to_save.values(), ignore_conflicts=True)
+
+    # We have to fetch ownerships separately, since if only some conditions of sale in 'to_save' were created,
+    # the ids or conditions of sale in the returned list from 'bulk_create' are not correct.
+    return list(
+        condition_of_sale_queryset()
+        .filter(Q(new_ownership__owner__in=owners) | Q(old_ownership__owner__in=owners))
+        .all()
+    )

--- a/backend/hitas/views/apartment_list.py
+++ b/backend/hitas/views/apartment_list.py
@@ -2,9 +2,7 @@ from rest_framework import mixins, viewsets
 
 from hitas.models import Apartment
 from hitas.views.apartment import ApartmentFilterSet, ApartmentListSerializer, ApartmentViewSet
-from hitas.views.utils import (
-    HitasModelMixin,
-)
+from hitas.views.utils import HitasModelMixin
 
 
 class ApartmentListViewSet(HitasModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet):

--- a/backend/hitas/views/apartment_sale.py
+++ b/backend/hitas/views/apartment_sale.py
@@ -6,9 +6,9 @@ from rest_framework import serializers
 
 from hitas.exceptions import HitasModelNotFound
 from hitas.models import Apartment, ApartmentSale
-from hitas.models.apartment import prefetch_first_sale
-from hitas.models.condition_of_sale import create_conditions_of_sale
 from hitas.models.ownership import Ownership, OwnershipLike, check_ownership_percentages
+from hitas.services.apartment import prefetch_first_sale
+from hitas.services.condition_of_sale import create_conditions_of_sale
 from hitas.utils import lookup_id_to_uuid
 from hitas.views.ownership import OwnershipSerializer
 from hitas.views.utils import HitasModelSerializer, HitasModelViewSet

--- a/backend/hitas/views/condition_of_sale.py
+++ b/backend/hitas/views/condition_of_sale.py
@@ -9,7 +9,8 @@ from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer
 
 from hitas.models import Apartment, ApartmentSale, ConditionOfSale, Owner, Ownership
-from hitas.models.condition_of_sale import GracePeriod, condition_of_sale_queryset, create_conditions_of_sale
+from hitas.models.condition_of_sale import GracePeriod
+from hitas.services.condition_of_sale import condition_of_sale_queryset, create_conditions_of_sale
 from hitas.utils import subquery_first_id
 from hitas.views.utils import ApartmentHitasAddressSerializer, HitasModelSerializer, HitasModelViewSet, UUIDField
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

Fixes `sell_by_date` calculation in cases where the apartment is completed before it is sold for the first time. 
In these cases, the `sell_by_date` should be calculated based on the first sale purchase date.

A bit of refactoring is also made to reuse code and avoid import loops.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- [x] Automatic tests

## Tickets

This pull request resolves all or part of the following ticket(s): HT-459
