### PR TITLE
Thirty year regulation changes

### DIFF
--- a/backend/hitas/models/thirty_year_regulation.py
+++ b/backend/hitas/models/thirty_year_regulation.py
@@ -22,7 +22,6 @@ class RegulationResult(Enum):
     AUTOMATICALLY_RELEASED = "automatically_released"
     RELEASED_FROM_REGULATION = "released_from_regulation"
     STAYS_REGULATED = "stays_regulated"
-    SKIPPED = "skipped"
 
 
 class FullSalesData(TypedDict):

--- a/backend/hitas/services/external_sales_data.py
+++ b/backend/hitas/services/external_sales_data.py
@@ -1,7 +1,10 @@
 from typing import TYPE_CHECKING, Literal, Optional
 
+from dateutil.relativedelta import relativedelta
+
 from hitas.models.external_sales_data import CostAreaData, ExternalSalesData, ExternalSalesDataType, QuarterData
 from hitas.models.postal_code import HitasPostalCode
+from hitas.utils import from_quarter, to_quarter
 
 if TYPE_CHECKING:
     from hitas.views.external_sales_data import CostAreaSalesCatalogData
@@ -42,4 +45,6 @@ def create_external_sales_data(data: "CostAreaSalesCatalogData") -> ExternalSale
                 )
             )
 
-    return ExternalSalesData.objects.update_or_create(calculation_quarter=data["quarter_4"], defaults=sales_data)[0]
+    calculation_quarter = to_quarter(from_quarter(data["quarter_4"]) + relativedelta(months=3))
+
+    return ExternalSalesData.objects.update_or_create(calculation_quarter=calculation_quarter, defaults=sales_data)[0]

