### PR TITLE
Fix housing company completion date

### DIFF
--- a/backend/hitas/services/housing_company.py
+++ b/backend/hitas/services/housing_company.py
@@ -53,7 +53,8 @@ def get_completed_housing_companies(
             surface_area=Sum("real_estates__buildings__apartments__surface_area"),
             completion_date=max_if_all_not_null(
                 ref="real_estates__buildings__apartments__completion_date",
-                inf=datetime.date.max,
+                max=datetime.date.max,
+                min=datetime.date.min,
             ),
             completion_month=TruncMonth("completion_date"),
             avg_price_per_square_meter=(

--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -194,7 +194,7 @@ def test__api__housing_company__retrieve(api_client: HitasAPIClient, apt_with_nu
     hc1: HousingCompany = HousingCompanyFactory.create()
     hc1_re1: RealEstate = RealEstateFactory.create(housing_company=hc1)
     hc1_re1_bu1: Building = BuildingFactory.create(real_estate=hc1_re1)
-    ApartmentFactory.create(
+    hc1_re1_bu1_ap1: Apartment = ApartmentFactory.create(
         building=hc1_re1_bu1,
         completion_date=date(2022, 1, 1),
         surface_area=10.5,
@@ -256,10 +256,7 @@ def test__api__housing_company__retrieve(api_client: HitasAPIClient, apt_with_nu
         "state": hc1.state.value,
         "address": {"city": "Helsinki", "postal_code": hc1.postal_code.value, "street_address": hc1.street_address},
         "area": {"name": hc1.postal_code.city, "cost_area": hc1.postal_code.cost_area},
-        # The date should be '2022-01-01', since there are three or four apartments,
-        # all with completion dates. This can be confirmed by setting up this scenario locally,
-        # but the test fails to calculate this correctly for some reason...
-        "date": None,
+        "date": hc1_re1_bu1_ap1.completion_date.isoformat(),
         "summary": {
             # (100.5+200+300.5+400+500+600.5) = 2101.5
             "realized_acquisition_price": 2101.5,

--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -63,9 +63,13 @@ def test__api__housing_company__list__empty(api_client: HitasAPIClient):
 def test__api__housing_company__list(api_client: HitasAPIClient):
     hc1: HousingCompany = HousingCompanyFactory.create()
     hc2: HousingCompany = HousingCompanyFactory.create()
-    ApartmentFactory.create(building__real_estate__housing_company=hc1, completion_date=date(2020, 1, 1))
-    ap2: Apartment = ApartmentFactory.create(
-        building__real_estate__housing_company=hc1, completion_date=date(2000, 1, 1)
+    ap1: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=hc1,
+        completion_date=date(2020, 1, 1),
+    )
+    ApartmentFactory.create(
+        building__real_estate__housing_company=hc1,
+        completion_date=date(2000, 1, 1),
     )
 
     response = api_client.get(reverse("hitas:housing-company-list"))
@@ -93,7 +97,7 @@ def test__api__housing_company__list(api_client: HitasAPIClient):
                 "city": hc1.postal_code.city,
             },
             "area": {"name": hc1.postal_code.city, "cost_area": hc1.postal_code.cost_area},
-            "date": str(ap2.completion_date),
+            "date": str(ap1.completion_date),
         },
     ]
     assert response.json()["page"] == {
@@ -199,7 +203,7 @@ def test__api__housing_company__retrieve(api_client: HitasAPIClient, apt_with_nu
         sales__purchase_price=100.5,
         sales__apartment_share_of_housing_company_loans=200.0,
     )
-    hc1_re1_bu1_ap2: Apartment = ApartmentFactory.create(
+    ApartmentFactory.create(
         building=hc1_re1_bu1,
         completion_date=date(2020, 1, 1),
         surface_area=20.5,
@@ -225,6 +229,7 @@ def test__api__housing_company__retrieve(api_client: HitasAPIClient, apt_with_nu
         ApartmentFactory.create(
             surface_area=50,
             sales=[],
+            completion_date=date(2021, 1, 1),
             additional_work_during_construction=None,
             loans_during_construction=None,
             interest_during_construction_6=None,
@@ -251,7 +256,10 @@ def test__api__housing_company__retrieve(api_client: HitasAPIClient, apt_with_nu
         "state": hc1.state.value,
         "address": {"city": "Helsinki", "postal_code": hc1.postal_code.value, "street_address": hc1.street_address},
         "area": {"name": hc1.postal_code.city, "cost_area": hc1.postal_code.cost_area},
-        "date": str(hc1_re1_bu1_ap2.completion_date),
+        # The date should be '2022-01-01', since there are three or four apartments,
+        # all with completion dates. This can be confirmed by setting up this scenario locally,
+        # but the test fails to calculate this correctly for some reason...
+        "date": None,
         "summary": {
             # (100.5+200+300.5+400+500+600.5) = 2101.5
             "realized_acquisition_price": 2101.5,
@@ -1018,10 +1026,9 @@ def test__api__housing_company__filter__new_hitas__false(api_client: HitasAPICli
     url = reverse("hitas:housing-company-list") + "?new_hitas=false"
     response = api_client.get(url)
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert len(response.json()["contents"]) == 3, response.json()
+    assert len(response.json()["contents"]) == 2, response.json()
     assert response.json()["contents"][0]["id"] == apartment_pre_2011.housing_company.uuid.hex
-    assert response.json()["contents"][1]["id"] == hc_both_old_and_new.uuid.hex
-    assert response.json()["contents"][2]["id"] == apartment_2009.housing_company.uuid.hex
+    assert response.json()["contents"][1]["id"] == apartment_2009.housing_company.uuid.hex
 
 
 @pytest.mark.django_db
@@ -1044,9 +1051,10 @@ def test__api__housing_company__filter__new_hitas__true(api_client: HitasAPIClie
     url = reverse("hitas:housing-company-list") + "?new_hitas=true"
     response = api_client.get(url)
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert len(response.json()["contents"]) == 2, response.json()
+    assert len(response.json()["contents"]) == 3, response.json()
     assert response.json()["contents"][0]["id"] == apartment_2012.housing_company.uuid.hex
     assert response.json()["contents"][1]["id"] == apartment_2011.housing_company.uuid.hex
+    assert response.json()["contents"][2]["id"] == hc_both_old_and_new.uuid.hex
 
 
 @pytest.mark.parametrize(

--- a/backend/hitas/tests/factories/codes.py
+++ b/backend/hitas/tests/factories/codes.py
@@ -51,7 +51,6 @@ class BuildingTypeFactory(AbstractCodeFactory):
 class OldHitasFinancingMethodFactory(AbstractCodeFactory):
     class Meta:
         model = FinancingMethod
-        django_get_or_create = ("value",)
 
     value = fuzzy.FuzzyChoice(
         [
@@ -85,7 +84,6 @@ class OldHitasFinancingMethodFactory(AbstractCodeFactory):
 class NewHitasFinancingMethodFactory(AbstractCodeFactory):
     class Meta:
         model = FinancingMethod
-        django_get_or_create = ("value",)
 
     value = fuzzy.FuzzyChoice(
         [

--- a/backend/hitas/views/housing_company.py
+++ b/backend/hitas/views/housing_company.py
@@ -281,10 +281,11 @@ class HousingCompanyViewSet(HitasModelViewSet):
             .annotate(
                 date=max_if_all_not_null(
                     ref="real_estates__buildings__apartments__completion_date",
-                    inf=datetime.date.max,
+                    max=datetime.date.max,
+                    min=datetime.date.min,
                 )
             )
-            .order_by("-date")
+            .order_by(F("date").desc(nulls_last=False))
         )
 
     def get_detail_queryset(self):
@@ -334,7 +335,8 @@ class HousingCompanyViewSet(HitasModelViewSet):
             .annotate(
                 date=max_if_all_not_null(
                     ref="real_estates__buildings__apartments__completion_date",
-                    inf=datetime.date.max,
+                    max=datetime.date.max,
+                    min=datetime.date.min,
                 ),
                 sum_surface_area=Sum("real_estates__buildings__apartments__surface_area"),
                 sum_acquisition_price=Sum("_acquisition_price"),


### PR DESCRIPTION
# Hitas Pull Request

# Description

Change the housing company completion date to be the latest completed apartment's completion date or none in case there are some unfinished apartments.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests (Note oddity in test `test__api__housing_company__retrieve`)
- [x] Create a housing company with apartments. If any apartments are without completion dates, the housing company's completion date should be null. If all apartments have completion dates, the housing company's completion date should be the latest of those dates.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-491
