### PR TITLE
Remove obfuscation for apartment completion date

### DIFF
--- a/backend/hitas/oracle_migration/oracle_schema/company.py
+++ b/backend/hitas/oracle_migration/oracle_schema/company.py
@@ -3,7 +3,6 @@ from sqlalchemy import Column, Date, Float, ForeignKey, ForeignKeyConstraint, In
 from hitas.oracle_migration.oracle_schema.metadata import metadata_obj
 from hitas.oracle_migration.types import (
     HitasAnonymizedAddress,
-    HitasAnonymizedDay,
     HitasAnonymizedMonthAndDay,
     HitasAnonymizedName,
     HitasAnonymizedNameCommaSeparated,
@@ -125,7 +124,7 @@ apartments = Table(
     Column("N_OSAKELKM1", Integer, key="share_number_start", nullable=False),
     Column("N_OSAKELKM2", Integer, key="share_number_end", nullable=False),
     Column("N_OSAKEYHT", Integer, nullable=False),
-    Column("D_VALMPVM", HitasAnonymizedDay, key="completion_date"),
+    Column("D_VALMPVM", Date, key="completion_date"),
     Column("N_LUOVHINTA", Integer, key="debt_free_purchase_price", nullable=False),
     Column("N_KAUPHINTA", Integer, key="purchase_price", nullable=False),
     Column("N_ENSIJLAINA", Integer, key="primary_loan_amount", nullable=False),


### PR DESCRIPTION
# Hitas Pull Request

# Description

Removes unnecessary obfuscation of the apartment completion date, which affects some calculations and thus testing.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [ ] Changes have been tested
    - [ ] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [x] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- [x] Run migration and check that completion dates don't change

## Tickets

This pull request resolves all or part of the following ticket(s): HT-414
