### PR TITLE
Add endpoint for surface area price ceiling results excel

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3554,6 +3554,35 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/v1/indices/surface-area-price-ceiling/reports/download-surface-area-price-ceiling-results:
+    get:
+      description: Download surface area price ceiling calculation results as an Excel
+      operationId: read-surface-area-price-ceiling-excel
+      tags:
+        - Indices
+      parameters:
+        - name: calculation_date
+          required: false
+          in: query
+          description: Calculation date of the surface area price ceiling, use current date if not given
+          schema:
+            type: string
+            example: 2023-01-01
+      responses:
+        '200':
+          description: Successfully downloaded a surface area price ceiling report
+          content:
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/v1/indices/{index}/{month}:
     get:
       description: Read a single index by month


### PR DESCRIPTION
# Hitas Pull Request

# Description

&lt;write your pull request description here&gt;

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] When using PyCharm, open the python console and run the following code:

```python
import datetime
from decimal import Decimal
from hitas.models.indices import SurfaceAreaPriceCeilingCalculationData, CalculationData, HousingCompanyData, SurfaceAreaPriceCeilingResult

data = CalculationData(
    housing_company_data=[
        HousingCompanyData(
            name="Foo",
            completion_date="2022-02-01",
            surface_area=10.0,
            realized_acquisition_price=60_000.0,
            unadjusted_average_price_per_square_meter=6_000.0,
            adjusted_average_price_per_square_meter=12_000.0,
            completion_month_index=100.0,
            calculation_month_index=200.0,
        ),
        HousingCompanyData(
            name="Bar",
            completion_date="2022-02-01",
            surface_area=25.0,
            realized_acquisition_price=40_000.0,
            unadjusted_average_price_per_square_meter=1_600.0,
            adjusted_average_price_per_square_meter=3_200.0,
            completion_month_index=100.0,
            calculation_month_index=200.0,
        ),
    ],
    created_surface_area_price_ceilings=[
        SurfaceAreaPriceCeilingResult(month="2023-02", value=7_600.0),
        SurfaceAreaPriceCeilingResult(month="2023-03", value=7_600.0),
        SurfaceAreaPriceCeilingResult(month="2023-04", value=7_600.0),
    ],
)

SurfaceAreaPriceCeilingCalculationData.objects.create(data=data, calculation_month=datetime.date(2023, 2, 1))

```

This should create a testing surface area price ceiling calculation results in the database. 

Now go `/api/v1/indices/surface-area-price-ceiling/reports/download-surface-area-price-ceiling-results` to download the report and observe the excel sheet.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-433
