### PR TITLE
Condition of Sale UI/styles

### DIFF
--- a/frontend/src/common/components/ListPageNumbers.tsx
+++ b/frontend/src/common/components/ListPageNumbers.tsx
@@ -1,44 +1,36 @@
 import React from "react";
 
-import {Button} from "hds-react";
+import {Pagination} from "hds-react";
 
 import {PageInfo} from "../schemas";
 
 interface ListPageNumbersProps {
-    pageInfo: PageInfo | undefined;
+    pageInfo: PageInfo;
     currentPage: number;
     setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
 }
 
-export default function ListPageNumbers({currentPage, setCurrentPage, pageInfo}: ListPageNumbersProps): JSX.Element {
-    if (pageInfo === undefined) return <></>;
-
-    const pageButtonData: {pageNumber: number; buttonText: string | number}[] = [];
-    const totalPages = pageInfo.total_pages;
-    for (let i = -3; i <= 3; i++) {
-        if (currentPage + i > 0 && currentPage + i <= totalPages) {
-            pageButtonData.push({pageNumber: currentPage + i, buttonText: currentPage + i});
-        }
-    }
-    pageButtonData.unshift({pageNumber: Math.max(1, currentPage - 1), buttonText: "<"});
-    pageButtonData.push({pageNumber: Math.min(totalPages, currentPage + 1), buttonText: ">"});
-    if (totalPages === 1) return <></>;
+export default function ListPageNumbers({
+    currentPage,
+    setCurrentPage,
+    pageInfo,
+    pageInfo: {total_pages: totalPages},
+}: ListPageNumbersProps): JSX.Element {
+    if (pageInfo === undefined || totalPages === 1) return <></>;
     return (
-        <div style={{display: "flex", justifyContent: "space-between"}}>
-            {pageButtonData.map(({pageNumber, buttonText}) => (
-                <Button
-                    key={`pageButton__${buttonText}`}
-                    onClick={() => setCurrentPage(pageNumber)}
-                    style={{
-                        backgroundColor: "transparent",
-                        color: "var(--text-color)",
-                        border: "0",
-                        fontWeight: "bold",
-                    }}
-                >
-                    {buttonText}
-                </Button>
-            ))}
-        </div>
+        <Pagination
+            language="fi"
+            onChange={(event, index) => {
+                event.preventDefault();
+                setCurrentPage(index + 1);
+            }}
+            pageCount={totalPages}
+            pageHref={() => currentPage.toString()}
+            pageIndex={currentPage - 1}
+            paginationAriaLabel="Pagination"
+            siblingCount={2}
+            hideNextButton={currentPage === totalPages}
+            hidePrevButton={currentPage === 1}
+        />
     );
 }

--- a/frontend/src/common/components/form/RelatedModelInput.tsx
+++ b/frontend/src/common/components/form/RelatedModelInput.tsx
@@ -76,6 +76,14 @@ const RelatedModelInput = ({
         }
     };
 
+    const handleKeyDown = (e) => {
+        // Make other key presses than Tab (and Shift+Tab) open the modal
+        if (e.code !== ("Tab" || "Shift")) {
+            e.preventDefault();
+            openModal();
+        }
+    };
+
     return (
         <div className={`input-field input-field--related-model${required ? " input-field--required" : ""}`}>
             {children ? (
@@ -91,7 +99,7 @@ const RelatedModelInput = ({
                     invalid={errors[fieldName]}
                     buttonIcon={!required && formObject.getValues(fieldName) ? <IconCrossCircle /> : <IconSearch />}
                     onButtonClick={!required && formObject.getValues(fieldName) ? clearFieldValue : openModal}
-                    onKeyDown={!required && formObject.getValues(fieldName) ? clearFieldValue : openModal}
+                    onKeyDown={(e) => handleKeyDown(e)}
                     onClick={openModal}
                 />
             )}

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -82,7 +82,9 @@ const ApartmentConditionsOfSaleCard = ({apartment}: {apartment: IApartmentDetail
                     </Button>
                 </Link>
             </div>
-            <label className="card-heading">Myyntiehdot</label>
+            <label className="card-heading">
+                <IconLock /> Myyntiehdot
+            </label>
             {Object.keys(groupedConditionsOfSale).length ? (
                 <ul>
                     {Object.entries(groupedConditionsOfSale).map(([ownerId, cos]) => (

--- a/frontend/src/features/apartment/ApartmentListPage.tsx
+++ b/frontend/src/features/apartment/ApartmentListPage.tsx
@@ -64,7 +64,6 @@ function result(data, error, isLoading, currentPage, setCurrentPage) {
                     pageInfo={data?.page}
                 />
             </QueryStateHandler>
-            <></>
         </div>
     );
 }

--- a/frontend/src/features/apartment/ApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentSalesPage.tsx
@@ -263,7 +263,7 @@ const LoadedApartmentSalesPage = ({
         );
     };
     return (
-        <>
+        <div className="view--apartment-conditions-of-sale">
             <div className="field-sets">
                 <Fieldset heading="Kaupan tiedot">
                     <form
@@ -390,7 +390,7 @@ const LoadedApartmentSalesPage = ({
                     />
                 </QueryStateHandler>
             </Dialog>
-        </>
+        </div>
     );
 };
 

--- a/frontend/src/features/housingCompany/HousingCompanyListPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyListPage.tsx
@@ -72,7 +72,7 @@ const HousingCompanyResultsList = ({filterParams}): JSX.Element => {
                 <ListPageNumbers
                     currentPage={currentPage}
                     setCurrentPage={setCurrentPage}
-                    pageInfo={data?.page}
+                    pageInfo={(data as IHousingCompanyListResponse).page}
                 />
             </QueryStateHandler>
         </div>

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -66,7 +66,7 @@
       a:hover
         text-decoration: underline
         svg
-          transform: scale(1.25)
+          transform: scale(1.2)
       .unresolved a:hover
         color: $color-black
       .resolved a:hover
@@ -76,7 +76,8 @@
       svg
         position: relative
         top: 4px
-        margin: 0px 10px 0 5px
+        margin: 0 10px 0 0
+        transition: transform 150ms linear
       .unresolved
         color: $color-black-60
       .resolved

--- a/frontend/src/styles/components/_CreatePage.sass
+++ b/frontend/src/styles/components/_CreatePage.sass
@@ -203,6 +203,7 @@
     display: grid
     grid-template-columns: auto 300px 150px 100px
     gap: 1em
+    grid-row: 1
     height: $spacing-layout-s
     font-size: $fontsize-body-s
     font-weight: 700
@@ -214,11 +215,29 @@
     padding: $spacing-layout-s
     background: $color-engel-medium-light
     display: grid
-    row-gap: 2em
+    grid-template-rows: 32px auto
+    grid-template-columns: 100%
+    row-gap: 1em
     &-item
+      background: white
       display: grid
       grid-template-columns: auto 300px 150px 100px
       gap: 1em
+      height: $spacing-layout-m
+      @include align-items(center)
+      .grace-period
+        padding-left: 18px
+      .fulfillment-date
+        align-items: center
+        margin: 0 auto
+      .input-wrap
+        @include flexbox()
+        @include align-items(center)
+      .icon-wrap
+        margin: 0 14px 0 -28px
+    svg
+      height: 22px
+      vertical-align: text-bottom
     .unresolved
       color: $color-black-60
     .resolved
@@ -228,3 +247,22 @@
       color: $color-black
     .resolved a:hover
       color: $color-black-50
+
+  // Add person/owner/entity at the condition of sale dialog
+#conditions-of-sale-creation-dialog
+  .ownership-item
+    @include flexbox()
+    @include align-items(center)
+    height: 56px
+    margin-bottom: 1em
+    .input-field
+      height: 56px
+      @include flex-grow(1)
+      margin-bottom: 0
+    .icon--remove
+      @include flexbox()
+      @include flex-flow(row)
+      @include align-items(center)
+      height: 100%
+      margin-left: $spacing-s
+

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -257,6 +257,33 @@ header
 .list-wrapper--real-estates, .list-wrapper--buildings
   width: 50%
 
+[class*="pagination_hds-pagination"] nav
+  margin-top: $spacing-s
+  @include flexbox()
+  @include justify-content(space-between)
+  @include align-items(center)
+  height: 40px
+  > div
+    display: none
+  > ul
+    @include flex-grow(1)
+    li
+      min-width: 40px
+  [class*="Button-module"]
+    border-radius: 40px
+    width: 142px
+    div
+      transition: all 350ms ease-out
+    &:hover
+      background: $color-engel
+      text-decoration: underline
+      &[class*="button-next"] div
+        transform: translateX(8px)
+      &[class*="button-prev"] div
+        transform: translateX(-8px)
+  &:before
+    display: none
+
 .detail-list
   &__heading
     @include flexbox()

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -257,32 +257,38 @@ header
 .list-wrapper--real-estates, .list-wrapper--buildings
   width: 50%
 
-[class*="pagination_hds-pagination"] nav
-  margin-top: $spacing-s
+[class*="pagination_hds-pagination-container"]
   @include flexbox()
-  @include justify-content(space-between)
-  @include align-items(center)
-  height: 40px
-  > div
-    display: none
-  > ul
-    @include flex-grow(1)
-    li
-      min-width: 40px
-  [class*="Button-module"]
-    border-radius: 40px
-    width: 142px
-    div
-      transition: all 350ms ease-out
-    &:hover
-      background: $color-engel
-      text-decoration: underline
-      &[class*="button-next"] div
-        transform: translateX(8px)
-      &[class*="button-prev"] div
-        transform: translateX(-8px)
-  &:before
-    display: none
+  nav
+    width: 100%
+    margin-top: $spacing-s
+    @include flexbox()
+    @include justify-content(space-between)
+    @include align-items(center)
+    height: 40px
+    position: relative
+    > div
+      display: none
+    > ul
+      @include flex-grow(1)
+      min-width: 760px
+      li
+        min-width: 40px
+    [type="button"]
+      border-radius: 40px
+      width: 142px
+      position: absolute
+      div
+        transition: all 350ms ease-out
+      &:hover
+        background: $color-engel
+        text-decoration: underline
+        &[class*="button-prev"] div
+          transform: translateX(-8px)
+        &[class*="button-next"] div
+          transform: translateX(8px)
+    &:before
+      display: none
 
 .detail-list
   &__heading


### PR DESCRIPTION
# Hitas Pull Request

# Description

Restyles the conditions of sale in the UI. Implements the HDS Pagination component, and fixes the problem with pressing tab and/or shift+tab when focused on a related model field. Before it was impossible to move the focus away from a related model input, as any keypress simply opened the relative model dialogbox.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested

## Test plan

Check out the sales conditions in both apartment detail view, and their own page. The remove-button was moved to it's correct place and I generally also compacted the list. The only thing I couldn't test was how the possible 3/6 month grace period is shown in the list. I replaced the raw values with icons from HDS (cross for no grace period, and a check mark along with the duration for the other two possible options there. 

## Tickets

This pull request resolves all or part of the following ticket(s): HT-392