### PR TITLE
Fix thirty-year regulation comparison

### DIFF
--- a/backend/hitas/services/thirty_year_regulation.py
+++ b/backend/hitas/services/thirty_year_regulation.py
@@ -362,17 +362,16 @@ def _determine_regulation_need(
                 results["skipped"].append(comparison_data)
                 continue
 
-            # TODO: Is this off by one?
-            if comparison_value <= postal_code_average_price_per_square_meter:
+            if comparison_value >= postal_code_average_price_per_square_meter:
                 logger.info(
                     f"Housing company {display_name!r} should be released from regulation since: "
-                    f"{comparison_value} <= {postal_code_average_price_per_square_meter}."
+                    f"{comparison_value} >= {postal_code_average_price_per_square_meter}."
                 )
                 results["released_from_regulation"].append(comparison_data)
             else:
                 logger.info(
                     f"Housing company {display_name!r} should stay regulated since: "
-                    f"{comparison_value} > {postal_code_average_price_per_square_meter}."
+                    f"{comparison_value} < {postal_code_average_price_per_square_meter}."
                 )
                 results["stays_regulated"].append(comparison_data)
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

Somehow the comparison was the wrong way round... (see HT-128) 

There was also a decision on whether equal values should result in the housing company being regulated or released from regulation: It should be released. (see HT-507)

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests

## Tickets

This pull request resolves all or part of the following ticket(s): HT-507
