### PR TITLE
Obfuscate owners without regulated apartments after 30-year regulation

### DIFF
--- a/backend/hitas/models/owner.py
+++ b/backend/hitas/models/owner.py
@@ -1,8 +1,16 @@
+from typing import Optional, TypedDict
+
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from hitas.models._base import ExternalHitasModel
 from hitas.models.utils import check_business_id, check_social_security_number
+
+
+class OwnerT(TypedDict):
+    name: Optional[str]
+    identifier: Optional[str]
+    email: Optional[str]
 
 
 class Owner(ExternalHitasModel):
@@ -22,7 +30,7 @@ class Owner(ExternalHitasModel):
         ordering = ["id"]
 
     def __str__(self):
-        return self.name
+        return str(self.name)
 
     def __repr__(self) -> str:
         return f"<{type(self).__name__}:{self.pk} ({str(self)})>"

--- a/backend/hitas/services/owner.py
+++ b/backend/hitas/services/owner.py
@@ -1,0 +1,48 @@
+from django.db import models
+from django.db.models import Count, OuterRef, QuerySet
+from django.db.models.functions import Coalesce
+
+from hitas.models.housing_company import RegulationStatus
+from hitas.models.owner import Owner, OwnerT
+from hitas.models.ownership import Ownership
+from hitas.utils import SQSum
+
+
+def obfuscate_owners_without_regulated_apartments() -> list[OwnerT]:
+    """Remove any personal information from owners which do not own any regulated hitas apartments."""
+    owners: QuerySet[Owner] = Owner.objects.annotate(
+        owned_regulated_housing_companies=Coalesce(
+            SQSum(
+                queryset=(
+                    Ownership.objects.select_related(
+                        "owner",
+                        "sale__apartment__building__real_estate__housing_company",
+                    )
+                    .filter(
+                        owner__id=OuterRef("id"),
+                        sale__apartment__building__real_estate__housing_company__regulation_status=(
+                            RegulationStatus.REGULATED
+                        ),
+                    )
+                    .annotate(__count=Count("*"))
+                    .values_list("__count")
+                ),
+                output_field=models.IntegerField(),
+                sum_field="__count",
+            ),
+            0,
+        )
+    ).filter(owned_regulated_housing_companies=0)
+
+    obfuscated_owners: list[OwnerT] = list(owners.values("name", "identifier", "email"))
+
+    if obfuscated_owners:
+        owners.update(
+            name=None,
+            identifier=None,
+            valid_identifier=False,
+            email=None,
+            bypass_conditions_of_sale=True,
+        )
+
+    return obfuscated_owners

