### PR TITLE
Endpoint for 30 year regulation excel

### DIFF
--- a/backend/hitas/services/thirty_year_regulation.py
+++ b/backend/hitas/services/thirty_year_regulation.py
@@ -11,7 +11,7 @@ from django.db import models
 from django.db.models import Count, F, Max, Min, OuterRef, Prefetch, Q, Subquery
 from django.db.models.functions import TruncMonth
 from openpyxl import Workbook
-from openpyxl.styles import Alignment, Font
+from openpyxl.styles import Alignment, Border, Font, Side
 from openpyxl.worksheet.worksheet import Worksheet
 
 from hitas.exceptions import HitasModelNotFound, get_hitas_object_or_404
@@ -632,9 +632,31 @@ def build_thirty_year_regulation_report_excel(results: ThirtyYearRegulationResul
         )
         worksheet.append(data)
 
+    last_row = worksheet.max_row
+    worksheet.auto_filter.ref = worksheet.dimensions
+
+    worksheet.append(
+        ReportColumns(
+            display_name="",
+            acquisition_price=f"=SUM(B2:B{last_row})",
+            apartment_count=f"=SUM(C2:C{last_row})",
+            indices="",
+            change=f"=SUM(E2:E{last_row})",
+            adjusted_acquisition_price=f"=SUM(F2:F{last_row})",
+            surface_area=f"=SUM(G2:G{last_row})",
+            price_per_square_meter=f"=SUM(H2:H{last_row})",
+            postal_code_price=f"=SUM(I2:I{last_row})",
+            state="",
+            completion_date="",
+            age="",
+        )
+    )
+
     format_sheet(
         worksheet,
         formatting_rules={
+            **{f"{letter}1": {"border": Border(bottom=Side(style="thin"))} for letter in "ABCDEFGHIJKL"},
+            **{f"{letter}{last_row}": {"border": Border(bottom=Side(style="thin"))} for letter in "ABCDEFGHIJKL"},
             "B": {"number_format": "#,##0.00\\ €"},
             "D": {"alignment": Alignment(horizontal="right")},
             "E": {"number_format": "#,##0.00\\ €"},
@@ -656,6 +678,5 @@ def build_thirty_year_regulation_report_excel(results: ThirtyYearRegulationResul
     )
 
     resize_columns(worksheet)
-    worksheet.auto_filter.ref = worksheet.dimensions
     worksheet.protection.sheet = True
     return workbook

--- a/backend/hitas/services/thirty_year_regulation.py
+++ b/backend/hitas/services/thirty_year_regulation.py
@@ -11,6 +11,7 @@ from django.db import models
 from django.db.models import Count, F, Max, Min, OuterRef, Prefetch, Q, Subquery
 from django.db.models.functions import TruncMonth
 from openpyxl import Workbook
+from openpyxl.styles import Alignment, Font
 from openpyxl.worksheet.worksheet import Worksheet
 
 from hitas.exceptions import HitasModelNotFound, get_hitas_object_or_404
@@ -33,8 +34,10 @@ from hitas.services.housing_company import get_completed_housing_companies, make
 from hitas.services.indices import subquery_appropriate_cpi
 from hitas.utils import (
     business_quarter,
+    format_sheet,
     hitas_calculation_quarter,
     humanize_relativedelta,
+    resize_columns,
     roundup,
     subquery_count,
     to_quarter,
@@ -629,4 +632,30 @@ def build_thirty_year_regulation_report_excel(results: ThirtyYearRegulationResul
         )
         worksheet.append(data)
 
+    format_sheet(
+        worksheet,
+        formatting_rules={
+            "B": {"number_format": "#,##0.00\\ €"},
+            "D": {"alignment": Alignment(horizontal="right")},
+            "E": {"number_format": "#,##0.00\\ €"},
+            "F": {"number_format": "#,##0.00\\ €"},
+            "G": {"number_format": "#,##0.00\\ \\m\\²"},
+            "H": {"number_format": "#,##0.00\\ €"},
+            "I": {"number_format": "#,##0.00\\ €"},
+            "J": {
+                "alignment": Alignment(horizontal="right"),
+                "font": {
+                    "Ei vapaudu": Font(color="FF0000"),
+                    "Ei voitu määrittää": Font(color="0000FF"),
+                    "Vapautuu": Font(color="00FF00"),
+                },
+            },
+            "K": {"number_format": "DD.MM.YYYY"},
+            "L": {"alignment": Alignment(horizontal="right")},
+        },
+    )
+
+    resize_columns(worksheet)
+    worksheet.auto_filter.ref = worksheet.dimensions
+    worksheet.protection.sheet = True
     return workbook

--- a/backend/hitas/tests/apis/test_api_thirty_year_regulation_report.py
+++ b/backend/hitas/tests/apis/test_api_thirty_year_regulation_report.py
@@ -821,7 +821,7 @@ def test__api__regulation_results__report(api_client: HitasAPIClient, freezer):
     response: HttpResponse = api_client.get(url)
     assert response.status_code == status.HTTP_200_OK
 
-    workbook: Workbook = load_workbook(BytesIO(response.content), data_only=True)
+    workbook: Workbook = load_workbook(BytesIO(response.content), data_only=False)
     worksheet: Worksheet = workbook.worksheets[0]
 
     assert list(worksheet.values) == [
@@ -852,6 +852,20 @@ def test__api__regulation_results__report(api_client: HitasAPIClient, freezer):
             "Ei vapaudu",
             datetime.datetime(1993, 2, 1, 0, 0),
             "30 v 0 kk",
+        ),
+        (
+            None,
+            "=SUM(B2:B2)",
+            "=SUM(C2:C2)",
+            None,
+            "=SUM(E2:E2)",
+            "=SUM(F2:F2)",
+            "=SUM(G2:G2)",
+            "=SUM(H2:H2)",
+            "=SUM(I2:I2)",
+            None,
+            None,
+            None,
         ),
     ]
 

--- a/backend/hitas/utils.py
+++ b/backend/hitas/utils.py
@@ -232,14 +232,23 @@ def resize_columns(worksheet: Worksheet) -> None:
 def format_sheet(worksheet: Worksheet, formatting_rules: dict[str, dict[str, Any]]) -> None:
     cell: Cell
     for column, changes in formatting_rules.items():
+        is_cell = len(column) == 2
         for key, value in changes.items():
+            if is_cell:
+                _set_cell_attribute(worksheet[column], key, value)
+                continue
+
             for cell in worksheet[column][1:]:
-                if not isinstance(value, dict):
-                    setattr(cell, key, value)
-                    continue
+                _set_cell_attribute(cell, key, value)
 
-                val = value.get(cell.value)
-                if val is None:
-                    continue
 
-                setattr(cell, key, val)
+def _set_cell_attribute(cell: Cell, key: str, value: Any) -> None:
+    if not isinstance(value, dict):
+        setattr(cell, key, value)
+        return
+
+    val = value.get(cell.value)
+    if val is None:
+        return
+
+    setattr(cell, key, val)

--- a/backend/hitas/utils.py
+++ b/backend/hitas/utils.py
@@ -4,6 +4,7 @@ from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Iterable, Optional, overload
 from uuid import UUID
 
+from dateutil.relativedelta import relativedelta
 from django.db import models
 from django.db.models import Case, Count, F, Max, Model, OuterRef, Q, Subquery, Value, When
 from django.db.models.functions import NullIf, Round
@@ -204,3 +205,7 @@ def roundup(v, precision: int = 2):
     if precision <= 0:
         return v.quantize(Decimal("1"), ROUND_HALF_UP)
     return v.quantize(Decimal("." + "0" * precision), ROUND_HALF_UP)
+
+
+def humanize_relativedelta(delta: relativedelta) -> str:
+    return f"{delta.years} v {delta.months} kk"

--- a/backend/hitas/views/thirty_year_regulation.py
+++ b/backend/hitas/views/thirty_year_regulation.py
@@ -11,10 +11,13 @@ from rest_framework.viewsets import ViewSet
 from hitas.exceptions import ModelConflict
 from hitas.models.thirty_year_regulation import RegulationResult
 from hitas.services.thirty_year_regulation import (
+    build_thirty_year_regulation_report_excel,
+    get_thirty_year_regulation_results,
     get_thirty_year_regulation_results_for_housing_company,
     perform_thirty_year_regulation,
 )
 from hitas.utils import from_iso_format_or_today_if_none
+from hitas.views.utils.excel import get_excel_response
 from hitas.views.utils.pdf import get_pdf_response
 
 
@@ -59,3 +62,20 @@ class ThirtyYearRegulationView(ViewSet):
         choice = "jatkumisesta" if results.regulation_result == RegulationResult.STAYS_REGULATED else "pättymisestä"
         filename = f"Tiedote sääntelyn {choice} - {results.housing_company.display_name}.pdf"
         return get_pdf_response(filename=filename, template="regulation_letter.jinja", context=context)
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path=r"reports/download-regulation-results",
+        url_name="results",
+    )
+    def regulation_results(self, request: Request, *args, **kwargs) -> HttpResponse:
+        try:
+            calculation_date = from_iso_format_or_today_if_none(request.query_params.get("calculation_date"))
+        except ValueError as error:
+            raise ValidationError({"calculation_date": str(error)}) from error
+
+        results = get_thirty_year_regulation_results(calculation_date)
+        workbook = build_thirty_year_regulation_report_excel(results)
+        filename = f"30v vertailun tulokset ({results.calculation_month.isoformat()}).xlsx"
+        return get_excel_response(filename=filename, excel=workbook)

--- a/backend/hitas/views/utils/excel.py
+++ b/backend/hitas/views/utils/excel.py
@@ -1,7 +1,9 @@
 from io import BytesIO
+from tempfile import NamedTemporaryFile
 from typing import Any, Literal, Optional, Protocol, TypeAlias
 
 from django.core.handlers.wsgi import WSGIRequest
+from django.http import HttpResponse
 from openpyxl.cell import Cell
 from openpyxl.reader.excel import load_workbook
 from openpyxl.utils import column_index_from_string
@@ -10,6 +12,17 @@ from openpyxl.worksheet.worksheet import Worksheet
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.parsers import BaseParser
 from rest_framework.serializers import Serializer
+
+
+def get_excel_response(filename: str, excel: Workbook) -> HttpResponse:
+    with NamedTemporaryFile() as tmp:
+        excel.save(tmp.name)
+        tmp.seek(0)
+        data: bytes = tmp.read()
+
+    response = HttpResponse(data, content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    response.headers["Content-Disposition"] = f"attachment; filename={filename}"
+    return response
 
 
 class _ExcelParser(BaseParser):

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2416,6 +2416,37 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/v1/thirty-year-regulation/reports/download-regulation-results:
+    get:
+      description: Download thirty-year regulation results as an Excel
+      operationId: read-regulation-report-excel
+      tags:
+        - Thirty Year Regulation
+      parameters:
+        - name: calculation_date
+          required: false
+          in: query
+          description: Calculation date of the regulation, use current date if not given
+          schema:
+            type: string
+            example: 2023-01-01
+      responses:
+        '200':
+          description: Successfully downloaded a regulation report
+          content:
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   # Property Manager
 
   /api/v1/property-managers:


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds the ability to create an excel report of the thirty-year regulation results.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests

- [ ] When using PyCharm, open the python console and run the following code:

```python
import datetime
from decimal import Decimal
from hitas.models.thirty_year_regulation import ThirtyYearRegulationResults, ThirtyYearRegulationResultsRow
from hitas.models.housing_company import HousingCompany

res = ThirtyYearRegulationResults.objects.create(
    regulation_month=datetime.datetime(1993, 2, 1),
    calculation_month=datetime.date(2023, 2, 1),
    surface_area_price_ceiling=Decimal('5000.00'),
    sales_data={
        "external": {},
        "internal": {'00001': {'2022Q4': {'price': 49000.0, 'sale_count': 1}}},
        "price_by_area": {'00001': 49000.0}
    }
)
hc = HousingCompany.objects.first()
row = ThirtyYearRegulationResultsRow.objects.create(
    parent=res,
    housing_company=hc,
    completion_date=datetime.date(1993, 2, 1),
    surface_area=Decimal('10.00'),
    postal_code="00001",
    realized_acquisition_price=Decimal('60000.00'),
    unadjusted_average_price_per_square_meter=Decimal('6000.00'),
    adjusted_average_price_per_square_meter=Decimal('12000.00'),
    completion_month_index=Decimal('100.00'),
    calculation_month_index=Decimal('200.00'),
    regulation_result="stays_regulated",
)
print(hc.uuid.hex)
```

This should create a testing thirty-year calculation results in the database. 

Now, go to `/api/v1/thirty-year-regulation/reports/download-regulation-results` and evaluate the resulting excel sheet.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-503
