### PR TITLE
Various small fixes

### DIFF
--- a/backend/hitas/models/external_sales_data.py
+++ b/backend/hitas/models/external_sales_data.py
@@ -19,7 +19,6 @@ class QuarterData(TypedDict):
 
 
 class ExternalSalesDataType(TypedDict):
-    calculation_quarter: str
     quarter_1: QuarterData
     quarter_2: QuarterData
     quarter_3: QuarterData

--- a/backend/hitas/services/external_sales_data.py
+++ b/backend/hitas/services/external_sales_data.py
@@ -18,7 +18,6 @@ def remove_unused_areas(data: "CostAreaSalesCatalogData") -> None:
 
 def create_external_sales_data(data: "CostAreaSalesCatalogData") -> ExternalSalesData:
     sales_data = ExternalSalesDataType(
-        calculation_quarter=data["quarter_4"],
         quarter_1=QuarterData(quarter="", areas=[]),
         quarter_2=QuarterData(quarter="", areas=[]),
         quarter_3=QuarterData(quarter="", areas=[]),
@@ -26,7 +25,7 @@ def create_external_sales_data(data: "CostAreaSalesCatalogData") -> ExternalSale
     )
 
     quarter: Literal["quarter_1", "quarter_2", "quarter_3", "quarter_4"]
-    for quarter in ["quarter_1", "quarter_2", "quarter_3", "quarter_4"]:
+    for quarter in sales_data:
         sales_data[quarter]["quarter"] = data[quarter]
         for cost_area in data["areas"]:
             # Do not add cost area to quarter if values don't exist
@@ -43,4 +42,4 @@ def create_external_sales_data(data: "CostAreaSalesCatalogData") -> ExternalSale
                 )
             )
 
-    return ExternalSalesData.objects.create(**sales_data)
+    return ExternalSalesData.objects.update_or_create(calculation_quarter=data["quarter_4"], defaults=sales_data)[0]

--- a/backend/hitas/services/housing_company.py
+++ b/backend/hitas/services/housing_company.py
@@ -5,7 +5,7 @@ from typing import Literal
 from _decimal import Decimal
 from django.db import models
 from django.db.models import ExpressionWrapper, F, Q, Sum
-from django.db.models.functions import Coalesce, NullIf, TruncMonth
+from django.db.models.functions import Coalesce, NullIf, Round, TruncMonth
 from rest_framework.exceptions import ValidationError
 from rest_framework.settings import api_settings
 from typing_extensions import TypeAlias
@@ -50,7 +50,7 @@ def get_completed_housing_companies(
                 Coalesce(Sum("_first_sale_prices"), 0) + F("_catalog_prices"),
                 output_field=HitasModelDecimalField(),
             ),
-            surface_area=Sum("real_estates__buildings__apartments__surface_area"),
+            surface_area=Round(Sum("real_estates__buildings__apartments__surface_area")),
             completion_date=max_if_all_not_null(
                 ref="real_estates__buildings__apartments__completion_date",
                 max=datetime.date.max,

--- a/backend/hitas/services/thirty_year_regulation.py
+++ b/backend/hitas/services/thirty_year_regulation.py
@@ -470,7 +470,13 @@ def _save_regulation_results(
     )
 
     if not created:
-        ThirtyYearRegulationResultsRow.objects.filter(parent=thirty_year_regulation_results).delete()
+        # Retain regulation results in this calculation month for released housing companies,
+        # as those will not have been part of subsequent regulation checks, but should still show up
+        # in this calculation month's regulation results.
+        ThirtyYearRegulationResultsRow.objects.filter(
+            Q(parent=thirty_year_regulation_results),
+            ~Q(housing_company__state=HousingCompanyState.GREATER_THAN_30_YEARS_NOT_FREE),
+        ).delete()
 
     rows_to_save: list[ThirtyYearRegulationResultsRow] = []
     for housing_company in housing_companies:

--- a/backend/hitas/tests/apis/test_api_external_sales_data.py
+++ b/backend/hitas/tests/apis/test_api_external_sales_data.py
@@ -454,19 +454,18 @@ def test__api__external_sales_data__create__invalid_data(api_client: HitasAPICli
 @pytest.mark.django_db
 def test__api__external_sales_data__retrieve(api_client: HitasAPIClient):
     data = ExternalSalesDataType(
-        calculation_quarter="2022Q4",
         quarter_1=QuarterData(quarter="2022Q1", areas=[CostAreaData(postal_code="00000", sale_count=1, price=2)]),
         quarter_2=QuarterData(quarter="2022Q2", areas=[CostAreaData(postal_code="00000", sale_count=3, price=4)]),
         quarter_3=QuarterData(quarter="2022Q3", areas=[CostAreaData(postal_code="00000", sale_count=5, price=6)]),
         quarter_4=QuarterData(quarter="2022Q4", areas=[CostAreaData(postal_code="00000", sale_count=7, price=8)]),
     )
-    ExternalSalesData.objects.create(**data)
+    ExternalSalesData.objects.create(calculation_quarter="2022Q4", **data)
 
     url = reverse("hitas:external-sales-data-detail", args=["2022Q4"])
     response = api_client.get(url, format="json")
 
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.json() == data
+    assert response.json() == {**{"calculation_quarter": "2022Q4"}, **data}
 
 
 @pytest.mark.django_db

--- a/backend/hitas/views/housing_company.py
+++ b/backend/hitas/views/housing_company.py
@@ -2,6 +2,7 @@ import datetime
 from typing import Any, Dict, Optional
 
 from django.db.models import F, OuterRef, Prefetch, Subquery, Sum
+from django.db.models.functions import Round
 from django_filters.rest_framework import BooleanFilter
 from enumfields.drf.serializers import EnumSupportSerializerMixin
 from rest_framework import serializers
@@ -338,7 +339,7 @@ class HousingCompanyViewSet(HitasModelViewSet):
                     max=datetime.date.max,
                     min=datetime.date.min,
                 ),
-                sum_surface_area=Sum("real_estates__buildings__apartments__surface_area"),
+                sum_surface_area=Round(Sum("real_estates__buildings__apartments__surface_area")),
                 sum_acquisition_price=Sum("_acquisition_price"),
                 avg_price_per_square_meter=RoundWithPrecision(
                     F("sum_acquisition_price") / F("sum_surface_area"),


### PR DESCRIPTION
# Hitas Pull Request

# Description

Small fixes for thirty-year regulation, external sales data and housing company surface area.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [ ] Create a thirty-year calculation, and try to re-run it. Any housing company that was freed in the first regulation check should still remain in the regulation results after the second check
- [ ] Upload external sales data (tilastokeskuksen kaupat) two times. It should not break but override the first results.
- [ ] Add fractions to some apartment surface area. The housing company surface area should still be a whole number.

## Tickets

This pull request resolves all or part of the following ticket(s): -