--- a/backend/hitas/services/housing_company.py
+++ b/backend/hitas/services/housing_company.py
@@ -35,6 +35,7 @@ def get_completed_housing_companies(
         HousingCompany.objects.select_related(
             "postal_code",
             "financing_method",
+            "property_manager",
         )
         .prefetch_related(
             "real_estates",

--- a/backend/hitas/services/thirty_year_regulation.py
+++ b/backend/hitas/services/thirty_year_regulation.py
@@ -56,11 +56,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger()
 
 
+class AddressInfo(TypedDict):
+    street_address: str
+    postal_code: str
+    city: str
+
+
+class PropertyManagerInfo(TypedDict):
+    id: str
+    name: str
+    email: str
+    address: AddressInfo
+
+
 class ComparisonData(TypedDict):
     id: HousingCompanyUUIDHex
     display_name: HousingCompanyNameT
+    address: AddressInfo
     price: Decimal
     old_ruleset: bool
+    completion_date: datetime.date | str
+    property_manager: PropertyManagerInfo
 
 
 class RegulationResults(TypedDict):
@@ -234,8 +250,24 @@ def _split_automatically_released(
                 ComparisonData(
                     id=housing_company.uuid.hex,
                     display_name=housing_company.display_name,
+                    address=AddressInfo(
+                        street_address=housing_company.street_address,
+                        postal_code=housing_company.postal_code.value,
+                        city=housing_company.postal_code.city,
+                    ),
                     price=Decimal("0"),  # Index adjusted price not calculate yet
                     old_ruleset=housing_company.hitas_type.old_hitas_ruleset,
+                    completion_date=housing_company.completion_date,
+                    property_manager=PropertyManagerInfo(
+                        id=housing_company.property_manager.uuid.hex,
+                        name=housing_company.property_manager.name,
+                        email=housing_company.property_manager.email,
+                        address=AddressInfo(
+                            street_address=housing_company.property_manager.street_address,
+                            postal_code=housing_company.property_manager.postal_code,
+                            city=housing_company.property_manager.city,
+                        ),
+                    ),
                 )
             )
             housing_companies[i] = None
@@ -259,8 +291,24 @@ def _get_comparison_values(
         comparison_values[postal_code][housing_company.uuid.hex] = ComparisonData(
             id=housing_company.uuid.hex,
             display_name=housing_company.display_name,
+            address=AddressInfo(
+                street_address=housing_company.street_address,
+                postal_code=housing_company.postal_code.value,
+                city=housing_company.postal_code.city,
+            ),
             price=max((housing_company.avg_price_per_square_meter, surface_area_price_ceiling)),
             old_ruleset=housing_company.hitas_type.old_hitas_ruleset,
+            completion_date=housing_company.completion_date,
+            property_manager=PropertyManagerInfo(
+                id=housing_company.property_manager.uuid.hex,
+                name=housing_company.property_manager.name,
+                email=housing_company.property_manager.email,
+                address=AddressInfo(
+                    street_address=housing_company.property_manager.street_address,
+                    postal_code=housing_company.property_manager.postal_code,
+                    city=housing_company.property_manager.city,
+                ),
+            ),
         )
 
     return comparison_values

--- a/backend/hitas/tests/apis/test_api_external_sales_data.py
+++ b/backend/hitas/tests/apis/test_api_external_sales_data.py
@@ -53,7 +53,7 @@ def test__api__external_sales_data__create(api_client: HitasAPIClient):
 
     assert response.status_code == status.HTTP_201_CREATED, response.json()
     assert response.json() == {
-        "calculation_quarter": "2022Q4",
+        "calculation_quarter": "2023Q1",
         "quarter_1": {
             "quarter": "2022Q1",
             "areas": [
@@ -118,7 +118,7 @@ def test__api__external_sales_data__create(api_client: HitasAPIClient):
 
     sales_data = list(ExternalSalesData.objects.all())
     assert len(sales_data) == 1
-    assert sales_data[0].calculation_quarter == "2022Q4"
+    assert sales_data[0].calculation_quarter == "2023Q1"
 
 
 @pytest.mark.django_db
@@ -138,7 +138,7 @@ def test__api__external_sales_data__create__missing_postal_codes(api_client: Hit
 
     assert response.status_code == status.HTTP_201_CREATED, response.json()
     assert response.json() == {
-        "calculation_quarter": "2022Q4",
+        "calculation_quarter": "2023Q1",
         "quarter_1": {
             "quarter": "2022Q1",
             "areas": [],
@@ -159,7 +159,7 @@ def test__api__external_sales_data__create__missing_postal_codes(api_client: Hit
 
     sales_data = list(ExternalSalesData.objects.all())
     assert len(sales_data) == 1
-    assert sales_data[0].calculation_quarter == "2022Q4"
+    assert sales_data[0].calculation_quarter == "2023Q1"
 
 
 @pytest.mark.django_db
@@ -199,7 +199,7 @@ def test__api__external_sales_data__create__postal_codes_not_on_housing_companie
 
     assert response.status_code == status.HTTP_201_CREATED, response.json()
     assert response.json() == {
-        "calculation_quarter": "2022Q4",
+        "calculation_quarter": "2023Q1",
         "quarter_1": {
             "quarter": "2022Q1",
             "areas": [],
@@ -220,7 +220,7 @@ def test__api__external_sales_data__create__postal_codes_not_on_housing_companie
 
     sales_data = list(ExternalSalesData.objects.all())
     assert len(sales_data) == 1
-    assert sales_data[0].calculation_quarter == "2022Q4"
+    assert sales_data[0].calculation_quarter == "2023Q1"
 
 
 @pytest.mark.parametrize(
@@ -459,12 +459,12 @@ def test__api__external_sales_data__retrieve(api_client: HitasAPIClient):
         quarter_3=QuarterData(quarter="2022Q3", areas=[CostAreaData(postal_code="00000", sale_count=5, price=6)]),
         quarter_4=QuarterData(quarter="2022Q4", areas=[CostAreaData(postal_code="00000", sale_count=7, price=8)]),
     )
-    ExternalSalesData.objects.create(calculation_quarter="2022Q4", **data)
-    url = reverse("hitas:external-sales-data-list") + "?calculation_date=2023-01-01"
+    ExternalSalesData.objects.create(calculation_quarter="2023Q1", **data)
+    url = reverse("hitas:external-sales-data-list") + "?calculation_date=2023-02-01"
     response = api_client.get(url, format="json")
 
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.json() == {**{"calculation_quarter": "2022Q4"}, **data}
+    assert response.json() == {**{"calculation_quarter": "2023Q1"}, **data}
 
 
 @pytest.mark.django_db
@@ -475,8 +475,8 @@ def test__api__external_sales_data__retrieve__wrong_date(api_client: HitasAPICli
         quarter_3=QuarterData(quarter="2022Q3", areas=[CostAreaData(postal_code="00000", sale_count=5, price=6)]),
         quarter_4=QuarterData(quarter="2022Q4", areas=[CostAreaData(postal_code="00000", sale_count=7, price=8)]),
     )
-    ExternalSalesData.objects.create(calculation_quarter="2022Q4", **data)
-    url = reverse("hitas:external-sales-data-list") + "?calculation_date=2024-01-01"
+    ExternalSalesData.objects.create(calculation_quarter="2023Q1", **data)
+    url = reverse("hitas:external-sales-data-list") + "?calculation_date=2024-02-01"
     response = api_client.get(url, format="json")
 
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
@@ -490,7 +490,7 @@ def test__api__external_sales_data__retrieve__wrong_date(api_client: HitasAPICli
 
 @pytest.mark.django_db
 def test__api__external_sales_data__retrieve__not_found(api_client: HitasAPIClient):
-    url = reverse("hitas:external-sales-data-list") + "?calculation_date=2023-01-01"
+    url = reverse("hitas:external-sales-data-list") + "?calculation_date=2023-02-01"
     response = api_client.get(url, format="json")
 
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()

--- a/backend/hitas/tests/apis/test_api_external_sales_data.py
+++ b/backend/hitas/tests/apis/test_api_external_sales_data.py
@@ -460,8 +460,7 @@ def test__api__external_sales_data__retrieve(api_client: HitasAPIClient):
         quarter_4=QuarterData(quarter="2022Q4", areas=[CostAreaData(postal_code="00000", sale_count=7, price=8)]),
     )
     ExternalSalesData.objects.create(calculation_quarter="2022Q4", **data)
-
-    url = reverse("hitas:external-sales-data-detail", args=["2022Q4"])
+    url = reverse("hitas:external-sales-data-list") + "?calculation_date=2023-01-01"
     response = api_client.get(url, format="json")
 
     assert response.status_code == status.HTTP_200_OK, response.json()
@@ -469,8 +468,29 @@ def test__api__external_sales_data__retrieve(api_client: HitasAPIClient):
 
 
 @pytest.mark.django_db
+def test__api__external_sales_data__retrieve__wrong_date(api_client: HitasAPIClient):
+    data = ExternalSalesDataType(
+        quarter_1=QuarterData(quarter="2022Q1", areas=[CostAreaData(postal_code="00000", sale_count=1, price=2)]),
+        quarter_2=QuarterData(quarter="2022Q2", areas=[CostAreaData(postal_code="00000", sale_count=3, price=4)]),
+        quarter_3=QuarterData(quarter="2022Q3", areas=[CostAreaData(postal_code="00000", sale_count=5, price=6)]),
+        quarter_4=QuarterData(quarter="2022Q4", areas=[CostAreaData(postal_code="00000", sale_count=7, price=8)]),
+    )
+    ExternalSalesData.objects.create(calculation_quarter="2022Q4", **data)
+    url = reverse("hitas:external-sales-data-list") + "?calculation_date=2024-01-01"
+    response = api_client.get(url, format="json")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+    assert response.json() == {
+        "error": "external_sales_data_not_found",
+        "message": "External sales data not found",
+        "reason": "Not Found",
+        "status": 404,
+    }
+
+
+@pytest.mark.django_db
 def test__api__external_sales_data__retrieve__not_found(api_client: HitasAPIClient):
-    url = reverse("hitas:external-sales-data-detail", args=["2022Q4"])
+    url = reverse("hitas:external-sales-data-list") + "?calculation_date=2023-01-01"
     response = api_client.get(url, format="json")
 
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()

--- a/backend/hitas/tests/apis/test_api_thirty_year_regulation.py
+++ b/backend/hitas/tests/apis/test_api_thirty_year_regulation.py
@@ -22,24 +22,7 @@ from hitas.tests.factories import ApartmentFactory, ApartmentSaleFactory
 from hitas.tests.factories.indices import MarketPriceIndexFactory, SurfaceAreaPriceCeilingFactory
 from hitas.utils import to_quarter
 
-
-@pytest.mark.django_db
-def test__api__regulation__empty(api_client: HitasAPIClient, freezer):
-    day = datetime.datetime(2023, 2, 1)
-    freezer.move_to(day)
-
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
-
-    response = api_client.get(url)
-
-    assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.json() == RegulationResults(
-        automatically_released=[],
-        released_from_regulation=[],
-        stays_regulated=[],
-        skipped=[],
-        obfuscated_owners=[],
-    )
+# Read regulation results
 
 
 @pytest.mark.django_db
@@ -137,6 +120,28 @@ def test__api__regulation__fetch_exising__not_available(api_client: HitasAPIClie
     }
 
 
+# Perform regulation
+
+
+@pytest.mark.django_db
+def test__api__regulation__empty(api_client: HitasAPIClient, freezer):
+    day = datetime.datetime(2023, 2, 1)
+    freezer.move_to(day)
+
+    url = reverse("hitas:thirty-year-regulation-list")
+
+    response = api_client.post(url, data={}, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == RegulationResults(
+        automatically_released=[],
+        released_from_regulation=[],
+        stays_regulated=[],
+        skipped=[],
+        obfuscated_owners=[],
+    )
+
+
 @pytest.mark.django_db
 def test__api__regulation__stays_regulated(api_client: HitasAPIClient, freezer):
     day = datetime.datetime(2023, 2, 1)
@@ -191,7 +196,7 @@ def test__api__regulation__stays_regulated(api_client: HitasAPIClient, freezer):
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
     # 1. Check for previous regulation results
     # 2. Fetch housing companies
@@ -209,7 +214,7 @@ def test__api__regulation__stays_regulated(api_client: HitasAPIClient, freezer):
     # 14. Save thirty year regulation results
     # 15. Save thirty year regulation results' rows
     with count_queries(15, list_queries_on_failure=True):
-        response = api_client.get(url)
+        response = api_client.post(url, data={}, format="json")
 
     #
     # Since the housing company's index adjusted acquisition price is 12_000, which is higher than the
@@ -341,7 +346,7 @@ def test__api__regulation__released_from_regulation(api_client: HitasAPIClient, 
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
     # 1. Check for previous regulation results
     # 2. Fetch housing companies
@@ -360,7 +365,7 @@ def test__api__regulation__released_from_regulation(api_client: HitasAPIClient, 
     # 15. Save thirty year regulation results
     # 16. Save thirty year regulation results' rows
     with count_queries(16, list_queries_on_failure=True):
-        response = api_client.get(url)
+        response = api_client.post(url, data={}, format="json")
 
     #
     # Since the housing company's index adjusted acquisition price is 12_000, which is higher than the
@@ -498,9 +503,9 @@ def test__api__regulation__comparison_is_equal(api_client: HitasAPIClient, freez
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     #
     # Since the housing company's index adjusted acquisition price is 12_000, which is higher than the
@@ -569,9 +574,9 @@ def test__api__regulation__indices_missing(api_client: HitasAPIClient, freezer):
         apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     assert response.status_code == status.HTTP_409_CONFLICT, response.json()
     assert response.json() == {
@@ -613,9 +618,9 @@ def test__api__regulation__external_sales_data_missing(api_client: HitasAPIClien
     MarketPriceIndexFactory.create(month=this_month, value=200)
     SurfaceAreaPriceCeilingFactory.create(month=this_month, value=5000)
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
     assert response.json() == {
@@ -649,9 +654,9 @@ def test__api__regulation__surface_area_price_ceiling_missing(api_client: HitasA
     MarketPriceIndexFactory.create(month=regulation_month, value=100)
     MarketPriceIndexFactory.create(month=this_month, value=200)
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
     assert response.json() == {
@@ -700,9 +705,9 @@ def test__api__regulation__automatically_release__all(api_client: HitasAPIClient
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert response.json() == RegulationResults(
@@ -839,9 +844,9 @@ def test__api__regulation__automatically_release__partial(api_client: HitasAPICl
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert response.json() == RegulationResults(
@@ -979,9 +984,9 @@ def test__api__regulation__surface_area_price_ceiling_is_used_in_comparison(api_
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     #
     # Since the housing company's index adjusted acquisition price is 12_000, which is lower than the
@@ -1083,9 +1088,9 @@ def test__api__regulation__no_sales_data_for_postal_code(api_client: HitasAPICli
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     #
     # Since postal code average square price does not exist, the housing company cannot be regulated,
@@ -1176,9 +1181,9 @@ def test__api__regulation__no_sales_data_for_postal_code__half_hitas(api_client:
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     #
     # Since postal code average square price does not exist, the housing company cannot be regulated,
@@ -1270,9 +1275,9 @@ def test__api__regulation__no_sales_data_for_postal_code__sale_previous_year(api
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     #
     # Since postal code average square price does not exist, the housing company cannot be regulated,
@@ -1356,9 +1361,9 @@ def test__api__regulation__only_external_sales_data(api_client: HitasAPIClient, 
         ),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     #
     # Since the housing company's index adjusted acquisition price is 12_000, which is higher than the
@@ -1461,9 +1466,9 @@ def test__api__regulation__both_hitas_and_external_sales_data(api_client: HitasA
         ),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     #
     # Since the housing company's index adjusted acquisition price is 12_000, which is higher than the
@@ -1564,9 +1569,9 @@ def test__api__regulation__use_catalog_prices(api_client: HitasAPIClient, freeze
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     #
     # Since the housing company's index adjusted acquisition price is 12_000, which is higher than the
@@ -1635,9 +1640,9 @@ def test__api__regulation__no_catalog_prices_or_sales(api_client: HitasAPIClient
         sales=[],
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     assert response.status_code == status.HTTP_409_CONFLICT, response.json()
     assert response.json() == {
@@ -1684,9 +1689,9 @@ def test__api__regulation__catalog_price_zero(api_client: HitasAPIClient, freeze
         sales=[],
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert response.json() == {
@@ -1732,9 +1737,9 @@ def test__api__regulation__no_surface_area(api_client: HitasAPIClient, freezer):
         apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     assert response.status_code == status.HTTP_409_CONFLICT, response.json()
     assert response.json() == {
@@ -1782,9 +1787,9 @@ def test__api__regulation__surface_area_zero(api_client: HitasAPIClient, freezer
         apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert response.json() == {
@@ -1830,9 +1835,9 @@ def test__api__regulation__no_catalog_prices_or_sales_or_surface_area(api_client
         sales=[],
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     assert response.status_code == status.HTTP_409_CONFLICT, response.json()
     assert response.json() == {
@@ -1909,9 +1914,9 @@ def test__api__regulation__exclude_from_statistics__housing_company(api_client: 
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     #
     # Since postal code average square price does not exist, the housing company cannot be regulated,
@@ -2004,9 +2009,9 @@ def test__api__regulation__exclude_from_statistics__sale__all(api_client: HitasA
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     #
     # Since postal code average square price does not exist, the housing company cannot be regulated,
@@ -2109,9 +2114,9 @@ def test__api__regulation__exclude_from_statistics__sale__partial(api_client: Hi
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     #
     # Since the housing company's index adjusted acquisition price is 12_000, which is higher than the
@@ -2179,9 +2184,9 @@ def test__api__regulation__no_housing_company_over_30_years(api_client: HitasAPI
         apartment_share_of_housing_company_loans=9_000,
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert response.json() == RegulationResults(
@@ -2258,9 +2263,9 @@ def test__api__regulation__housing_company_regulation_status(
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     assert response.status_code == status.HTTP_200_OK, response.json()
 
@@ -2345,9 +2350,9 @@ def test__api__regulation__regulation_already_made(api_client: HitasAPIClient, f
         regulation_result=RegulationResult.STAYS_REGULATED,
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     assert response.status_code == status.HTTP_409_CONFLICT, response.json()
     assert response.json() == {
@@ -2433,9 +2438,9 @@ def test__api__regulation__regulation_already_made__skipped(api_client: HitasAPI
         quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
     )
 
-    url = reverse("hitas:thirty-year-regulation-list") + "?check=true"
+    url = reverse("hitas:thirty-year-regulation-list")
 
-    response = api_client.get(url)
+    response = api_client.post(url, data={}, format="json")
 
     # Regulation is allowed to complete
     assert response.status_code == status.HTTP_200_OK, response.json()

--- a/backend/hitas/tests/apis/test_api_thirty_year_regulation.py
+++ b/backend/hitas/tests/apis/test_api_thirty_year_regulation.py
@@ -15,7 +15,7 @@ from hitas.models.thirty_year_regulation import (
     RegulationResult,
     ThirtyYearRegulationResults,
 )
-from hitas.services.thirty_year_regulation import ComparisonData, RegulationResults
+from hitas.services.thirty_year_regulation import AddressInfo, ComparisonData, PropertyManagerInfo, RegulationResults
 from hitas.tests.apis.helpers import HitasAPIClient, count_queries
 from hitas.tests.factories import ApartmentFactory, ApartmentSaleFactory
 from hitas.tests.factories.indices import MarketPriceIndexFactory, SurfaceAreaPriceCeilingFactory
@@ -130,8 +130,24 @@ def test__api__regulation__stays_regulated(api_client: HitasAPIClient, freezer):
             ComparisonData(
                 id=sale.apartment.housing_company.uuid.hex,
                 display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("12000.0"),
                 old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         skipped=[],
@@ -263,8 +279,24 @@ def test__api__regulation__released_from_regulation(api_client: HitasAPIClient, 
             ComparisonData(
                 id=sale.apartment.housing_company.uuid.hex,
                 display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("12000.0"),
                 old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         stays_regulated=[],
@@ -387,8 +419,24 @@ def test__api__regulation__comparison_is_equal(api_client: HitasAPIClient, freez
             ComparisonData(
                 id=sale.apartment.housing_company.uuid.hex,
                 display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("12000.0"),
                 old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         stays_regulated=[],
@@ -564,8 +612,24 @@ def test__api__regulation__automatically_release__all(api_client: HitasAPIClient
             ComparisonData(
                 id=sale.apartment.housing_company.uuid.hex,
                 display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("0"),
                 old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         released_from_regulation=[],
@@ -687,16 +751,48 @@ def test__api__regulation__automatically_release__partial(api_client: HitasAPICl
             ComparisonData(
                 id=sale_1.apartment.housing_company.uuid.hex,
                 display_name=sale_1.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale_1.apartment.housing_company.street_address,
+                    postal_code=sale_1.apartment.housing_company.postal_code.value,
+                    city=sale_1.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("0"),
                 old_ruleset=sale_1.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale_1.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale_1.apartment.housing_company.property_manager.name,
+                    email=sale_1.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale_1.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale_1.apartment.housing_company.property_manager.postal_code,
+                        city=sale_1.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         released_from_regulation=[
             ComparisonData(
                 id=sale_2.apartment.housing_company.uuid.hex,
                 display_name=sale_2.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale_2.apartment.housing_company.street_address,
+                    postal_code=sale_2.apartment.housing_company.postal_code.value,
+                    city=sale_2.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("12000.0"),
                 old_ruleset=sale_2.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale_2.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale_2.apartment.housing_company.property_manager.name,
+                    email=sale_2.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale_2.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale_2.apartment.housing_company.property_manager.postal_code,
+                        city=sale_2.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         stays_regulated=[],
@@ -804,8 +900,24 @@ def test__api__regulation__surface_area_price_ceiling_is_used_in_comparison(api_
             ComparisonData(
                 id=sale.apartment.housing_company.uuid.hex,
                 display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("50000.0"),
                 old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         stays_regulated=[],
@@ -890,8 +1002,24 @@ def test__api__regulation__no_sales_data_for_postal_code(api_client: HitasAPICli
             ComparisonData(
                 id=sale.apartment.housing_company.uuid.hex,
                 display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("12000.0"),
                 old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         obfuscated_owners=[],
@@ -967,8 +1095,24 @@ def test__api__regulation__no_sales_data_for_postal_code__half_hitas(api_client:
             ComparisonData(
                 id=sale.apartment.housing_company.uuid.hex,
                 display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("12000.0"),
                 old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         obfuscated_owners=[],
@@ -1045,8 +1189,24 @@ def test__api__regulation__no_sales_data_for_postal_code__sale_previous_year(api
             ComparisonData(
                 id=sale.apartment.housing_company.uuid.hex,
                 display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("12000.0"),
                 old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         obfuscated_owners=[],
@@ -1118,8 +1278,24 @@ def test__api__regulation__only_external_sales_data(api_client: HitasAPIClient, 
             ComparisonData(
                 id=sale.apartment.housing_company.uuid.hex,
                 display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("12000.0"),
                 old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         skipped=[],
@@ -1210,8 +1386,24 @@ def test__api__regulation__both_hitas_and_external_sales_data(api_client: HitasA
             ComparisonData(
                 id=sale.apartment.housing_company.uuid.hex,
                 display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("12000.0"),
                 old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         skipped=[],
@@ -1294,8 +1486,24 @@ def test__api__regulation__use_catalog_prices(api_client: HitasAPIClient, freeze
             ComparisonData(
                 id=apartment_1.housing_company.uuid.hex,
                 display_name=apartment_1.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=apartment_1.housing_company.street_address,
+                    postal_code=apartment_1.housing_company.postal_code.value,
+                    city=apartment_1.housing_company.postal_code.city,
+                ),
                 price=Decimal("12000.0"),
                 old_ruleset=apartment_1.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=apartment_1.housing_company.property_manager.uuid.hex,
+                    name=apartment_1.housing_company.property_manager.name,
+                    email=apartment_1.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=apartment_1.housing_company.property_manager.street_address,
+                        postal_code=apartment_1.housing_company.property_manager.postal_code,
+                        city=apartment_1.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         skipped=[],
@@ -1620,8 +1828,24 @@ def test__api__regulation__exclude_from_statistics__housing_company(api_client: 
             ComparisonData(
                 id=sale.apartment.housing_company.uuid.hex,
                 display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("12000.0"),
                 old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         obfuscated_owners=[],
@@ -1699,8 +1923,24 @@ def test__api__regulation__exclude_from_statistics__sale__all(api_client: HitasA
             ComparisonData(
                 id=sale.apartment.housing_company.uuid.hex,
                 display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("12000.0"),
                 old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         obfuscated_owners=[],
@@ -1791,8 +2031,24 @@ def test__api__regulation__exclude_from_statistics__sale__partial(api_client: Hi
             ComparisonData(
                 id=sale.apartment.housing_company.uuid.hex,
                 display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
                 price=Decimal("12000.0"),
                 old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
             )
         ],
         skipped=[],
@@ -1918,8 +2174,24 @@ def test__api__regulation__housing_company_regulation_status(
                 ComparisonData(
                     id=sale.apartment.housing_company.uuid.hex,
                     display_name=sale.apartment.housing_company.display_name,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.street_address,
+                        postal_code=sale.apartment.housing_company.postal_code.value,
+                        city=sale.apartment.housing_company.postal_code.city,
+                    ),
                     price=Decimal("12000.0"),
                     old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                    completion_date=regulation_month.isoformat(),
+                    property_manager=PropertyManagerInfo(
+                        id=sale.apartment.housing_company.property_manager.uuid.hex,
+                        name=sale.apartment.housing_company.property_manager.name,
+                        email=sale.apartment.housing_company.property_manager.email,
+                        address=AddressInfo(
+                            street_address=sale.apartment.housing_company.property_manager.street_address,
+                            postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                            city=sale.apartment.housing_company.property_manager.city,
+                        ),
+                    ),
                 )
             ],
             skipped=[],

--- a/backend/hitas/tests/apis/test_api_thirty_year_regulation_report.py
+++ b/backend/hitas/tests/apis/test_api_thirty_year_regulation_report.py
@@ -710,66 +710,6 @@ def test__api__regulation_letter__id_missing(api_client: HitasAPIClient, freezer
     }
 
 
-@pytest.mark.django_db
-def test__api__regulation_letter__regulation_skipped(api_client: HitasAPIClient, freezer):
-    day = datetime.datetime(2023, 2, 1)
-    freezer.move_to(day)
-
-    this_month = day.date()
-    regulation_month = this_month - relativedelta(years=30)
-
-    sale: ApartmentSale = ApartmentSaleFactory.create(
-        purchase_date=regulation_month,
-        purchase_price=50_000,
-        apartment_share_of_housing_company_loans=10_000,
-        apartment__surface_area=10,
-        apartment__completion_date=regulation_month,
-        apartment__building__real_estate__housing_company__postal_code__value="00001",
-        apartment__building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
-        apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
-    )
-
-    result = ThirtyYearRegulationResults.objects.create(
-        regulation_month=datetime.datetime(1993, 2, 1),
-        calculation_month=datetime.date(2023, 2, 1),
-        surface_area_price_ceiling=Decimal("5000.00"),
-        sales_data={
-            "external": {},
-            "internal": {"00001": {"2022Q4": {"price": 4900.0, "sale_count": 1}}},
-            "price_by_area": {"00001": 4900.0},
-        },
-    )
-
-    ThirtyYearRegulationResultsRow.objects.create(
-        parent=result,
-        housing_company=sale.apartment.housing_company,
-        completion_date=datetime.date(1993, 2, 1),
-        surface_area=Decimal("10.00"),
-        postal_code="00001",
-        realized_acquisition_price=Decimal("60000.00"),
-        unadjusted_average_price_per_square_meter=Decimal("6000.00"),
-        adjusted_average_price_per_square_meter=Decimal("12000.00"),
-        completion_month_index=Decimal("100.00"),
-        calculation_month_index=Decimal("200.00"),
-        regulation_result=RegulationResult.SKIPPED,
-    )
-
-    url = (
-        reverse("hitas:thirty-year-regulation-letter")
-        + f"?housing_company_id={sale.apartment.housing_company.uuid.hex}"
-    )
-
-    response = api_client.get(url)
-
-    assert response.status_code == status.HTTP_409_CONFLICT, response.json()
-    assert response.json() == {
-        "error": "invalid",
-        "message": "Cannot download PDF since regulation for this housing company was skipped.",
-        "reason": "Conflict",
-        "status": 409,
-    }
-
-
 # Regulation Excel report
 
 

--- a/backend/hitas/utils.py
+++ b/backend/hitas/utils.py
@@ -151,6 +151,7 @@ def hitas_calculation_quarter(date: datetime.date) -> datetime.date:
 
 
 def to_quarter(date: datetime.date) -> str:
+    """Get business quarter as a string from a date."""
     if date.month in (1, 2, 3):
         return f"{date.year}Q1"
     if date.month in (4, 5, 6):

--- a/backend/hitas/utils.py
+++ b/backend/hitas/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import operator
+import re
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Iterable, Optional, overload
 from uuid import UUID
@@ -159,6 +160,20 @@ def to_quarter(date: datetime.date) -> str:
     if date.month in (10, 11, 12):
         return f"{date.year}Q4"
     raise NotImplementedError
+
+
+def from_quarter(quarter: str) -> datetime.date:
+    """Get business quarter as a date from string."""
+    result = re.match(r"(?P<year>\d{4})Q(?P<quarter>[1234])", quarter)
+    if result is None:
+        raise ValueError(f"{quarter!r} is not a valid quarter.")
+
+    year = result.group("year")
+    number = result.group("quarter")
+    number_to_month = {"1": 1, "2": 4, "3": 7, "4": 10}
+    month = number_to_month[number]
+
+    return datetime.date(year=int(year), month=month, day=1)
 
 
 def from_iso_format_or_today_if_none(date: Optional[str]) -> datetime.date:

--- a/backend/hitas/views/external_sales_data.py
+++ b/backend/hitas/views/external_sales_data.py
@@ -1,6 +1,5 @@
 from typing import Optional, TypedDict
 
-from dateutil.relativedelta import relativedelta
 from openpyxl.workbook import Workbook
 from openpyxl.worksheet.worksheet import Worksheet
 from rest_framework import serializers, status
@@ -12,7 +11,7 @@ from hitas.exceptions import HitasModelNotFound
 from hitas.models import ExternalSalesData
 from hitas.services.external_sales_data import create_external_sales_data, remove_unused_areas
 from hitas.services.validation import validate_postal_code, validate_quarter
-from hitas.utils import business_quarter, from_iso_format_or_today_if_none, to_quarter
+from hitas.utils import business_quarter, from_iso_format_or_today_if_none, hitas_calculation_quarter, to_quarter
 from hitas.views.utils.excel import NewExcelParser, OldExcelParser, parse_sheet
 from hitas.views.utils.fields import IntegerOrEmpty
 
@@ -130,8 +129,7 @@ class ExternalSalesDataView(ViewSet):
         except ValueError as error:
             raise ValidationError({"calculation_date": str(error)}) from error
 
-        calculation_quarter = business_quarter(calculation_date)
-        quarter = to_quarter(calculation_quarter - relativedelta(months=3))
+        quarter = to_quarter(business_quarter(hitas_calculation_quarter(calculation_date)))
 
         try:
             sales_data = ExternalSalesData.objects.get(calculation_quarter=quarter)

--- a/backend/hitas/views/thirty_year_regulation.py
+++ b/backend/hitas/views/thirty_year_regulation.py
@@ -12,6 +12,7 @@ from hitas.exceptions import ModelConflict
 from hitas.models.thirty_year_regulation import RegulationResult
 from hitas.services.thirty_year_regulation import (
     build_thirty_year_regulation_report_excel,
+    convert_thirty_year_regulation_results_to_comparison_data,
     get_thirty_year_regulation_results,
     get_thirty_year_regulation_results_for_housing_company,
     perform_thirty_year_regulation,
@@ -28,7 +29,14 @@ class ThirtyYearRegulationView(ViewSet):
         except ValueError as error:
             raise ValidationError({"calculation_date": str(error)}) from error
 
-        results = perform_thirty_year_regulation(calculation_date)
+        check = request.query_params.get("check", 0) in ("True", "true", "1", 1)
+
+        if check:
+            results = perform_thirty_year_regulation(calculation_date)
+        else:
+            data = get_thirty_year_regulation_results(calculation_date)
+            results = convert_thirty_year_regulation_results_to_comparison_data(data)
+
         return Response(data=results, status=status.HTTP_200_OK)
 
     @action(

--- a/backend/hitas/views/thirty_year_regulation.py
+++ b/backend/hitas/views/thirty_year_regulation.py
@@ -29,14 +29,18 @@ class ThirtyYearRegulationView(ViewSet):
         except ValueError as error:
             raise ValidationError({"calculation_date": str(error)}) from error
 
-        check = request.query_params.get("check", 0) in ("True", "true", "1", 1)
+        data = get_thirty_year_regulation_results(calculation_date)
+        results = convert_thirty_year_regulation_results_to_comparison_data(data)
 
-        if check:
-            results = perform_thirty_year_regulation(calculation_date)
-        else:
-            data = get_thirty_year_regulation_results(calculation_date)
-            results = convert_thirty_year_regulation_results_to_comparison_data(data)
+        return Response(data=results, status=status.HTTP_200_OK)
 
+    def create(self, request: Request, *args, **kwargs) -> Response:
+        try:
+            calculation_date = from_iso_format_or_today_if_none(request.data.get("calculation_date"))
+        except ValueError as error:
+            raise ValidationError({"calculation_date": str(error)}) from error
+
+        results = perform_thirty_year_regulation(calculation_date)
         return Response(data=results, status=status.HTTP_200_OK)
 
     @action(

--- a/backend/hitas/views/thirty_year_regulation.py
+++ b/backend/hitas/views/thirty_year_regulation.py
@@ -8,7 +8,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
-from hitas.exceptions import ModelConflict
 from hitas.models.thirty_year_regulation import RegulationResult
 from hitas.services.thirty_year_regulation import (
     build_thirty_year_regulation_report_excel,
@@ -63,12 +62,6 @@ class ThirtyYearRegulationView(ViewSet):
             raise ValidationError({"calculation_date": str(error)}) from error
 
         results = get_thirty_year_regulation_results_for_housing_company(housing_company_uuid, calculation_date)
-
-        if results.regulation_result == RegulationResult.SKIPPED:
-            raise ModelConflict(
-                "Cannot download PDF since regulation for this housing company was skipped.",
-                error_code="invalid",
-            )
 
         context = {"results": results}
         choice = "jatkumisesta" if results.regulation_result == RegulationResult.STAYS_REGULATED else "pättymisestä"

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2345,18 +2345,28 @@ paths:
   /api/v1/thirty-year-regulation:
 
     get:
-      description: Check housing companies over 30 years old whether they should be released from hitas regulation or not.
-      operationId: check-regulation
+      description: >-
+        If 'check' parameter is 'true', check housing companies over 30 years old
+        whether they should be released from Hitas regulation or not.
+        Otherwise, try to fetch existing regulation results.
+      operationId: read-or-check-regulation
       tags:
         - Thirty Year Regulation
       parameters:
         - name: calculation_date
           required: false
           in: query
-          description: Calculation date, use current date if not given
+          description: Calculation date, use current date if not given.
           schema:
             type: string
             example: 2023-01-01
+        - name: check
+          required: false
+          in: query
+          description: If set to 'true', check regulation instead of fetching existing regulation data.
+          schema:
+            type: string
+            example: true
       responses:
         '200':
           description: Successfully performed thirty-year regulation for housing companies

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2271,6 +2271,36 @@ paths:
 
   /api/v1/external-sales-data:
 
+    get:
+      description: Read external sales data for the quarter
+      operationId: read-external-sales-data
+      tags:
+        - External Sales Data
+      parameters:
+        - name: calculation_date
+          required: false
+          in: query
+          description: Calculation date the Excel is needed for, use current date if not given
+          schema:
+            type: string
+            example: 2023-01-01
+      responses:
+        '200':
+          description: Successfully read external sales data for the quarter
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                $ref: '#/components/schemas/ExternalSalesData'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
     post:
       description: Read cost area sales catalog from statistics center to external sales data
       operationId: create-external-sales-data
@@ -2305,38 +2335,6 @@ paths:
           $ref: '#/components/responses/NotAcceptableExcel'
         '415':
           $ref: '#/components/responses/UnsupportedMediaTypeExcel'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /api/v1/external-sales-data/{quarter}:
-
-    get:
-      description: Read external sales data for the quarter
-      operationId: read-external-sales-data
-      tags:
-        - External Sales Data
-      parameters:
-        - name: quarter
-          required: true
-          in: path
-          description: Calculation quarter
-          schema:
-            type: string
-            example: 2022Q1
-      responses:
-        '200':
-          description: Successfully read external sales data for the quarter
-          content:
-            application/json:
-              schema:
-                additionalProperties: false
-                $ref: '#/components/schemas/ExternalSalesData'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '406':
-          $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2333,6 +2333,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '406':
           $ref: '#/components/responses/NotAcceptableExcel'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '415':
           $ref: '#/components/responses/UnsupportedMediaTypeExcel'
         '500':

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2343,13 +2343,9 @@ paths:
   # Thirty Year Regulation
 
   /api/v1/thirty-year-regulation:
-
     get:
-      description: >-
-        If 'check' parameter is 'true', check housing companies over 30 years old
-        whether they should be released from Hitas regulation or not.
-        Otherwise, try to fetch existing regulation results.
-      operationId: read-or-check-regulation
+      description: Try to fetch existing thirty-year regulation results.
+      operationId: read-thirty-year-regulation
       tags:
         - Thirty Year Regulation
       parameters:
@@ -2360,13 +2356,42 @@ paths:
           schema:
             type: string
             example: 2023-01-01
-        - name: check
-          required: false
-          in: query
-          description: If set to 'true', check regulation instead of fetching existing regulation data.
-          schema:
-            type: string
-            example: true
+      responses:
+        '200':
+          description: Successfully read thirty-year regulation results
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                $ref: '#/components/schemas/ThirtyYearRegulationResults'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    post:
+      description: Perform thirty-year regulation for housing companies
+      operationId: perform-thirty-year-regulation
+      tags:
+        - Thirty Year Regulation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: Thirty-year regulation information
+              type: object
+              additionalProperties: false
+              properties:
+                calculation_date:
+                  description: Calculation date, use current date if not given.
+                  type: string
+                  example: 2023-01-01
       responses:
         '200':
           description: Successfully performed thirty-year regulation for housing companies

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -7258,6 +7258,8 @@ components:
           description: Housing company's display name
           type: string
           example: Taloyhtiö Helmi
+        address:
+          $ref: '#/components/schemas/HitasHousingCompanyAddress'
         price:
           description: |-
             Average price per square meter for all apartments in the housing company,
@@ -7272,6 +7274,13 @@ components:
           description: Does this housing company use the old or the new hitas ruleset?
           type: boolean
           example: false
+        completion_date:
+          description: Housing company completion date
+          type: string
+          format: date
+          example: 2023-02-01
+        property_manager:
+          $ref: '#/components/schemas/ReadOnlyPropertyManager'
 
     ObfuscatedOwner:
       description: Owner that has been obfuscated due to no longer owning any regulated apartments
@@ -7297,7 +7306,6 @@ components:
           type: string
           nullable: true
           example: martti.virtanen@example.com
-
 
     SurfaceAreaPriceCeilingCalculationResult:
       description: Surface area price ceiling calculation


### PR DESCRIPTION
# Hitas Pull Request

# Description

Implements discussed changes for 30-year regulation:
- [x] External sales import endpoint uses date instead of a quarter
- [x] 30-year regulation includes more fields
- [x] 30-year regulation results can be fetched without re-checking regulation
- [x] 30-year regulation can only be re-checked if is no previous regulation results, or there are skipped housing companies in the previous results
- [x] Do not allow overriding external sales data
- [x] Add calculation date parameter to external sales data endpoint to validate that the given Excel sheet matched that date.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests

## Tickets

This pull request resolves all or part of the following ticket(s): HT-535, HT-536, HT-538, HT-539, HT-540, HT-541
