### PR TITLE
Frontend conditions of sale

### DIFF
--- a/backend/hitas/models/apartment.py
+++ b/backend/hitas/models/apartment.py
@@ -241,10 +241,13 @@ class Apartment(ExternalHitasModel):
                 if sell_by_date is None:
                     continue
 
-                # If apartment was first sold after it was completed,
-                # the sell by date is calculated based on first sale date.
-                if cos.first_purchase_date is not None and cos.first_purchase_date > sell_by_date:
-                    sell_by_date = cos.first_purchase_date
+                # If apartment was sold after it was completed, the sell by date is calculated based on first sale date.
+                if hasattr(cos, "first_purchase_date"):
+                    first_purchase_date = cos.first_purchase_date
+                else:
+                    first_purchase_date = cos.get_first_purchase_date()
+                if first_purchase_date is not None and first_purchase_date > sell_by_date:
+                    sell_by_date = first_purchase_date
 
                 # If grace period has been given, it should be included
                 if cos.grace_period == GracePeriod.THREE_MONTHS:

--- a/backend/hitas/models/condition_of_sale.py
+++ b/backend/hitas/models/condition_of_sale.py
@@ -55,6 +55,21 @@ class ConditionOfSale(ExternalHitasModel):
     def fulfilled(self) -> Optional[datetime.datetime]:
         return self.deleted  # noqa
 
