### PR TITLE
Fix apartment sale sorting when multiple sales are made in the same day

### DIFF
--- a/backend/hitas/calculations/max_prices/max_price.py
+++ b/backend/hitas/calculations/max_prices/max_price.py
@@ -320,7 +320,7 @@ def fetch_apartment(
             _first_sale_purchase_price=Subquery(
                 queryset=(
                     ApartmentSale.objects.filter(apartment_id=OuterRef("id"))
-                    .order_by("purchase_date")
+                    .order_by("purchase_date", "id")
                     .values_list("purchase_price", flat=True)[:1]
                 ),
                 output_field=HitasModelDecimalField(null=True),
@@ -328,7 +328,7 @@ def fetch_apartment(
             _first_sale_share_of_housing_company_loans=Subquery(
                 queryset=(
                     ApartmentSale.objects.filter(apartment_id=OuterRef("id"))
-                    .order_by("purchase_date")
+                    .order_by("purchase_date", "id")
                     .values_list("apartment_share_of_housing_company_loans", flat=True)[:1]
                 ),
                 output_field=HitasModelDecimalField(null=True),

--- a/backend/hitas/models/condition_of_sale.py
+++ b/backend/hitas/models/condition_of_sale.py
@@ -66,7 +66,7 @@ class ConditionOfSale(ExternalHitasModel):
 
         return (
             ApartmentSale.objects.filter(apartment=self.new_ownership.apartment)
-            .order_by("purchase_date")
+            .order_by("purchase_date", "id")
             .values_list("purchase_date", flat=True)
             .first()
         )

--- a/backend/hitas/services/thirty_year_regulation.py
+++ b/backend/hitas/services/thirty_year_regulation.py
@@ -289,7 +289,7 @@ def _get_sales_data(
             _first_sale_id=Subquery(
                 queryset=(
                     ApartmentSale.objects.filter(apartment_id=OuterRef("apartment_id"))
-                    .order_by("purchase_date")
+                    .order_by("purchase_date", "id")
                     .values_list("id", flat=True)[:1]
                 ),
                 output_field=models.IntegerField(null=True),

--- a/backend/hitas/tests/test_properties.py
+++ b/backend/hitas/tests/test_properties.py
@@ -3,7 +3,7 @@ from typing import Iterable, NamedTuple, Optional
 
 import pytest
 
-from hitas.models import Apartment
+from hitas.models import Apartment, ApartmentSale
 from hitas.tests.apis.helpers import parametrize_helper
 from hitas.tests.factories import ApartmentFactory, ApartmentSaleFactory
 
@@ -97,21 +97,29 @@ def test__properties__apartment__is_new(config: ApartmentConfig, is_new: bool, f
 
 
 @pytest.mark.django_db
-def test__properties__apartment__latest_purchase_date__no_sales():
+def test__properties__apartment__purchase_dates__no_sales():
     apartment: Apartment = ApartmentFactory.create(sales=[])
     assert apartment.latest_purchase_date is None
 
 
 @pytest.mark.django_db
-def test__properties__apartment__latest_purchase_date__single_sale():
+def test__properties__apartment__purchase_dates__single_sale():
     apartment: Apartment = ApartmentFactory.create(sales=[])
-    ApartmentSaleFactory.create(apartment=apartment)
+    sale: ApartmentSale = ApartmentSaleFactory.create(apartment=apartment)
+    assert apartment.first_purchase_date == sale.purchase_date
     assert apartment.latest_purchase_date is None  # Should not be set with only one sale
 
 
 @pytest.mark.django_db
-def test__properties__apartment__latest_purchase_date__multiple_sales():
+def test__properties__apartment__purchase_dates__multiple_sales():
     apartment: Apartment = ApartmentFactory.create(sales=[])
-    ApartmentSaleFactory.create(apartment=apartment)
-    ApartmentSaleFactory.create(apartment=apartment)
-    assert apartment.latest_purchase_date is not None
+    sale_1: ApartmentSale = ApartmentSaleFactory.create(
+        apartment=apartment,
+        purchase_date=datetime.date(2022, 1, 1),
+    )
+    sale_2: ApartmentSale = ApartmentSaleFactory.create(
+        apartment=apartment,
+        purchase_date=datetime.date(2022, 2, 1),
+    )
+    assert apartment.first_purchase_date == sale_1.purchase_date
+    assert apartment.latest_purchase_date == sale_2.purchase_date

--- a/backend/hitas/utils.py
+++ b/backend/hitas/utils.py
@@ -50,11 +50,11 @@ def subquery_count(model: type[Model], outer_field: str, **kwargs) -> Subquery:
     )
 
 
-def subquery_first_id(model: type[Model], outer_field: str, order_by: str, **kwargs) -> Subquery:
+def subquery_first_id(model: type[Model], outer_field: str, order_by: list[str], **kwargs) -> Subquery:
     """Selects the first row on the model (with references to outer_field) based on the given ordering."""
     return Subquery(
         model.objects.filter(**{outer_field: OuterRef(outer_field)}, **kwargs)
-        .order_by(order_by)
+        .order_by(*order_by)
         .values_list("id", flat=True)[:1]
     )
 

--- a/backend/hitas/views/condition_of_sale.py
+++ b/backend/hitas/views/condition_of_sale.py
@@ -103,7 +103,7 @@ class ConditionOfSaleCreateSerializer(serializers.Serializer):
                     # Limit the fetched sales to only the first sale,
                     # as we only need that to figure out if the apartment is new
                     ApartmentSale.objects.filter(
-                        id__in=subquery_first_id(ApartmentSale, "apartment_id", order_by="purchase_date"),
+                        id__in=subquery_first_id(ApartmentSale, "apartment_id", order_by=["purchase_date", "id"]),
                     ),
                 ),
             ).filter(uuid__in=owner_uuids)

--- a/backend/hitas/views/housing_company.py
+++ b/backend/hitas/views/housing_company.py
@@ -391,7 +391,7 @@ class HousingCompanyViewSet(HitasModelViewSet):
                 _acquisition_price=Subquery(
                     queryset=(
                         ApartmentSale.objects.filter(apartment_id=OuterRef("real_estates__buildings__apartments__id"))
-                        .order_by("purchase_date")
+                        .order_by("purchase_date", "id")
                         .annotate(
                             _acquisition_price=Sum(F("purchase_price") + F("apartment_share_of_housing_company_loans"))
                         )


### PR DESCRIPTION
# Hitas Pull Request

# Description

Fixes apartment's latest sale when there are multiple sales on the same day so that the latest sale is from the largest id. Same applies to the first sale, it is from the smallest id if there are multiple on the same day.

> Some of the sortings were the wrong way round, in which case they were corrected.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] Create multiple sales for an apartment on the same day. The most recent one should still be where the latest sale purchase price ("viimeisin kauppakirjahinta") is taken from. Same for the first sale, if there are multiple on the same day, the first one should be the first one made.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-524