### PR TITLE
Sale conditions styling

### DIFF
--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -30,19 +30,36 @@ const SingleApartmentConditionOfSale = ({conditionsOfSale}: {conditionsOfSale: I
                 {conditionsOfSale[0].owner.name} ({conditionsOfSale[0].owner.identifier})
             </h3>
             <ul>
-                {conditionsOfSale.map((cos) => (
-                    <li
-                        key={cos.id}
-                        className={cos.fulfilled ? "resolved" : "unresolved"}
-                    >
-                        <Link
-                            to={`/housing-companies/${cos.apartment.housing_company.id}/apartments/${cos.apartment.id}`}
+                {conditionsOfSale
+                    .filter((cos) => !cos.fulfilled)
+                    .map((cos) => (
+                        <li
+                            key={cos.id}
+                            className="unresolved"
                         >
-                            <ConditionsOfSaleStatus conditionOfSale={cos} />
-                            {formatAddress(cos.apartment.address)}
-                        </Link>
-                    </li>
-                ))}
+                            <Link
+                                to={`/housing-companies/${cos.apartment.housing_company.id}/apartments/${cos.apartment.id}`}
+                            >
+                                <ConditionsOfSaleStatus conditionOfSale={cos} />
+                                <span className="address">{formatAddress(cos.apartment.address)}</span>
+                            </Link>
+                        </li>
+                    ))}
+                {conditionsOfSale
+                    .filter((cos) => cos.fulfilled)
+                    .map((cos) => (
+                        <li
+                            key={cos.id}
+                            className="resolved"
+                        >
+                            <Link
+                                to={`/housing-companies/${cos.apartment.housing_company.id}/apartments/${cos.apartment.id}`}
+                            >
+                                <ConditionsOfSaleStatus conditionOfSale={cos} />
+                                <span className="address">{formatAddress(cos.apartment.address)}</span>
+                            </Link>
+                        </li>
+                    ))}
             </ul>
         </li>
     );

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -83,9 +83,7 @@ const ApartmentConditionsOfSaleCard = ({apartment}: {apartment: IApartmentDetail
                     </Button>
                 </Link>
             </div>
-            <label className="card-heading">
-                <IconLock /> Myyntiehdot
-            </label>
+            <label className="card-heading card-heading--conditions-of-sale">Myyntiehdot</label>
             {Object.keys(groupedConditionsOfSale).length ? (
                 <ul>
                     {Object.entries(groupedConditionsOfSale).map(([ownerId, cos]) => (

--- a/frontend/src/features/apartment/ApartmentListPage.tsx
+++ b/frontend/src/features/apartment/ApartmentListPage.tsx
@@ -24,8 +24,11 @@ const ApartmentListItem = ({apartment}: {apartment: IApartment}): JSX.Element =>
         <Link to={`/housing-companies/${apartment.links.housing_company.id}/apartments/${apartment.id}`}>
             <li className="results-list__item results-list__item--apartment">
                 <div className="number">
-                    {apartment.address.stair}
-                    {apartment.address.apartment_number}
+                    <span className="stair-and-number">
+                        {apartment.address.stair}
+                        {apartment.address.apartment_number}
+                    </span>
+                    <ConditionsOfSaleStatus apartment={apartment} />
                 </div>
                 <div className="details">
                     <div className="housing-company">{apartment.links.housing_company.display_name}</div>
@@ -45,7 +48,6 @@ const ApartmentListItem = ({apartment}: {apartment: IApartment}): JSX.Element =>
                     </div>
                 </div>
                 <div className="state">
-                    <ConditionsOfSaleStatus apartment={apartment} />
                     <StatusLabel>{getApartmentStateLabel(apartment.state)}</StatusLabel>
                 </div>
             </li>

--- a/frontend/src/styles/base/_general.sass
+++ b/frontend/src/styles/base/_general.sass
@@ -27,6 +27,16 @@ ul, ol
       .results &
         --spinner-size: 12rem
         --spinner-thickness: 1.4rem
+[class^="view--"]
+  @include flexbox()
+  @include flex-flow(column nowrap)
+  flex-grow: 1
+  > .spinner-wrap
+    flex-grow: 1
+    [class*="LoadingSpinner-module_loadingSpinner"]
+      --spinner-size: 12rem
+      --spinner-color: var(--color-engel)
+      --spinner-thickness: 1.4rem
 
 .query-handler-error
   @include flexbox()

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -66,19 +66,25 @@
       margin: 0
       padding: 0
       a:hover
-        text-decoration: underline
-        svg
-          transform: scale(1.2)
+        .address
+          text-decoration: underline
       .unresolved a:hover
         color: $color-black
       .resolved a:hover
         color: $color-black-50
       h3
-        margin-bottom: 0
+        margin: $spacing-2-xs 0
+      [class*="hds-status-label-icon"]
+        margin-right: -4px
       svg
         position: relative
         margin: 0 10px 0 0
         transition: transform 150ms linear
+      li
+        margin-bottom: 5px
+        &:not(:first-child)
+          h3
+            margin-top: 1rem
       .unresolved
         color: $color-black-60
       .resolved
@@ -103,9 +109,10 @@
         font-size: $fontsize-heading-m
         font-weight: 700
         margin-bottom: 0.5rem
-
         &:last-of-type
           margin-top: $spacing-l
+        &--conditions-of-sale
+          margin-top: $spacing-2-xs !important
 
       .unconfirmed-prices
         @include flexbox()

--- a/frontend/src/styles/components/_CreatePage.sass
+++ b/frontend/src/styles/components/_CreatePage.sass
@@ -196,8 +196,8 @@
   .conditions-of-sale-headers
     position: relative
     display: grid
-    grid-template-columns: auto 300px 150px 100px
-    gap: 1em
+    grid-template-columns: auto 500px 150px 100px
+    gap: $spacing-layout-2-xs
     grid-row: 1
     height: $spacing-layout-s
     font-size: $fontsize-body-s
@@ -210,13 +210,13 @@
     padding: $spacing-layout-s
     background: $color-engel-medium-light
     display: grid
-    grid-template-rows: 32px auto
+    grid-template-rows: $spacing-layout-2-xs auto
     grid-template-columns: 100%
     row-gap: 1em
     &-item
       background: white
       display: grid
-      grid-template-columns: auto 300px 150px 100px
+      grid-template-columns: auto 500px 150px 100px
       gap: 1em
       height: $spacing-layout-m
       @include align-items(center)

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -353,15 +353,33 @@ footer
     margin: $spacing-m 0
 
 .conditions-of-sale-status
-  display: flex
+  @include flexbox()
   flex-direction: row
-  align-items: center
-  padding-left: 8px
-  padding-right: 8px
+  @include justify-content(center)
+  @include align-items(center)
+  //padding-left: 8px
+  //padding-right: 8px
   margin-right: 0.5em
   span
     margin: 0
+    svg
+      margin: 0 !important
+  [class*="hds-status-label-icon"]
+    width: 24px
+    opacity: 1
+    transition: width 200ms 100ms, opacity 100ms
   .sell-by-date
-    display: none
-  &:hover > .sell-by-date
-    display: inline-block
+    overflow: hidden
+    width: 0px
+    opacity: 0
+    text-align: center
+    transition: width 200ms 100ms, opacity 200ms
+  &:hover
+    [class*="hds-status-label-icon"]
+      width: 0px
+      opacity: 0
+      transition: width 100ms, opacity 100ms
+    .sell-by-date
+      width: 74px
+      opacity: 1
+      transition: width 200ms, opacity 200ms 100ms

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -92,11 +92,33 @@ header
         grid-template-rows: auto auto
 
         .number
+          @include flexbox()
+          @include align-items(center)
           font-size: $fontsize-heading-l
           letter-spacing: -1px
-          text-transform: uppercase
-          width: 10%
-          line-height: 1.25
+          width: 12%
+          text-align: center
+          padding-right: 1rem
+          .stair-and-number
+            width: 100%
+            line-height: 1.25
+            text-transform: uppercase
+          .conditions-of-sale-status
+            position: relative
+            width: 32px
+            margin: 0
+            padding: 0
+            transition: width 200ms
+            [class*="hds-status-label-icon"]
+              position: absolute
+              width: 24px
+              transition: opacity 200ms 200ms
+            &:hover
+              width: 70px
+              [class*="hds-status-label-icon"]
+                transition: opacity 200ms
+              .sell-by-date
+                overflow: visible
 
         .details
           @include flex-grow(1)


### PR DESCRIPTION
# Hitas Pull Request

# Description

Restyles the conditions of sale elements, and fixes the loading spinner styling on white backgrounds (initial page load).

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [X] Changes have been tested

## Test plan

Check out how the CoS list and status labels look now. Same with the loading spinner.. the fix can be seen e.g. on the apartment details page, as it has the QueryStateHandler on a white background.

## Tickets

This pull request resolves all or part of the following ticket(s): 