+    def get_first_purchase_date(self) -> Optional[datetime.date]:
+        """
+        Return the first purchase date of the new apartment.
+        Can be used to determine the sell by date.
+        When apartment was sold after it was completed, the sell by date is calculated based on first sale date.
+        """
+        from hitas.models import ApartmentSale
+
+        return (
+            ApartmentSale.objects.filter(apartment=self.new_ownership.apartment)
+            .order_by("purchase_date")
+            .values_list("purchase_date", flat=True)
+            .first()
+        )
+
     def __str__(self) -> str:
         return (
             f"{self.old_ownership.owner}: {self.old_ownership.apartment} "

--- a/backend/hitas/models/condition_of_sale.py
+++ b/backend/hitas/models/condition_of_sale.py
@@ -73,13 +73,19 @@ class ConditionOfSale(ExternalHitasModel):
 
     @property
     def sell_by_date(self) -> Optional[datetime.date]:
+        if self.fulfilled:
+            return None
+
         # If the apartment has not been completed, there is no sell by date yet.
         sell_by_date = self.new_ownership.apartment.completion_date
         if sell_by_date is None:
             return None
 
         # If apartment was sold after it was completed, the sell by date is calculated based on first sale date.
-        first_purchase_date = getattr(self, "first_purchase_date", self.get_first_purchase_date())
+        if hasattr(self, "first_purchase_date"):
+            first_purchase_date = self.first_purchase_date
+        else:
+            first_purchase_date = self.get_first_purchase_date()
         if first_purchase_date is not None and first_purchase_date > sell_by_date:
             sell_by_date = first_purchase_date
 

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -671,6 +671,7 @@ def test__api__apartment__retrieve(api_client: HitasAPIClient):
                 "id": cos.uuid.hex,
                 "grace_period": str(cos.grace_period.value),
                 "fulfilled": cos.fulfilled,
+                "sell_by_date": str(ap2.completion_date),
                 "apartment": {
                     "id": ap2.uuid.hex,
                     "address": {

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -554,10 +554,15 @@ class ApartmentConditionsOfSaleSerializer(EnumSupportSerializerMixin, HitasModel
     apartment = serializers.SerializerMethodField()
     grace_period = EnumField(GracePeriod)
     fulfilled = serializers.SerializerMethodField()
+    sell_by_date = serializers.SerializerMethodField()
 
     @staticmethod
     def get_fulfilled(instance: ConditionOfSale) -> Optional[datetime.datetime]:
         return instance.fulfilled
+
+    @staticmethod
+    def get_sell_by_date(instance: ConditionOfSale) -> Optional[datetime.date]:
+        return instance.sell_by_date
 
     def select_ownership(self, instance: ConditionOfSale) -> Ownership:
         if instance.old_ownership.apartment == self.context["apartment"]:
@@ -579,6 +584,7 @@ class ApartmentConditionsOfSaleSerializer(EnumSupportSerializerMixin, HitasModel
             "apartment",
             "grace_period",
             "fulfilled",
+            "sell_by_date",
         ]
 
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -6461,6 +6461,7 @@ components:
         - apartment
         - grace_period
         - fulfilled
+        - sell_by_date
       properties:
         id:
           description: ID of this condition of sale
@@ -6482,6 +6483,15 @@ components:
           readOnly: true
           format: date-time
           example: 1985-12-10T00:00:00+00:00
+        sell_by_date:
+          description: |-
+            The date when this apartment needs to be sold to fulfill a condition of sale linked to this apartment's
+            ownership(s). In case of multiple conditions of sale, use the first one in chronological order.
+            The value will be null if there are no current conditions of sale for this apartment's ownerships.
+          type: string
+          format: date
+          nullable: true
+          readOnly: true
 
     ConditionOfSale:
       description: Condition of sale between two ownerships

--- a/frontend/src/common/localisation.ts
+++ b/frontend/src/common/localisation.ts
@@ -1,0 +1,46 @@
+export const getHousingCompanyStateName = (state) => {
+    switch (state) {
+        case "not_ready":
+            return "Ei valmis";
+        case "lt_30_years":
+            return "Alle 30-vuotta";
+        case "gt_30_years_not_free":
+            return "Yli 30-vuotta, ei vapautunut";
+        case "gt_30_years_free":
+            return "Yli 30-vuotta, vapautunut";
+        case "gt_30_years_plot_department_notification":
+            return "Yli 30-vuotta, vapautunut tonttiosaston ilmoitus";
+        case "half_hitas":
+            return "Puoli-hitas";
+        case "ready_no_statistics":
+            return "Valmis, ei tilastoihin";
+        default:
+            return "VIRHE";
+    }
+};
+
+export function getIndexType(indexType: string) {
+    switch (indexType) {
+        case "market_price_index":
+            return "markkinahintaindeksi";
+        case "construction_price_index":
+            return "rakennuskustannusindeksi";
+        case "surface_area_price_ceiling":
+            return "rajaneliöhintaindeksi";
+        default:
+            return "VIRHE";
+    }
+}
+
+export const getApartmentStateLabel = (state) => {
+    switch (state) {
+        case "free":
+            return "Vapaa";
+        case "reserved":
+            return "Varattu";
+        case "sold":
+            return "Myyty";
+        default:
+            return "VIRHE";
+    }
+};

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -256,6 +256,7 @@ const ApartmentConditionOfSaleSchema = object({
     }),
     grace_period: z.enum(["not_given", "three_months", "six_months"]),
     fulfilled: string().nullable(),
+    sell_by_date: string().nullable(), // Read only
 });
 
 const ConditionOfSaleSchema = object({

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -375,6 +375,7 @@ const ApartmentDetailsSchema = object({
     }),
     links: ApartmentLinkedModelsSchema,
     conditions_of_sale: ApartmentConditionOfSaleSchema.array(),
+    sell_by_date: string().nullable(),
 });
 
 const ApartmentWritableSchema = object({

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -157,7 +157,9 @@ export function doesAContainB(A: object, B: object): boolean {
     return true;
 }
 
-export const getConditionsOfSaleStatusLabelType = (hasGracePeriod: boolean, sellByDate: string) => {
+export const getConditionsOfSaleStatusLabelType = (hasGracePeriod: boolean, sellByDate: string | null) => {
+    if (sellByDate === null) return "neutral";
+
     if (new Date() >= new Date(sellByDate)) return "error";
     else if (hasGracePeriod) return "alert";
     return "neutral";

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -53,17 +53,6 @@ function formatDate(value: string | null): string {
     return new Date(value).toLocaleDateString("fi-FI");
 }
 
-function formatIndex(indexType: string) {
-    switch (indexType) {
-        case "market_price_index":
-            return "markkinahintaindeksi";
-        case "construction_price_index":
-            return "rakennuskustannusindeksi";
-        case "surface_area_price_ceiling":
-            return "rajaneliöhintaindeksi";
-    }
-}
-
 function validateBusinessId(value: string): boolean {
     // e.g. '1234567-8'
     return !!value.match(/^(\d{7})-(\d)$/);
@@ -170,7 +159,6 @@ export {
     formatOwner,
     formatMoney,
     formatDate,
-    formatIndex,
     validateBusinessId,
     validateSocialSecurityNumber,
     hitasToast,

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -2,7 +2,7 @@ import toast, {ToastOptions} from "react-hot-toast";
 
 import {IAddress, IApartmentAddress, IOwner} from "./schemas";
 
-function dotted(obj: object, path: string | string[], value?: number | string | null | object) {
+export function dotted(obj: object, path: string | string[], value?: number | string | null | object) {
     /*
      Dotted getter and setter
      refs. https://stackoverflow.com/a/6394168/12730861
@@ -23,18 +23,18 @@ function dotted(obj: object, path: string | string[], value?: number | string | 
     else return dotted(obj[path[0]], path.slice(1), value);
 }
 
-function formatAddress(address: IAddress | IApartmentAddress): string {
+export function formatAddress(address: IAddress | IApartmentAddress): string {
     if ("apartment_number" in address) {
         return `${address.street_address} ${address.stair} ${address.apartment_number}, ${address.postal_code}, ${address.city}`;
     }
     return `${address.street_address}, ${address.postal_code}, ${address.city}`;
 }
 
-function formatOwner(owner: IOwner): string {
+export function formatOwner(owner: IOwner): string {
     return `${owner.name} (${owner.identifier})`;
 }
 
-function formatMoney(value: number | undefined | null, forceDecimals = false): string {
+export function formatMoney(value: number | undefined | null, forceDecimals = false): string {
     if (!value) return "-";
 
     const formatOptions = {
@@ -47,18 +47,18 @@ function formatMoney(value: number | undefined | null, forceDecimals = false): s
     return new Intl.NumberFormat("fi-FI", formatOptions).format(value);
 }
 
-function formatDate(value: string | null): string {
+export function formatDate(value: string | null): string {
     if (value === null) return "-";
 
     return new Date(value).toLocaleDateString("fi-FI");
 }
 
-function validateBusinessId(value: string): boolean {
+export function validateBusinessId(value: string): boolean {
     // e.g. '1234567-8'
     return !!value.match(/^(\d{7})-(\d)$/);
 }
 
-function validateSocialSecurityNumber(value: string): boolean {
+export function validateSocialSecurityNumber(value: string): boolean {
     if (value === null) return false;
     if (!value.match(/^(\d{6})([A-FYXWVU+-])(\d{3})([\dA-Z])$/)) {
         return false;
@@ -123,14 +123,18 @@ function validateSocialSecurityNumber(value: string): boolean {
     return checkDigits[Number(value.substring(0, 6) + idNumber) % 31] === checkDigit;
 }
 
-const today = () => new Date().toISOString().split("T")[0]; // Today's date in YYYY-MM-DD format
+export const today = () => new Date().toISOString().split("T")[0]; // Today's date in YYYY-MM-DD format
 
 // Toast hook with easier Notification typing
-function hitasToast(message: string | JSX.Element, type?: "success" | "info" | "error" | "alert", opts?: ToastOptions) {
+export function hitasToast(
+    message: string | JSX.Element,
+    type?: "success" | "info" | "error" | "alert",
+    opts?: ToastOptions
+) {
     toast(message, {...opts, className: type});
 }
 
-const hdsToast = {
+export const hdsToast = {
     success: (message: string | JSX.Element, opts?: ToastOptions) => toast(message, {...opts, className: "success"}),
     info: (message: string | JSX.Element, opts?: ToastOptions) => toast(message, {...opts, className: "info"}),
     error: (message: string | JSX.Element, opts?: ToastOptions) => toast(message, {...opts, className: "error"}),
@@ -139,7 +143,7 @@ const hdsToast = {
 
 // Returns true if obj1 contains the same key/value pairs as obj2. Note that this is non-exclusive, so obj1 doesn't
 // have to be identical to obj2, as it can contain more data than only the ones from obj2.
-function doesAContainB(A: object, B: object): boolean {
+export function doesAContainB(A: object, B: object): boolean {
     const AProps = Object.getOwnPropertyNames(A);
     const BProps = Object.getOwnPropertyNames(B);
     if (AProps.length < BProps.length) {
@@ -153,23 +157,8 @@ function doesAContainB(A: object, B: object): boolean {
     return true;
 }
 
-const getConditionsOfSaleStatusLabelType = (hasGracePeriod: boolean, sellByDate: string) => {
+export const getConditionsOfSaleStatusLabelType = (hasGracePeriod: boolean, sellByDate: string) => {
     if (new Date() >= new Date(sellByDate)) return "error";
     else if (hasGracePeriod) return "alert";
     return "neutral";
-};
-
-export {
-    dotted,
-    formatAddress,
-    formatOwner,
-    formatMoney,
-    formatDate,
-    validateBusinessId,
-    validateSocialSecurityNumber,
-    hitasToast,
-    hdsToast,
-    today,
-    doesAContainB,
-    getConditionsOfSaleStatusLabelType,
 };

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -153,6 +153,12 @@ function doesAContainB(A: object, B: object): boolean {
     return true;
 }
 
+const getConditionsOfSaleStatusLabelType = (hasGracePeriod: boolean, sellByDate: string) => {
+    if (new Date() >= new Date(sellByDate)) return "error";
+    else if (hasGracePeriod) return "alert";
+    return "neutral";
+};
+
 export {
     dotted,
     formatAddress,
@@ -165,4 +171,5 @@ export {
     hdsToast,
     today,
     doesAContainB,
+    getConditionsOfSaleStatusLabelType,
 };

--- a/frontend/src/features/apartment/ApartmentCreatePage.tsx
+++ b/frontend/src/features/apartment/ApartmentCreatePage.tsx
@@ -28,6 +28,7 @@ import {
     TextAreaInput,
     TextInput,
 } from "../../common/components/form";
+import {getApartmentStateLabel} from "../../common/localisation";
 import {
     apartmentStates,
     ApartmentWritableFormSchema,
@@ -43,19 +44,6 @@ interface IApartmentState {
     pathname: string;
     state: null | {apartment: IApartmentDetails};
 }
-
-const getApartmentStateLabel = (state) => {
-    switch (state) {
-        case "free":
-            return "Vapaa";
-        case "reserved":
-            return "Varattu";
-        case "sold":
-            return "Myyty";
-        default:
-            return "VIRHE";
-    }
-};
 
 const apartmentStateOptions = apartmentStates.map((state) => {
     return {label: getApartmentStateLabel(state), value: state};

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -375,11 +375,11 @@ const LoadedApartmentDetails = ({data}: {data: IApartmentDetails}): JSX.Element 
                                             value={formatMoney(data.prices.first_sale_share_of_housing_company_loans)}
                                         />
                                         <DetailField
-                                            label="Ensimmäinen ostopäivä"
+                                            label="Ensimmäinen kauppapäivä"
                                             value={formatDate(data.prices.first_purchase_date)}
                                         />
                                         <DetailField
-                                            label="Viimeisin ostopäivä"
+                                            label="Viimeisin kauppapäivä"
                                             value={formatDate(data.prices.latest_purchase_date)}
                                         />
                                         <DetailField

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -1,6 +1,6 @@
 import {useState} from "react";
 
-import {Button, Card, Dialog, IconDownload, IconGlyphEuro, IconLock, IconLockOpen, Tabs} from "hds-react";
+import {Button, Card, Dialog, IconDownload, IconGlyphEuro, IconLock, IconLockOpen, StatusLabel, Tabs} from "hds-react";
 import {Link, useParams} from "react-router-dom";
 
 import {
@@ -19,7 +19,7 @@ import {
     IHousingCompanyDetails,
     IOwnership,
 } from "../../common/schemas";
-import {formatAddress, formatDate, formatMoney} from "../../common/utils";
+import {formatAddress, formatDate, formatMoney, getConditionsOfSaleStatusLabelType} from "../../common/utils";
 import ApartmentHeader from "./components/ApartmentHeader";
 
 const SingleApartmentConditionOfSale = ({conditionsOfSale}: {conditionsOfSale: IApartmentConditionOfSale[]}) => {
@@ -37,7 +37,18 @@ const SingleApartmentConditionOfSale = ({conditionsOfSale}: {conditionsOfSale: I
                         <Link
                             to={`/housing-companies/${cos.apartment.housing_company.id}/apartments/${cos.apartment.id}`}
                         >
-                            {cos.fulfilled ? <IconLockOpen /> : <IconLock />}
+                            <StatusLabel
+                                className="conditions-of-sale-lock"
+                                type={
+                                    cos.fulfilled
+                                        ? "neutral"
+                                        : getConditionsOfSaleStatusLabelType(
+                                              cos.grace_period !== "not_given",
+                                              cos.sell_by_date
+                                          )
+                                }
+                                iconLeft={cos.fulfilled ? <IconLockOpen /> : <IconLock />}
+                            />
                             {formatAddress(cos.apartment.address)}
                         </Link>
                     </li>

--- a/frontend/src/features/apartment/ApartmentListPage.tsx
+++ b/frontend/src/features/apartment/ApartmentListPage.tsx
@@ -2,7 +2,6 @@ import {useState} from "react";
 
 import {IconLock, SearchInput, StatusLabel} from "hds-react";
 import {Link} from "react-router-dom";
-
 import {useGetApartmentsQuery, useGetHousingCompanyApartmentsQuery} from "../../app/services";
 import {
     FilterIntegerField,
@@ -12,7 +11,9 @@ import {
     QueryStateHandler,
 } from "../../common/components";
 import FilterCheckboxField from "../../common/components/FilterCheckboxField";
+import {getApartmentStateLabel} from "../../common/localisation";
 import {IApartment, IApartmentListResponse} from "../../common/schemas";
+import {formatDate, getConditionsOfSaleStatusLabelType} from "../../common/utils";
 
 const ApartmentListItem = ({apartment}: {apartment: IApartment}): JSX.Element => {
     // Combine ownerships into a single formatted string
@@ -44,8 +45,16 @@ const ApartmentListItem = ({apartment}: {apartment: IApartment}): JSX.Element =>
                     </div>
                 </div>
                 <div className="state">
-                    {apartment.has_conditions_of_sale ? <IconLock size="s" /> : null}
-                    <StatusLabel>{apartment.state}</StatusLabel>
+                    {apartment.has_conditions_of_sale && apartment.sell_by_date ? (
+                        <StatusLabel
+                            type={getConditionsOfSaleStatusLabelType(
+                                apartment.has_grace_period,
+                                apartment.sell_by_date
+                            )}
+                            iconLeft={<IconLock size="s" />}
+                        />
+                    ) : null}
+                    <StatusLabel>{getApartmentStateLabel(apartment.state)}</StatusLabel>
                 </div>
             </li>
         </Link>

--- a/frontend/src/features/apartment/ApartmentListPage.tsx
+++ b/frontend/src/features/apartment/ApartmentListPage.tsx
@@ -47,12 +47,15 @@ const ApartmentListItem = ({apartment}: {apartment: IApartment}): JSX.Element =>
                 <div className="state">
                     {apartment.has_conditions_of_sale && apartment.sell_by_date ? (
                         <StatusLabel
+                            className="conditions-of-sale"
                             type={getConditionsOfSaleStatusLabelType(
                                 apartment.has_grace_period,
                                 apartment.sell_by_date
                             )}
                             iconLeft={<IconLock size="s" />}
-                        />
+                        >
+                            <div className="sell-by-date">{formatDate(apartment.sell_by_date)}</div>
+                        </StatusLabel>
                     ) : null}
                     <StatusLabel>{getApartmentStateLabel(apartment.state)}</StatusLabel>
                 </div>

--- a/frontend/src/features/apartment/ApartmentListPage.tsx
+++ b/frontend/src/features/apartment/ApartmentListPage.tsx
@@ -25,16 +25,18 @@ const ApartmentListItem = ({apartment}: {apartment: IApartment}): JSX.Element =>
                 <div className="number">
                     {apartment.address.stair}
                     {apartment.address.apartment_number}
-                    {apartment.has_conditions_of_sale ? <IconLock /> : null}
                 </div>
                 <div className="details">
                     <div className="housing-company">{apartment.links.housing_company.display_name}</div>
                     <div className="ownership">{`${ownershipsString}`}</div>
                     <div className="address">
-                        {apartment.address.street_address} {apartment.address.stair}{" "}
-                        {apartment.address.apartment_number}
-                        <br />
-                        {`${apartment.address.postal_code}, ${apartment.address.city}`}
+                        <div className="street-address">
+                            {apartment.address.street_address} {apartment.address.stair}{" "}
+                            {apartment.address.apartment_number}
+                        </div>
+                        <div className="postal-code">
+                            {apartment.address.postal_code}, {apartment.address.city}
+                        </div>
                     </div>
                     <div className="area">
                         {`${apartment.surface_area ? apartment.surface_area + "m²" : ""}
@@ -42,6 +44,7 @@ const ApartmentListItem = ({apartment}: {apartment: IApartment}): JSX.Element =>
                     </div>
                 </div>
                 <div className="state">
+                    {apartment.has_conditions_of_sale ? <IconLock size="s" /> : null}
                     <StatusLabel>{apartment.state}</StatusLabel>
                 </div>
             </li>

--- a/frontend/src/features/apartment/ApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentSalesPage.tsx
@@ -16,8 +16,9 @@ import {
 import {Heading, NavigateBackButton, QueryStateHandler, SaveButton} from "../../common/components";
 import {Checkbox, DateInput, NumberInput} from "../../common/components/form";
 import OwnershipsList from "../../common/components/OwnershipsList";
+import {getIndexType} from "../../common/localisation";
 import {ApartmentSaleSchema, IApartmentDetails, IApartmentMaximumPrice, IApartmentSaleForm} from "../../common/schemas";
-import {formatDate, formatIndex, formatMoney, hdsToast, today} from "../../common/utils";
+import {formatDate, formatMoney, hdsToast, today} from "../../common/utils";
 import ApartmentHeader from "./components/ApartmentHeader";
 import MaximumPriceModalContent from "./components/ApartmentMaximumPriceBreakdownModal";
 
@@ -209,7 +210,7 @@ const LoadedApartmentSalesPage = ({
                     <p>
                         Enimmäishinnat ovat laskettu{" "}
                         <span>
-                            {` ${formatIndex(maxPriceData ? maxPriceData.index : maxPriceCalculation.index)}llä`}
+                            {` ${getIndexType(maxPriceData ? maxPriceData.index : maxPriceCalculation.index)}llä`}
                         </span>{" "}
                         ja{" "}
                         <span>

--- a/frontend/src/features/apartment/components/ApartmentHeader.tsx
+++ b/frontend/src/features/apartment/components/ApartmentHeader.tsx
@@ -1,4 +1,4 @@
-import {StatusLabel} from "hds-react";
+import {IconLock, StatusLabel} from "hds-react";
 import {Link} from "react-router-dom";
 
 import {EditButton, Heading} from "../../../common/components";
@@ -19,6 +19,12 @@ const ApartmentHeader = ({
                     <span className="name">{apartment.links.housing_company.display_name}</span>
                     <span className="address">{apartment && formatAddress(apartment.address)}</span>
                     <StatusLabel>{apartment.state}</StatusLabel>
+                    {apartment.sell_by_date ? (
+                        <StatusLabel
+                            className="conditions-of-sale-lock"
+                            iconLeft={<IconLock />}
+                        />
+                    ) : null}
                 </Link>
                 {showEditButton ? <EditButton state={{apartment: apartment}} /> : null}
             </Heading>

--- a/frontend/src/features/apartment/components/ApartmentHeader.tsx
+++ b/frontend/src/features/apartment/components/ApartmentHeader.tsx
@@ -2,6 +2,7 @@ import {IconLock, StatusLabel} from "hds-react";
 import {Link} from "react-router-dom";
 
 import {EditButton, Heading} from "../../../common/components";
+import {getApartmentStateLabel} from "../../../common/localisation";
 import {IApartmentDetails} from "../../../common/schemas";
 import {formatAddress} from "../../../common/utils";
 
@@ -18,7 +19,7 @@ const ApartmentHeader = ({
                 <Link to={`/housing-companies/${apartment.links.housing_company.id}`}>
                     <span className="name">{apartment.links.housing_company.display_name}</span>
                     <span className="address">{apartment && formatAddress(apartment.address)}</span>
-                    <StatusLabel>{apartment.state}</StatusLabel>
+                    <StatusLabel>{getApartmentStateLabel(apartment.state)}</StatusLabel>
                     {apartment.sell_by_date ? (
                         <StatusLabel
                             className="conditions-of-sale-lock"

--- a/frontend/src/features/codes/IndicesList.tsx
+++ b/frontend/src/features/codes/IndicesList.tsx
@@ -8,35 +8,14 @@ import {FilterTextInputField, FormInputField, QueryStateHandler, SaveButton} fro
 import {IIndex} from "../../common/schemas";
 import {hitasToast} from "../../common/utils";
 
-const indexTypes: {label: string}[] = [
-    {label: "market-price-index"},
-    {label: "market-price-index-2005-equal-100"},
-    {label: "construction-price-index"},
-    {label: "construction-price-index-2005-equal-100"},
-    {label: "surface-area-price-ceiling"},
-    {label: "maximum-price-index"},
+const indexOptions: {label: string; value: string}[] = [
+    {label: "Markkinahintaindeksi 1983", value: "market-price-index"},
+    {label: "Markkinahintaindeksi 2005", value: "market-price-index-2005-equal-100"},
+    {label: "Rakennuskustannusindeksi 1980", value: "construction-price-index"},
+    {label: "Rakennuskustannusindeksi 2005", value: "construction-price-index-2005-equal-100"},
+    {label: "Rajaneliöhinta", value: "surface-area-price-ceiling"},
+    {label: "Luovutushintaindeksi", value: "maximum-price-index"},
 ];
-const getIndexTypeName = (indexType: string): string => {
-    switch (indexType) {
-        case "maximum-price-index":
-            return "Luovutushintaindeksi";
-        case "market-price-index":
-            return "Markkinahintaindeksi 1983";
-        case "market-price-index-2005-equal-100":
-            return "Markkinahintaindeksi 2005";
-        case "construction-price-index":
-            return "Rakennuskustannusindeksi 1980";
-        case "construction-price-index-2005-equal-100":
-            return "Rakennuskustannusindeksi 2005";
-        case "surface-area-price-ceiling":
-            return "Rajaneliöhinta";
-        default:
-            return "VIRHE";
-    }
-};
-const indexOptions = indexTypes.map(({label}) => {
-    return {label: getIndexTypeName(label), value: label};
-});
 
 const IndexListItem = ({month, value, editFn}: {month: string; value: number; editFn}) => (
     <div
@@ -51,7 +30,7 @@ const IndexListItem = ({month, value, editFn}: {month: string; value: number; ed
     </div>
 );
 
-const LoadedIndexResultsList = ({data, editFn, currentPage}) => {
+const LoadedIndexResultsList = ({data, editFn}) => {
     return (
         <div className="results">
             <div className="list-headers">
@@ -72,12 +51,11 @@ const LoadedIndexResultsList = ({data, editFn, currentPage}) => {
     );
 };
 
-const IndexResultList = ({currentPage, setFormData, setCreateDialogOpen, indexType, filterParams}) => {
+const IndexResultList = ({setFormData, setCreateDialogOpen, indexType, filterParams}) => {
     const {data, error, isLoading} = useGetIndicesQuery({
-        indexType: indexType.label,
+        indexType: indexType.value,
         params: {
             ...filterParams,
-            page: currentPage,
             limit: 12,
         },
     });
@@ -98,34 +76,27 @@ const IndexResultList = ({currentPage, setFormData, setCreateDialogOpen, indexTy
                         });
                         setCreateDialogOpen(true);
                     }}
-                    currentPage={currentPage}
                 />
             </QueryStateHandler>
         </div>
     );
 };
 
-const todaysDate = new Date();
-const initialSaveData: IIndex = {
-    indexType: indexTypes[0].label,
-    month: `${todaysDate.getFullYear()}-${("0" + (todaysDate.getMonth() + 1)).slice(-2)}`,
-    value: null,
-};
-
 const IndicesList = (): JSX.Element => {
+    const initialSaveData: IIndex = {
+        indexType: indexOptions[0].value,
+        month: `${new Date().getFullYear()}-${("0" + (new Date().getMonth() + 1)).slice(-2)}`,
+        value: null,
+    };
+
     const [filterParams, setFilterParams] = useState({});
-    const [currentIndexType, setCurrentIndexType] = useState(indexTypes[0]);
-    const [currentPage, setCurrentPage] = useState(1);
+    const [currentIndexType, setCurrentIndexType] = useState(indexOptions[0]);
     const [formData, setFormData] = useImmer(initialSaveData);
     const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
     const closeModal = () => {
         setFormData(initialSaveData);
         setIsModalOpen(false);
-    };
-    const onSelectionChange = ({value}) => {
-        setCurrentPage(1);
-        setCurrentIndexType(() => ({label: value}));
     };
 
     return (
@@ -134,11 +105,8 @@ const IndicesList = (): JSX.Element => {
                 <Select
                     label="Indeksityyppi"
                     options={indexOptions}
-                    onChange={onSelectionChange}
-                    defaultValue={{
-                        value: indexTypes[0].label,
-                        label: getIndexTypeName(indexTypes[0].label),
-                    }}
+                    onChange={(selected) => setCurrentIndexType(selected)}
+                    defaultValue={indexOptions[0]}
                 />
                 <FilterTextInputField
                     label="Vuosi"
@@ -150,7 +118,6 @@ const IndicesList = (): JSX.Element => {
                 />
             </div>
             <IndexResultList
-                currentPage={currentPage}
                 indexType={currentIndexType}
                 setFormData={setFormData}
                 setCreateDialogOpen={setIsModalOpen}
@@ -181,7 +148,7 @@ const EditIndexModal = ({indexType, formData, setFormData, isModalOpen, closeMod
     const handleSaveIndex = () => {
         saveIndex({
             data: formData,
-            index: indexType.label,
+            index: indexType.value,
             month: formData.month,
         });
     };
@@ -208,7 +175,7 @@ const EditIndexModal = ({indexType, formData, setFormData, isModalOpen, closeMod
         >
             <Dialog.Header
                 id="index-creation-header"
-                title={"Tallenna " + getIndexTypeName(indexType.label).toLowerCase()}
+                title={`Tallenna ${indexType.label}`}
             />
             <Dialog.Content>
                 <FormInputField

--- a/frontend/src/features/housingCompany/HousingCompanyCreatePage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyCreatePage.tsx
@@ -13,6 +13,7 @@ import {
     useSaveHousingCompanyMutation,
 } from "../../app/services";
 import {FormInputField, Heading, SaveButton, SaveDialogModal} from "../../common/components";
+import {getHousingCompanyStateName} from "../../common/localisation";
 import {
     housingCompanyStates,
     ICode,
@@ -22,27 +23,6 @@ import {
     IPropertyManager,
 } from "../../common/schemas";
 import {hitasToast, validateBusinessId} from "../../common/utils";
-
-const getHousingCompanyStateName = (state) => {
-    switch (state) {
-        case "not_ready":
-            return "Ei valmis";
-        case "lt_30_years":
-            return "Alle 30-vuotta";
-        case "gt_30_years_not_free":
-            return "Yli 30-vuotta, ei vapautunut";
-        case "gt_30_years_free":
-            return "Yli 30-vuotta, vapautunut";
-        case "gt_30_years_plot_department_notification":
-            return "Yli 30-vuotta, vapautunut tonttiosaston ilmoitus";
-        case "half_hitas":
-            return "Puoli-hitas";
-        case "ready_no_statistics":
-            return "Valmis, ei tilastoihin";
-        default:
-            return "VIRHE";
-    }
-};
 
 interface IHousingCompanyLocationState {
     pathname: string;

--- a/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
@@ -3,6 +3,7 @@ import {Link, useParams} from "react-router-dom";
 
 import {useGetHousingCompanyDetailQuery} from "../../app/services";
 import {DetailField, EditButton, Heading, ImprovementsTable, QueryStateHandler} from "../../common/components";
+import {getHousingCompanyStateName} from "../../common/localisation";
 import {IHousingCompanyDetails} from "../../common/schemas";
 import {formatAddress, formatDate, formatMoney} from "../../common/utils";
 import {HousingCompanyApartmentResultsList} from "../apartment/ApartmentListPage";
@@ -16,7 +17,7 @@ const LoadedHousingCompanyDetails = ({data}: {data: IHousingCompanyDetails}) => 
                 <EditButton state={{housingCompany: data}} />
             </Heading>
             <div className="company-status">
-                <StatusLabel>Vapautunut 1.6.2022 ({data.state})</StatusLabel>
+                <StatusLabel>Vapautunut 1.6.2022 ({getHousingCompanyStateName(data.state)})</StatusLabel>
             </div>
             <div className="company-details">
                 <div className="tab-area">

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -75,7 +75,6 @@
         margin-bottom: 0
       svg
         position: relative
-        top: 4px
         margin: 0 10px 0 0
         transition: transform 150ms linear
       .unresolved
@@ -83,7 +82,12 @@
       .resolved
         color: $color-black-30
         text-decoration: line-through
-
+      .conditions-of-sale-lock
+        padding-left: 8px
+        padding-right: 8px
+        margin-right: 0.5em
+        span
+          margin: 0
 
     [class^="Card-module_card"]
       @include flexbox()

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -20,6 +20,11 @@
         display: inline-block
         margin-right: $spacing-layout-s
 
+    .conditions-of-sale-lock
+      padding-left: 8px
+      padding-right: 8px
+      display: flex
+
     .address
       font-weight: 400
 

--- a/frontend/src/styles/components/_ApartmentList.sass
+++ b/frontend/src/styles/components/_ApartmentList.sass
@@ -3,16 +3,14 @@
 .view--apartments-listing
 
   .results-list
-    height: 1009px // 10 items and 9 borders
     background: #eee
-    overflow: hidden
 
   .results-list__item
-    height: 100px
+    height: 108px
     background: white
 
   .results-list > a:last-child
-    border-bottom: 1px solid #ccc
+    border-bottom: 0
 
   .list-header
 

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -174,6 +174,12 @@ header
           justify-content: right
           column-gap: 0.4em
           width: 15%
+
+          .sell-by-date
+            display: none
+          .conditions-of-sale:hover > .sell-by-date
+              display: inline-block
+
 .list
 
   &-amount

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -107,30 +107,43 @@ header
 
           .housing-company, .address
             width: 45%
-            margin: 0
             padding-right: 1em
 
           .housing-company
-            font-size: $fontsize-body-s
+            font-size: $fontsize-body-m
             font-weight: 600
             margin: -0.3em 0 0.3em
+            margin-bottom: auto
+
+          .address
+            margin-top: auto
+
+          .street-address
+            font-size: $fontsize-body-m
+
+          .postal-code
+            font-size: $fontsize-body-s
 
           .ownership, .area
             @include flex-grow(1)
+            width: 40%
+            font-size: $fontsize-body-m
 
           .ownership
             color: $color-black-60
             display: inline-block
-            position: relative
             z-index: 10
-            font-size: $fontsize-body-m
             line-height: 1
-            width: 40%
             white-space: nowrap
             overflow: hidden
             text-overflow: ellipsis
             scrollbar-width: none
             scrollbar-color: transparent transparent
+            margin-bottom: auto
+
+          .area
+            font-size: $fontsize-body-m
+            margin-top: auto
 
         &:hover .details .ownership
           overflow-x: auto
@@ -156,7 +169,10 @@ header
 
         .state
           @include flexbox()
-          @include align-items(flex-end)
+          flex-direction: row
+          align-items: center
+          justify-content: right
+          column-gap: 0.4em
           width: 15%
 .list
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Rename `Ostopäivä` -> `Kauppapäivä`
- Make the conditions-of-sale lock coloured
- Random fixes to things that bothered me enough to have them fixed

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [x] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- Confirm how the conditions of sale behaves in frontend: Normally=gray, with grace period=yellow, overtime=red.
- Be amazed at all the other small (mostly stylistic) improvements

## Tickets

This pull request resolves all or part of the following ticket(s): HT-349, HT-472
