### PR TITLE
Fix apartment sales list showing sales not for the apartment

### DIFF
--- a/backend/hitas/views/apartment_sale.py
+++ b/backend/hitas/views/apartment_sale.py
@@ -9,7 +9,7 @@ from hitas.models import Apartment, ApartmentSale
 from hitas.models.ownership import Ownership, OwnershipLike, check_ownership_percentages
 from hitas.services.apartment import prefetch_first_sale
 from hitas.services.condition_of_sale import create_conditions_of_sale
-from hitas.utils import lookup_id_to_uuid
+from hitas.utils import lookup_id_to_uuid, lookup_model_id_by_uuid
 from hitas.views.ownership import OwnershipSerializer
 from hitas.views.utils import HitasModelSerializer, HitasModelViewSet
 
@@ -121,9 +121,10 @@ class ApartmentSaleViewSet(HitasModelViewSet):
     model_class = ApartmentSale
 
     def get_default_queryset(self):
+        apartment_id = lookup_model_id_by_uuid(self.kwargs["apartment_uuid"], Apartment)
         return ApartmentSale.objects.prefetch_related(
             Prefetch(
                 "ownerships",
                 Ownership.objects.select_related("owner"),
             ),
-        )
+        ).filter(apartment_id=apartment_id)


### PR DESCRIPTION
# Hitas Pull Request

# Description

The apartment sale endpoint is mistakingly showing all sales for all apartments, even though it is under `/api/v1/housing-companies/{housing_company_id}/apartments/{apartment_id}/`, and should therefore only show that apartment's sales. This PR fixes that behavior.

## Pull request checklist

Check the boxes for each DoD items that has been completed:

- **Frontend**
    - [ ] Changes have been tested
- **Backend**
    - [x] Changes have been tested
    - [x] Automatic tests has been added
    - [ ] OpenAPI definitions have been updated
    - [ ] Database migrations will work in test environment
    - [ ] Oracle migration has been updated
    - [ ] initial.json has been updated to work with migrations

## Test plan

- [x] Check `/api/v1/housing-companies/{housing_company_id}/apartments/{apartment_id}/sales` for an apartment, it should only contain its own sales now

## Tickets

This pull request resolves all or part of the following ticket(s): ---