--- a/backend/hitas/tests/services/test_services_owner.py
+++ b/backend/hitas/tests/services/test_services_owner.py
@@ -1,0 +1,147 @@
+from typing import NamedTuple
+
+import pytest
+
+from hitas.models import HousingCompanyState, Owner, Ownership
+from hitas.models.housing_company import RegulationStatus
+from hitas.services.owner import obfuscate_owners_without_regulated_apartments
+from hitas.tests.apis.helpers import parametrize_helper
+from hitas.tests.factories import OwnerFactory, OwnershipFactory
+
+
+@pytest.mark.django_db
+def test_obfuscate_owners_without_regulated_apartments__empty():
+    owners = obfuscate_owners_without_regulated_apartments()
+    assert owners == []
+
+
+@pytest.mark.django_db
+def test_obfuscate_owners_without_regulated_apartments__no_ownerships__single():
+    owner_1: Owner = OwnerFactory.create()
+
+    owners = obfuscate_owners_without_regulated_apartments()
+
+    assert len(owners) == 1
+
+    assert owners[0]["name"] == owner_1.name
+    assert owners[0]["identifier"] == owner_1.identifier
+    assert owners[0]["email"] == owner_1.email
+
+    owner_1.refresh_from_db()
+    assert owner_1.name is None
+    assert owner_1.identifier is None
+    assert owner_1.valid_identifier is False
+    assert owner_1.email is None
+    assert owner_1.bypass_conditions_of_sale is True
+
+
+@pytest.mark.django_db
+def test_obfuscate_owners_without_regulated_apartments__no_ownerships__multiple():
+    owner_1: Owner = OwnerFactory.create()
+    owner_2: Owner = OwnerFactory.create()
+
+    owners = obfuscate_owners_without_regulated_apartments()
+
+    assert len(owners) == 2
+
+    assert owners[0]["name"] == owner_1.name
+    assert owners[0]["identifier"] == owner_1.identifier
+    assert owners[0]["email"] == owner_1.email
+
+    assert owners[1]["name"] == owner_2.name
+    assert owners[1]["identifier"] == owner_2.identifier
+    assert owners[1]["email"] == owner_2.email
+
+    owner_1.refresh_from_db()
+    assert owner_1.name is None
+    assert owner_1.identifier is None
+    assert owner_1.valid_identifier is False
+    assert owner_1.email is None
+    assert owner_1.bypass_conditions_of_sale is True
+
+    owner_2.refresh_from_db()
+    assert owner_2.name is None
+    assert owner_2.identifier is None
+    assert owner_2.valid_identifier is False
+    assert owner_2.email is None
+    assert owner_2.bypass_conditions_of_sale is True
+
+
+class ObfuscationTestInfo(NamedTuple):
+    regulation_status: HousingCompanyState
+    obfuscated: bool
+
+
+@pytest.mark.parametrize(
+    **parametrize_helper(
+        {
+            "NOT_READY": ObfuscationTestInfo(
+                regulation_status=RegulationStatus.REGULATED,
+                obfuscated=False,
+            ),
+            "RELEASED_BY_HITAS": ObfuscationTestInfo(
+                regulation_status=RegulationStatus.RELEASED_BY_HITAS,
+                obfuscated=True,
+            ),
+            "RELEASED_BY_PLOT_DEPARTMENT": ObfuscationTestInfo(
+                regulation_status=RegulationStatus.RELEASED_BY_PLOT_DEPARTMENT,
+                obfuscated=True,
+            ),
+        }
+    ),
+)
+@pytest.mark.django_db
+def test_obfuscate_owners_without_regulated_apartments__housing_company_regulation_status(
+    regulation_status, obfuscated
+):
+    ownership: Ownership = OwnershipFactory.create(
+        apartment__building__real_estate__housing_company__regulation_status=regulation_status,
+    )
+
+    owners = obfuscate_owners_without_regulated_apartments()
+
+    if obfuscated:
+        assert len(owners) == 1
+
+        assert owners[0]["name"] == ownership.owner.name
+        assert owners[0]["identifier"] == ownership.owner.identifier
+        assert owners[0]["email"] == ownership.owner.email
+
+    else:
+        assert len(owners) == 0
+
+
+@pytest.mark.django_db
+def test_obfuscate_owners_without_regulated_apartments__one_owns_regulated():
+    ownership: Ownership = OwnershipFactory.create(
+        apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.RELEASED_BY_HITAS,
+    )
+    OwnershipFactory.create(
+        apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+    )
+
+    owners = obfuscate_owners_without_regulated_apartments()
+
+    assert len(owners) == 1
+
+    assert owners[0]["name"] == ownership.owner.name
+    assert owners[0]["identifier"] == ownership.owner.identifier
+    assert owners[0]["email"] == ownership.owner.email
+
+
+@pytest.mark.django_db
+def test_obfuscate_owners_without_regulated_apartments__one_owns_one_regulated_and_one_released():
+    ownership_1: Ownership = OwnershipFactory.create(
+        apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.RELEASED_BY_HITAS,
+    )
+    ownership_2: Ownership = OwnershipFactory.create(
+        apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+    )
+    OwnershipFactory.create(
+        owner=ownership_1.owner,
+        apartment__building__real_estate__housing_company=ownership_2.apartment.housing_company,
+    )
+
+    owners = obfuscate_owners_without_regulated_apartments()
+
+    assert len(owners) == 0

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2359,7 +2359,7 @@ paths:
             example: 2023-01-01
       responses:
         '200':
-          description: Successfully performed thrity year regulation for housing companies
+          description: Successfully performed thirty-year regulation for housing companies
           content:
             application/json:
               schema:
@@ -7211,6 +7211,8 @@ components:
         - automatically_released
         - released_from_regulation
         - stays_regulated
+        - skipped
+        - obfuscated_owners
       properties:
         automatically_released:
           description: Housing Companies that are release from regulation automatically.
@@ -7232,6 +7234,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ThirtyYearRegulationData'
+        obfuscated_owners:
+          description: Owners that have been obfuscated due to no longer owning any regulated apartments
+          type: array
+          items:
+            $ref: '#/components/schemas/ObfuscatedOwner'
 
     ThirtyYearRegulationData:
       description: Thirty year regulation data for a checked housing company
@@ -7265,6 +7272,32 @@ components:
           description: Does this housing company use the old or the new hitas ruleset?
           type: boolean
           example: false
+
+    ObfuscatedOwner:
+      description: Owner that has been obfuscated due to no longer owning any regulated apartments
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - identifier
+        - email
+      properties:
+        name:
+          description: Name of this owner
+          type: string
+          nullable: true
+          example: Martti Virtanen
+        identifier:
+          description: Identifier (social security number, business id, etc) of this owner
+          type: string
+          nullable: true
+          example: 260969-420B
+        email:
+          description: Email for this owner
+          type: string
+          nullable: true
+          example: martti.virtanen@example.com
+
 
     SurfaceAreaPriceCeilingCalculationResult:
       description: Surface area price ceiling calculation


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds the ability to obfuscate owner information when the owner no longer owns any regulated apartments after a 30-year regulation check. The obfuscation simply sets their name, identifier, and email to null. If any owners were obfuscated this way, they are returned in the 30-year regulation check response (in their pre-obfuscation state) for the frontend to show.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] This is a bit tedious to test manually since the setup is so specific, but you can set up some scenarios in the automated tests and go through them.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-520
