### PR TITLE
Add endpoints for fetching surface area price ceiling calculation data

### DIFF
--- a/backend/hitas/urls.py
+++ b/backend/hitas/urls.py
@@ -34,6 +34,11 @@ router.register(
     basename="surface-area-price-ceiling",
 )
 router.register(
+    r"indices/surface-area-price-ceiling-calculation-data",
+    views.SurfaceAreaPriceCeilingCalculationDataViewSet,
+    basename="surface-area-price-ceiling-calculation-data",
+)
+router.register(
     r"external-sales-data",
     views.ExternalSalesDataView,
     basename="external-sales-data",

--- a/backend/hitas/views/__init__.py
+++ b/backend/hitas/views/__init__.py
@@ -13,6 +13,7 @@ from hitas.views.indices import (
     MarketPriceIndex2005Equal100ViewSet,
     MarketPriceIndexViewSet,
     MaximumPriceIndexViewSet,
+    SurfaceAreaPriceCeilingCalculationDataViewSet,
     SurfaceAreaPriceCeilingViewSet,
 )
 from hitas.views.owner import OwnerViewSet

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3580,6 +3580,70 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
+
+  /api/v1/indices/surface-area-price-ceiling-calculation-data:
+    get:
+      description: List all stored surface area price ceiling calculation data
+      operationId: list-surface-area-price-ceiling-calculation-data
+      tags:
+        - Indices
+      responses:
+        '200':
+          description: Successfully fetched list of surface area price ceiling calculation data
+          content:
+            application/json:
+              schema:
+                description: Single page of surface area price ceiling calculation data
+                type: object
+                additionalProperties: false
+                required:
+                  - page
+                  - contents
+                properties:
+                  page:
+                    $ref: '#/components/schemas/PageInfo'
+                  contents:
+                    description: List of surface area price ceiling calculation data
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SurfaceAreaPriceCeilingCalculationResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/v1/indices/surface-area-price-ceiling-calculation-data/{calculation_month}:
+    get:
+      description: Read a sinlge surface area price ceiling calculation data for the given month
+      operationId: read-surface-area-price-ceiling-calculation-data
+      tags:
+        - Indices
+      parameters:
+        - name: calculation_month
+          required: true
+          in: path
+          description: Calculation month for a surface area price ceiling
+          schema:
+            type: string
+            format: date
+            example: 2023-02-01
+      responses:
+        '200':
+          description: Successfully fetched list of surface area price ceiling calculation data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SurfaceAreaPriceCeilingCalculationResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -7032,6 +7096,89 @@ components:
           description: Does this housing company use the old or the new hitas ruleset?
           type: boolean
           example: false
+
+    SurfaceAreaPriceCeilingCalculationResult:
+      description: Surface area price ceiling calculation
+      type: object
+      additionalProperties: false
+      required:
+        - calculation_month
+        - data
+      properties:
+        calculation_month:
+          description: Surface area price ceiling calculation month
+          type: string
+          format: date
+          example: 2023-02-01
+        data:
+          $ref: '#/components/schemas/SurfaceAreaPriceCeilingCalculationData'
+
+    SurfaceAreaPriceCeilingCalculationData:
+      description: Surface area price ceiling calculation data
+      type: object
+      additionalProperties: false
+      required:
+        - housing_company_data
+        - created_surface_area_price_ceilings
+      properties:
+        housing_company_data:
+          type: array
+          items:
+            $ref: '#/components/schemas/SurfaceAreaPriceCeilingCalculationHousingCompanyData'
+        created_surface_area_price_ceilings:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items:
+            $ref: '#/components/schemas/Index'
+
+    SurfaceAreaPriceCeilingCalculationHousingCompanyData:
+      description: Surface area price ceiling calculation data
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - completion_date
+        - surface_area
+        - realized_acquisition_price
+        - unadjusted_average_price_per_square_meter
+        - adjusted_average_price_per_square_meter
+        - completion_month_index
+        - calculation_month_index
+      properties:
+        name:
+          description: Housing company's display name
+          type: string
+          example: Taloyhtiö Helmi
+        completion_date:
+          description: Housing company completion date
+          type: string
+          format: date
+          example: 1999-12-31
+        surface_area:
+          description: Housing company surface area
+          type: number
+          example: 59.6
+        realized_acquisition_price:
+          description: Housing company realized acquisition price
+          type: number
+          example: 60000.0
+        unadjusted_average_price_per_square_meter:
+          description: Average price per square meter before index adjustment
+          type: number
+          example: 6000.0
+        adjusted_average_price_per_square_meter:
+          description: Average price per square meter after index adjustment
+          type: number
+          example: 12000.0
+        completion_month_index:
+          description: Market price index for the month the housing company was completed
+          type: number
+          example: 100.0
+        calculation_month_index:
+          description: Market price index for the month the calculation was made
+          type: number
+          example: 200.0
 
     # Errors
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds endpoints for listing calculation data for surface area price ceiling.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] When using PyCharm, open the python console and run the following code:

```python
import datetime
from decimal import Decimal
from hitas.models.indices import SurfaceAreaPriceCeilingCalculationData, CalculationData, HousingCompanyData, SurfaceAreaPriceCeilingResult

data = CalculationData(
    housing_company_data=[
        HousingCompanyData(
            name="Foo",
            completion_date="2022-02-01",
            surface_area=10.0,
            realized_acquisition_price=60_000.0,
            unadjusted_average_price_per_square_meter=6_000.0,
            adjusted_average_price_per_square_meter=12_000.0,
            completion_month_index=100.0,
            calculation_month_index=200.0,
        ),
        HousingCompanyData(
            name="Bar",
            completion_date="2022-02-01",
            surface_area=25.0,
            realized_acquisition_price=40_000.0,
            unadjusted_average_price_per_square_meter=1_600.0,
            adjusted_average_price_per_square_meter=3_200.0,
            completion_month_index=100.0,
            calculation_month_index=200.0,
        ),
    ],
    created_surface_area_price_ceilings=[
        SurfaceAreaPriceCeilingResult(month="2023-02", value=7_600.0),
        SurfaceAreaPriceCeilingResult(month="2023-03", value=7_600.0),
        SurfaceAreaPriceCeilingResult(month="2023-04", value=7_600.0),
    ],
)

SurfaceAreaPriceCeilingCalculationData.objects.create(data=data, calculation_month=datetime.date(2023, 2, 1))

```

This should create a testing surface area price ceiling calculation results in the database. 

Now go `/api/v1/indices/surface-area-price-ceiling-calculation-data` to see a paginated list of all saved calculation data. To see a calculation data for a specific date, use  `/api/v1/indices/surface-area-price-ceiling-calculation-data/{calculation_date}` where `calculation_date` is an ISO date when the calculation was made, e.g. `2023-02-01` in the example case.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-505
