### PR TITLE
Refactor test factories

### DIFF
--- a/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
@@ -9,6 +9,7 @@ from hitas.models import (
     Apartment,
     ApartmentConstructionPriceImprovement,
     ApartmentMarketPriceImprovement,
+    ApartmentSale,
     HousingCompanyConstructionPriceImprovement,
     HousingCompanyMarketPriceImprovement,
     Ownership,
@@ -20,6 +21,7 @@ from hitas.tests.factories import (
     ApartmentConstructionPriceImprovementFactory,
     ApartmentFactory,
     ApartmentMarketPriceImprovementFactory,
+    ApartmentSaleFactory,
     HousingCompanyConstructionPriceImprovementFactory,
     HousingCompanyMarketPriceImprovementFactory,
     OwnershipFactory,
@@ -41,8 +43,7 @@ def test__api__apartment_max_price__construction_price_index__2011_onwards(api_c
         surface_area=30.0,
         share_number_start=18402,
         share_number_end=20784,
-        sales__purchase_price=80350,
-        sales__apartment_share_of_housing_company_loans=119150,
+        sales=[],
         building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     # Create another apartment with rest of the surface area
@@ -56,8 +57,15 @@ def test__api__apartment_max_price__construction_price_index__2011_onwards(api_c
     mpi_improvement: HousingCompanyMarketPriceImprovement = HousingCompanyMarketPriceImprovementFactory.create(
         housing_company=a.housing_company, value=150000, completion_date=datetime.date(2020, 5, 21)
     )
-    o1: Ownership = OwnershipFactory.create(apartment=a, percentage=75.2)
-    o2: Ownership = OwnershipFactory.create(apartment=a, percentage=24.8)
+
+    sale: ApartmentSale = ApartmentSaleFactory.create(
+        apartment=a,
+        purchase_price=80350,
+        apartment_share_of_housing_company_loans=119150,
+        ownerships=[],
+    )
+    o1: Ownership = OwnershipFactory.create(apartment=a, percentage=75.2, sale=sale)
+    o2: Ownership = OwnershipFactory.create(apartment=a, percentage=24.8, sale=sale)
 
     # Create necessary apartment's completion date indices
     ConstructionPriceIndex2005Equal100Factory.create(month=datetime.date(2019, 11, 1), value=129.29)
@@ -256,8 +264,7 @@ def test__api__apartment_max_price__market_price_index__2011_onwards(api_client:
         surface_area=48.0,
         share_number_start=1,
         share_number_end=142,
-        sales__purchase_price=139706,
-        sales__apartment_share_of_housing_company_loans=80955,
+        sales=[],
         building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     # Create another apartment with rest of the surface area
@@ -271,7 +278,14 @@ def test__api__apartment_max_price__market_price_index__2011_onwards(api_client:
     mpi_improvement: HousingCompanyMarketPriceImprovement = HousingCompanyMarketPriceImprovementFactory.create(
         housing_company=a.housing_company, value=150000, completion_date=datetime.date(2020, 5, 21)
     )
-    o1: Ownership = OwnershipFactory.create(apartment=a, percentage=100.0)
+
+    sale: ApartmentSale = ApartmentSaleFactory.create(
+        apartment=a,
+        purchase_price=139706,
+        apartment_share_of_housing_company_loans=80955,
+        ownerships=[],
+    )
+    o1: Ownership = OwnershipFactory.create(apartment=a, percentage=100.0, sale=sale)
 
     # Create necessary apartment's completion date indices
     ConstructionPriceIndex2005Equal100Factory.create(month=datetime.date(2014, 8, 1), value=123.5)
@@ -447,18 +461,17 @@ def test__api__apartment_max_price__market_price_index__pre_2011(api_client: Hit
         surface_area=54.5,
         share_number_start=1,
         share_number_end=2,
+        sales=[],
         building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
-        sales__purchase_price=104693.0,
-        sales__apartment_share_of_housing_company_loans=18480.0,
     )
     # Create another apartment with rest of the surface area
     ApartmentFactory.create(
         building__real_estate__housing_company=a.housing_company,
         surface_area=3336,
-        sales__purchase_price=0.0,
-        sales__apartment_share_of_housing_company_loans=0.0,
         share_number_start=3,
         share_number_end=4,
+        sales__purchase_price=0.0,
+        sales__apartment_share_of_housing_company_loans=0.0,
     )
 
     mpi_ap_improvement: ApartmentMarketPriceImprovement = ApartmentMarketPriceImprovementFactory.create(
@@ -477,8 +490,15 @@ def test__api__apartment_max_price__market_price_index__pre_2011(api_client: Hit
     mpi_hc_improvement3: HousingCompanyMarketPriceImprovement = HousingCompanyMarketPriceImprovementFactory.create(
         housing_company=a.housing_company, value=2000, completion_date=datetime.date(2004, 10, 1), no_deductions=True
     )
-    o1: Ownership = OwnershipFactory.create(apartment=a, percentage=50.0)
-    o2: Ownership = OwnershipFactory.create(apartment=a, percentage=50.0)
+
+    sale: ApartmentSale = ApartmentSaleFactory.create(
+        apartment=a,
+        purchase_price=104693.0,
+        apartment_share_of_housing_company_loans=18480.0,
+        ownerships=[],
+    )
+    o1: Ownership = OwnershipFactory.create(apartment=a, percentage=50.0, sale=sale)
+    o2: Ownership = OwnershipFactory.create(apartment=a, percentage=50.0, sale=sale)
 
     # Create necessary apartment's completion date indices
     ConstructionPriceIndexFactory.create(month=datetime.date(2003, 5, 1), value=244.9)
@@ -727,9 +747,8 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
         surface_area=45.5,
         share_number_start=19717,
         share_number_end=20188,
+        sales=[],
         building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
-        sales__purchase_price=52738.0,
-        sales__apartment_share_of_housing_company_loans=123192.0,
     )
     # Create another apartment with rest of the surface area
     ApartmentFactory.create(
@@ -768,7 +787,13 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
         depreciation_percentage=Decimal("10.0"),
     )
 
-    o1: Ownership = OwnershipFactory.create(apartment=a, percentage=100.0)
+    sale: ApartmentSale = ApartmentSaleFactory.create(
+        apartment=a,
+        purchase_price=52738.0,
+        apartment_share_of_housing_company_loans=123192.0,
+        ownerships=[],
+    )
+    o1: Ownership = OwnershipFactory.create(apartment=a, percentage=100.0, sale=sale)
 
     # Create necessary apartment's completion date indices
     ConstructionPriceIndexFactory.create(month=datetime.date(2012, 6, 1), value=296.10)
@@ -1112,13 +1137,19 @@ def test__api__apartment_max_price__surface_area_price_ceiling(api_client: Hitas
         surface_area=48.5,
         share_number_start=504,
         share_number_end=601,
-        sales__purchase_price=107753,
-        sales__apartment_share_of_housing_company_loans=61830,
+        sales=[],
         building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     # Create another apartment with rest of the surface area
     ApartmentFactory.create(building__real_estate__housing_company=a.housing_company, surface_area=2655)
-    o1: Ownership = OwnershipFactory.create(apartment=a, percentage=100.0)
+
+    sale: ApartmentSale = ApartmentSaleFactory.create(
+        apartment=a,
+        purchase_price=107753,
+        apartment_share_of_housing_company_loans=61830,
+        ownerships=[],
+    )
+    o1: Ownership = OwnershipFactory.create(apartment=a, percentage=100.0, sale=sale)
 
     # Create necessary apartment's completion date indices
     ConstructionPriceIndex2005Equal100Factory.create(month=datetime.date(2012, 1, 1), value=115.9)

--- a/backend/hitas/tests/apis/test_api_apartment_list.py
+++ b/backend/hitas/tests/apis/test_api_apartment_list.py
@@ -40,8 +40,8 @@ def test__api__apartment__list__empty(api_client: HitasAPIClient):
 
 @pytest.mark.django_db
 def test__api__apartment__list(api_client: HitasAPIClient):
-    ap1: Apartment = ApartmentFactory.create(apartment_number=1)
-    ap2: Apartment = ApartmentFactory.create(apartment_number=2)
+    ap1: Apartment = ApartmentFactory.create(apartment_number=1, sales=[])
+    ap2: Apartment = ApartmentFactory.create(apartment_number=2, sales=[])
     hc1: HousingCompany = ap1.housing_company
     hc2: HousingCompany = ap2.housing_company
     o1: Ownership = OwnershipFactory.create(apartment=ap1, percentage=50)

--- a/backend/hitas/tests/factories/apartment.py
+++ b/backend/hitas/tests/factories/apartment.py
@@ -57,8 +57,8 @@ class ApartmentFactory(DjangoModelFactory):
             return
 
         if extracted is None:
-            kwargs.setdefault("ownerships", [])  # prevents infinite recursion
-            extracted = [ApartmentSaleFactory.create(apartment=self, **kwargs)]
+            kwargs.setdefault("apartment", self)
+            extracted = [ApartmentSaleFactory.create(**kwargs)]
 
         for ownership in extracted:
             self.sales.add(ownership)

--- a/backend/hitas/tests/factories/apartment_sale.py
+++ b/backend/hitas/tests/factories/apartment_sale.py
@@ -29,7 +29,9 @@ class ApartmentSaleFactory(DjangoModelFactory):
             return
 
         if extracted is None:
-            extracted = [OwnershipFactory.create(apartment=self.apartment, apartment__sales=self, **kwargs)]
+            kwargs.setdefault("sale", self)
+            kwargs.setdefault("apartment", self.apartment)
+            extracted = [OwnershipFactory.create(**kwargs)]
 
         for ownership in extracted:
             self.ownerships.add(ownership)

--- a/backend/hitas/tests/factories/owner.py
+++ b/backend/hitas/tests/factories/owner.py
@@ -49,6 +49,14 @@ class OwnershipFactory(DjangoModelFactory):
     class Meta:
         model = Ownership
 
-    apartment = factory.SubFactory("hitas.tests.factories.ApartmentFactory")
+    apartment = factory.SubFactory(
+        "hitas.tests.factories.ApartmentFactory",
+        sales=factory.LazyAttribute(lambda _: []),  # prevents another sale from being created
+    )
     owner = factory.SubFactory("hitas.tests.factories.OwnerFactory")
+    sale = factory.SubFactory(
+        "hitas.tests.factories.ApartmentSaleFactory",
+        ownerships=factory.LazyAttribute(lambda _: []),  # prevents another ownership from being created
+        apartment=factory.LazyAttribute(lambda self: self.factory_parent.apartment),
+    )
     percentage = 100


### PR DESCRIPTION
# Hitas Pull Request

# Description

Issue: OwnershipFactory does not set an ApartmentSale to it when Ownership is created. Ownership should belong to an ApartmentSale by default.

Add Subfactory for ApartmentSale in OwnershipFactory. Make ApartmentFactory to create an ApartmentSale and Ownership with it by default. Make ApartmentSaleFactory to create an Ownership for it. Refactor tests to support this change.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] See if test setups can be simplified, or if there are inconsistencies

## Tickets

This pull request resolves all or part of the following ticket(s): -
