### PR TITLE
Use empty property manager info when missing

### DIFF
--- a/backend/hitas/calculations/max_prices/max_price.py
+++ b/backend/hitas/calculations/max_prices/max_price.py
@@ -29,7 +29,7 @@ from hitas.models import (
 )
 from hitas.models._base import HitasModelDecimalField
 from hitas.models.apartment import ApartmentWithAnnotationsMaxPrice
-from hitas.utils import monthify
+from hitas.utils import monthify, safe_attrgetter
 
 
 def create_max_price_calculation(
@@ -216,8 +216,16 @@ def calculate_max_price(
             "official_name": apartment.housing_company.official_name,
             "archive_id": apartment.housing_company.id,
             "property_manager": {
-                "name": apartment.housing_company.property_manager.name,
-                "street_address": apartment.housing_company.property_manager.street_address,
+                "name": safe_attrgetter(
+                    apartment.housing_company,
+                    "property_manager.name",
+                    default="",
+                ),
+                "street_address": safe_attrgetter(
+                    apartment.housing_company,
+                    "property_manager.street_address",
+                    default="",
+                ),
             },
         },
         "additional_info": additional_info,


### PR DESCRIPTION
# Hitas Pull Request

# Description

Fixes max price calculation when property manager is missing

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] Try to create a max price calculation in an apartment in a housing company that has no property manager. It should work now.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-523