### PR TITLE
Add user info endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 .idea/
 *.iml
+tunnistamo/

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django.urls import include, path
 
 from hitas.views.health import HealthCheckView
+from users.views import UserInfoView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -10,6 +11,7 @@ urlpatterns = [
     path("healthz", HealthCheckView.as_view(), name="health_check"),
     path("pysocial/", include("social_django.urls", namespace="social")),
     path("helauth/", include("helusers.urls")),
+    path("helauth/userinfo/", UserInfoView.as_view(), name="userinfo"),
 ]
 
 if settings.DEBUG_TOOLBAR:

--- a/backend/hitas/tests/apis/test_api_userinfo.py
+++ b/backend/hitas/tests/apis/test_api_userinfo.py
@@ -1,0 +1,70 @@
+import json
+import uuid
+from base64 import urlsafe_b64encode
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from social_django.models import UserSocialAuth
+
+from hitas.tests.apis.helpers import HitasAPIClient
+
+
+@pytest.mark.django_db
+def test__api__userinfo__email_only(api_client: HitasAPIClient):
+    user = api_client.handler._force_user
+
+    data = {"email": "user@example.com"}
+    raw_token = urlsafe_b64encode(json.dumps(data).encode()).decode().replace("=", "")
+
+    UserSocialAuth.objects.create(
+        user=user,
+        provider="tunnistamo",
+        uid=str(uuid.uuid4()),
+        extra_data={"id_token": ".".join(["foo", raw_token, "bar"])},
+    )
+
+    response = api_client.get(reverse("userinfo"))
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+
+    assert response.json() == {
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "email": data["email"],
+    }
+
+
+@pytest.mark.django_db
+def test__api__userinfo__name_found(api_client: HitasAPIClient):
+    user = api_client.handler._force_user
+
+    data = {
+        "given_name": "foo",
+        "family_name": "bar",
+        "email": "user@example.com",
+    }
+    raw_token = urlsafe_b64encode(json.dumps(data).encode()).decode().replace("=", "")
+
+    UserSocialAuth.objects.create(
+        user=user,
+        provider="tunnistamo",
+        uid=str(uuid.uuid4()),
+        extra_data={"id_token": ".".join(["foo", raw_token, "bar"])},
+    )
+
+    response = api_client.get(reverse("userinfo"))
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+
+    assert response.json() == {
+        "first_name": data["given_name"],
+        "last_name": data["family_name"],
+        "email": data["email"],
+    }
+
+
+@pytest.mark.django_db
+def test__api__userinfo__info_not_found(api_client: HitasAPIClient):
+    response = api_client.get(reverse("userinfo"))
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3754,6 +3754,54 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  # Helsinki profile authentication
+
+  /helauth/userinfo/:
+    get:
+      description: Get user info for the currently logged in user
+      operationId: get-userinfo
+      tags:
+        - Helauth
+      responses:
+        '200':
+          description: Successfully fetched user info
+          content:
+            application/json:
+              schema:
+                description: User info
+                type: object
+                additionalProperties: false
+                required:
+                  - first_name
+                  - last_name
+                  - email
+                properties:
+                  first_name:
+                    description: First name of this user
+                    type: string
+                    nullable: true
+                    example: Matti
+                  last_name:
+                    description: Last name of this user
+                    type: string
+                    nullable: true
+                    example: Meikäläinen
+                  email:
+                    description: Last name of this user
+                    type: string
+                    nullable: true
+                    example: maija.meikalainen@example.com
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
 components:
   parameters:
     PagingLimitParameter:

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,0 +1,29 @@
+import json
+from base64 import urlsafe_b64decode
+
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from social_django.models import UserSocialAuth
+
+
+class UserInfoView(APIView):
+    def get(self, request: Request, *args, **kwargs) -> Response:
+        try:
+            user_info = UserSocialAuth.objects.get(user=request.user)
+        except UserSocialAuth.DoesNotExist as error:
+            from hitas.exceptions import HitasModelNotFound
+
+            raise HitasModelNotFound(UserSocialAuth) from error
+
+        raw_token = user_info.extra_data["id_token"].split(".")[1]
+        padded_token = raw_token + "=" * divmod(len(raw_token), 4)[1]
+        token_payload = json.loads(urlsafe_b64decode(padded_token))
+
+        data = {
+            "first_name": token_payload.get("given_name", request.user.first_name),
+            "last_name": token_payload.get("family_name", request.user.last_name),
+            "email": token_payload.get("email", request.user.email),
+        }
+        return Response(data=data, status=status.HTTP_200_OK)


### PR DESCRIPTION
# Hitas Pull Request

# Description

Allows user information to be fetched for users logged in using Tunnistamo.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [x] Login using Tunnistamo and use the provided endpoint for user information.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-532
