### PR TITLE
Apartment first sale

### DIFF
--- a/frontend/src/common/components/QueryStateHandler.tsx
+++ b/frontend/src/common/components/QueryStateHandler.tsx
@@ -35,17 +35,20 @@ export default function QueryStateHandler({
             </p>
         );
     }
-    return error ? (
-        errorComponent
-    ) : isLoading ? (
-        <div className="spinner-wrap">
-            <div className="spinner-container">
-                <LoadingSpinner />
+
+    if (error) {
+        return errorComponent;
+    } else if (isLoading) {
+        return (
+            <div className="spinner-wrap">
+                <div className="spinner-container">
+                    <LoadingSpinner />
+                </div>
             </div>
-        </div>
-    ) : data && (!("contents" in data) || data.contents.length) ? (
-        <>{children}</>
-    ) : (
-        <p>Ei tuloksia</p>
-    );
+        );
+    } else if (data && (!("contents" in data) || data.contents.length)) {
+        return <>{children}</>;
+    } else {
+        return <p>Ei tuloksia</p>;
+    }
 }

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -50,6 +50,9 @@ export const errorMessages = {
     APIIdMax: "Rajapinnan palauttamassa ID-arvossa on liian monta merkkiä",
     overMaxPrice: "Kauppahinta ylittää enimmäishinnan",
     loanShareChanged: "Lainaosuus muuttunut laskelmasta",
+    catalogOverMaxPrice: "Kauppahinta ylittää myyntihintaluettelon hinnan",
+    catalogUnderMaxPrice: "Kauppahinta alittaa myyntihintaluettelon hinnan",
+    catalogPricesMissing: "Myyntihintaluettelon hinnat puuttuvat",
 };
 
 const customErrorMap: z.ZodErrorMap = (issue, ctx) => {
@@ -349,7 +352,7 @@ const ApartmentPricesSchema = object({
     latest_purchase_date: string().nullable(), // Read only
     catalog_purchase_price: number().nullable(), // Read only
     catalog_share_of_housing_company_loans: number().nullable(), // Read only
-    catalog_acquisition_price: number().nullable(), // Read only
+    catalog_acquisition_price: number().nullable(), // Read only. (purchase_price + share_of_hosing_company_loans)
     construction: object({
         loans: number().nullable(),
         additional_work: number().nullable(),

--- a/frontend/src/features/apartment/ApartmentNewSalePage/ApartmentCatalogPrices.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/ApartmentCatalogPrices.tsx
@@ -1,0 +1,41 @@
+import {Fieldset, IconAlertCircleFill} from "hds-react";
+import {formatMoney} from "../../../common/utils";
+
+const ApartmentCatalogPrices = ({apartment, errorMessage}) => {
+    const maximumPrices = {
+        maximumPrice: apartment.prices.catalog_purchase_price ?? 0,
+        debtFreePurchasePrice: apartment.prices.catalog_acquisition_price ?? 0,
+        apartmentShareOfHousingCompanyLoans: apartment.prices.catalog_share_of_housing_company_loans ?? 0,
+        index: "",
+    };
+
+    return (
+        <Fieldset heading="Myyntihintaluettelon hinnat">
+            <div className="max-prices">
+                <div className="row row--max-prices">
+                    <div className="fieldset--max-prices__value">
+                        <legend>Myyntihinta (€)</legend>
+                        <span className="">{formatMoney(maximumPrices.maximumPrice)}</span>
+                    </div>
+                    <div className="fieldset--max-prices__value">
+                        <legend>Osuus yhtiön lainoista (€)</legend>
+                        <span>{formatMoney(maximumPrices.apartmentShareOfHousingCompanyLoans)}</span>
+                    </div>
+                    <div className="fieldset--max-prices__value">
+                        <legend>Velaton enimmäishinta (€)</legend>
+                        <span>{formatMoney(maximumPrices.debtFreePurchasePrice)}</span>
+                    </div>
+                </div>
+
+                {errorMessage ? (
+                    <p className="error-text">
+                        <IconAlertCircleFill />
+                        {errorMessage}
+                    </p>
+                ) : null}
+            </div>
+        </Fieldset>
+    );
+};
+
+export default ApartmentCatalogPrices;

--- a/frontend/src/features/apartment/ApartmentNewSalePage/ApartmentNewSalePage.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/ApartmentNewSalePage.tsx
@@ -23,7 +23,9 @@ const ApartmentNewSalePage = () => {
                 isLoading={isLoading}
             >
                 <ApartmentHeader apartment={data as IApartmentDetails} />
-                <Heading type="main">Kauppatapahtuma</Heading>
+                <Heading type="main">
+                    {data && data.prices.first_purchase_date ? "Kauppatapahtuma" : "Uudiskohteen kauppa"}
+                </Heading>
                 <LoadedApartmentSalesPage apartment={data as IApartmentDetails} />
             </QueryStateHandler>
         </div>

--- a/frontend/src/features/apartment/ApartmentNewSalePage/LoadedApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/LoadedApartmentSalesPage.tsx
@@ -21,7 +21,6 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
         | undefined
         | {
               maximumPrice: number;
-              maxPricePerSquare: number;
               debtFreePurchasePrice: number;
               apartmentShareOfHousingCompanyLoans: number;
               index: string;

--- a/frontend/src/features/apartment/ApartmentNewSalePage/LoadedApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/LoadedApartmentSalesPage.tsx
@@ -11,11 +11,18 @@ import ConfirmDialogModal from "../../../common/components/ConfirmDialogModal";
 import {Checkbox, DateInput, NumberInput} from "../../../common/components/form";
 import {ApartmentSaleSchema, errorMessages, IApartmentDetails, IApartmentSaleForm} from "../../../common/schemas";
 import {hdsToast, today} from "../../../common/utils";
+import ApartmentCatalogPrices from "./ApartmentCatalogPrices";
 import MaximumPriceCalculationFieldSet from "./MaximumPriceCalculationFieldSet";
 import OwnershipsListFieldSet from "./OwnershipsListFieldSet";
 
 const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) => {
     const navigate = useNavigate();
+
+    const isApartmentFirstSale = !apartment.prices.first_purchase_date;
+    const hasValidCatalogPrices =
+        apartment.prices.catalog_purchase_price !== null &&
+        apartment.prices.catalog_share_of_housing_company_loans !== null &&
+        apartment.prices.catalog_acquisition_price !== null;
 
     const [maximumPrices, setMaximumPrices] = useState<
         | undefined
@@ -25,7 +32,16 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
               apartmentShareOfHousingCompanyLoans: number;
               index: string;
           }
-    >();
+    >(
+        isApartmentFirstSale && hasValidCatalogPrices
+            ? {
+                  maximumPrice: apartment.prices.catalog_purchase_price ?? 0,
+                  debtFreePurchasePrice: apartment.prices.catalog_acquisition_price ?? 0,
+                  apartmentShareOfHousingCompanyLoans: apartment.prices.catalog_share_of_housing_company_loans ?? 0,
+                  index: "",
+              }
+            : undefined
+    );
 
     // ************************
     // * Form data and schema *
@@ -34,46 +50,71 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
     const initialFormData: IApartmentSaleForm = {
         notification_date: today(),
         purchase_date: "",
-        purchase_price: maximumPrices?.maximumPrice ?? null,
-        apartment_share_of_housing_company_loans: maximumPrices?.apartmentShareOfHousingCompanyLoans ?? null,
+        purchase_price: isApartmentFirstSale && hasValidCatalogPrices ? apartment.prices.catalog_purchase_price : null,
+        apartment_share_of_housing_company_loans:
+            isApartmentFirstSale && hasValidCatalogPrices
+                ? apartment.prices.catalog_share_of_housing_company_loans
+                : null,
         exclude_from_statistics: false,
     };
     const initialFormOwnershipsList = apartment.ownerships.map((o) => ({...o, key: uuidv4()}));
 
+    // Hard Errors
     // ApartmentSaleSchema with additional validation related to maximum price calculation
     const RefinedApartmentSaleSchema: ZodSchema = ApartmentSaleSchema.superRefine((data, ctx) => {
-        // Sale can't be made without a confirmed maximum price calculation.
-        if (maximumPrices === undefined) {
-            ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ["maximum_price_calculation"],
-                message: "Enimmäishintalaskelma puuttuu.",
-            });
-            return;
-        }
-        // The apartment share of housing company loans must match the maximum price calculations.
-        if (data.apartment_share_of_housing_company_loans !== maximumPrices.apartmentShareOfHousingCompanyLoans) {
-            ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ["apartment_share_of_company_loans"],
-                message: errorMessages.loanShareChanged,
-            });
+        if (!isApartmentFirstSale) {
+            // Sale can't be made without a confirmed maximum price calculation.
+            if (maximumPrices === undefined) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ["maximum_price_calculation"],
+                    message: "Enimmäishintalaskelma puuttuu.",
+                });
+                return;
+            }
+            // The apartment share of housing company loans must match the maximum price calculations.
+            if (data.apartment_share_of_housing_company_loans !== maximumPrices.apartmentShareOfHousingCompanyLoans) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ["apartment_share_of_company_loans"],
+                    message: errorMessages.loanShareChanged,
+                });
+            }
         }
     });
 
+    // Soft Errors
     const resolver = (data, context, options) => {
         return zodResolver(
             RefinedApartmentSaleSchema.superRefine((data, ctx) => {
-                // Price can not be bigger than the maximum price calculations maximum price.
-                if (
-                    !warningsGiven.purchase_price &&
-                    (!maximumPrices || data.purchase_price > maximumPrices.maximumPrice)
-                ) {
-                    ctx.addIssue({
-                        code: z.ZodIssueCode.custom,
-                        path: ["purchase_price"],
-                        message: errorMessages.overMaxPrice,
-                    });
+                if (!isApartmentFirstSale) {
+                    // Price can not be bigger than the maximum price calculations maximum price.
+                    if (
+                        !warningsGiven.purchase_price &&
+                        (!maximumPrices || data.purchase_price > maximumPrices.maximumPrice)
+                    ) {
+                        ctx.addIssue({
+                            code: z.ZodIssueCode.custom,
+                            path: ["purchase_price"],
+                            message: errorMessages.overMaxPrice,
+                        });
+                    }
+                } else {
+                    // We should show a warning and ask for confirmation if catalog prices are missing
+                    if (
+                        !warningsGiven.catalog_acquisition_price &&
+                        (!hasValidCatalogPrices ||
+                            (apartment.prices.catalog_acquisition_price !== null &&
+                                (data.purchase_price + data.apartment_share_of_housing_company_loans >
+                                    apartment.prices.catalog_acquisition_price ||
+                                    data.purchase_price + data.apartment_share_of_housing_company_loans <
+                                        apartment.prices.catalog_acquisition_price)))
+                    ) {
+                        ctx.addIssue({
+                            code: z.ZodIssueCode.custom,
+                            path: ["catalog_acquisition_price"],
+                        });
+                    }
                 }
             })
         )(data, context, {...options, mode: "sync"});
@@ -93,11 +134,13 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
 
     // Certain form errors should be able to be ignored.
     const [isWarningModalVisible, setIsWarningModalVisible] = useState(false);
-    const noWarningsGiven = {purchase_price: false};
+    const noWarningsGiven = {purchase_price: false, catalog_acquisition_price: false};
     const [warningsGiven, setWarningsGiven] = useState(noWarningsGiven);
+    const [warningMessage, setWarningMessage] = useState("");
 
     const closeWarningsModal = () => {
         setWarningsGiven(noWarningsGiven);
+        setWarningMessage("");
         setIsWarningModalVisible(false);
     };
 
@@ -120,9 +163,35 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
         if (errors.purchase_price && errors.purchase_price.type === z.ZodIssueCode.custom) {
             setIsWarningModalVisible(true);
             setWarningsGiven((prev) => ({...prev, purchase_price: true}));
+            setWarningMessage("Kauppahinta ylittää laskelman enimmäishinnan.");
+        } else if (
+            errors.catalog_acquisition_price &&
+            errors.catalog_acquisition_price.type === z.ZodIssueCode.custom
+        ) {
+            setIsWarningModalVisible(true);
+            setWarningsGiven((prev) => ({...prev, catalog_acquisition_price: true}));
+            setWarningMessage(getCatalogPriceError());
         } else {
-            hdsToast.error(`Virhe luodessa asunnon kauppaa! ${errors}`);
+            hdsToast.error(`Virhe luodessa asunnon kauppaa!`);
+            // eslint-disable-next-line no-console
+            console.error(errors);
         }
+    };
+
+    const getCatalogPriceError = () => {
+        const acquisitionPrice =
+            saleForm.getValues("purchase_price") + saleForm.getValues("apartment_share_of_housing_company_loans");
+
+        if (!hasValidCatalogPrices) {
+            return errorMessages.catalogPricesMissing;
+        } else if (apartment.prices.catalog_acquisition_price !== null) {
+            if (acquisitionPrice > apartment.prices.catalog_acquisition_price) {
+                return errorMessages.catalogOverMaxPrice;
+            } else if (acquisitionPrice < apartment.prices.catalog_acquisition_price) {
+                return errorMessages.catalogUnderMaxPrice;
+            }
+        }
+        return "";
     };
 
     // Send a request to the API to create a sale
@@ -156,16 +225,18 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
 
     // Check if the parts of the sale form needed for a max price calculation are currently valid
     const hasLoanValueChanged =
+        !isApartmentFirstSale &&
         maximumPrices !== undefined &&
         saleForm.getValues("apartment_share_of_housing_company_loans") !==
             maximumPrices.apartmentShareOfHousingCompanyLoans;
 
     // Disable the saving button when the form has errors or when there is no valid calculation
-    const isSavingDisabled =
-        maximumPrices === undefined || !RefinedApartmentSaleSchema.safeParse(saleForm.getValues()).success;
+    const isSavingDisabled = isApartmentFirstSale
+        ? !RefinedApartmentSaleSchema.safeParse(saleForm.getValues()).success
+        : maximumPrices === undefined || !RefinedApartmentSaleSchema.safeParse(saleForm.getValues()).success;
 
-    // Disable all fields not related to creating a calculation when it's missing
-    const isMaximumPriceCalculationMissing = maximumPrices === undefined;
+    // Disable all fields not related to creating a calculation when it's missing (Does not apply for first sales)
+    const isMaximumPriceCalculationMissing = !isApartmentFirstSale && maximumPrices === undefined;
 
     return (
         <div className="view--apartment-conditions-of-sale">
@@ -224,11 +295,18 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
                     </form>
                 </Fieldset>
 
-                <MaximumPriceCalculationFieldSet
-                    apartment={apartment}
-                    setMaximumPrices={setMaximumPrices}
-                    saleForm={saleForm}
-                />
+                {isApartmentFirstSale ? (
+                    <ApartmentCatalogPrices
+                        apartment={apartment}
+                        errorMessage={getCatalogPriceError()}
+                    />
+                ) : (
+                    <MaximumPriceCalculationFieldSet
+                        apartment={apartment}
+                        setMaximumPrices={setMaximumPrices}
+                        saleForm={saleForm}
+                    />
+                )}
                 <OwnershipsListFieldSet
                     formObject={saleForm}
                     disabled={isMaximumPriceCalculationMissing}
@@ -249,7 +327,7 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
                 isLoading={isCreateSaleLoading}
                 isVisible={isWarningModalVisible}
                 setIsVisible={setIsWarningModalVisible}
-                modalText="Kauppahinta ylittää laskelman enimmäishinnan. Haluatko varmasti tallentaa kaupan?"
+                modalText={`${warningMessage} Haluatko varmasti tallentaa kaupan?`}
                 modalHeader="Vahvista kaupan tallennus"
                 cancelAction={closeWarningsModal}
                 confirmAction={handleSaveButtonClick}

--- a/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationExists.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationExists.tsx
@@ -45,33 +45,33 @@ const MaximumPriceCalculationExists = ({
                 </div>
             </div>
 
-            <div className="row row--prompt">
-                <p>
-                    Enimmäishinnat on laskettu
-                    <span>{` ${getIndexType(maximumPrices.index)}llä`}</span> sekä{" "}
-                    <span>
-                        {maximumPrices.apartmentShareOfHousingCompanyLoans === 0
-                            ? "0 €"
-                            : formatMoney(maximumPrices.apartmentShareOfHousingCompanyLoans)}
-                    </span>{" "}
-                    lainaosuudella.
+            <p>
+                Enimmäishinnat on laskettu
+                <span>{` ${getIndexType(maximumPrices.index)}llä`}</span> sekä{" "}
+                <span>
+                    {maximumPrices.apartmentShareOfHousingCompanyLoans === 0
+                        ? "0 €"
+                        : formatMoney(maximumPrices.apartmentShareOfHousingCompanyLoans)}
+                </span>{" "}
+                lainaosuudella.
+            </p>
+
+            {hasLoanValueChanged && (
+                <p className="error-text">
+                    <IconAlertCircleFill />
+                    <span>Yhtiön lainaosuus</span> on muuttunut, ole hyvä ja
+                    <span> tee uusi enimmäishintalaskelma</span>.
                 </p>
-                {hasLoanValueChanged && (
-                    <p className="error-text">
-                        <IconAlertCircleFill />
-                        <span>Yhtiön lainaosuus</span> on muuttunut, ole hyvä ja
-                        <span> tee uusi enimmäishintalaskelma</span>.
-                    </p>
-                )}
-                <Button
-                    theme="black"
-                    variant={hasLoanValueChanged ? "primary" : "secondary"}
-                    onClick={handleCalculateButton}
-                    disabled={!isCalculationFormValid}
-                >
-                    Luo uusi enimmäishintalaskelma
-                </Button>
-            </div>
+            )}
+
+            <Button
+                theme="black"
+                variant={hasLoanValueChanged ? "primary" : "secondary"}
+                onClick={handleCalculateButton}
+                disabled={!isCalculationFormValid}
+            >
+                Luo uusi enimmäishintalaskelma
+            </Button>
         </div>
     );
 };

--- a/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationFieldSet.tsx
@@ -46,7 +46,6 @@ const MaximumPriceCalculationFieldSet = ({apartment, setMaximumPrices, saleForm}
         const indexVariables = calculation.calculations[calculation.index].calculation_variables;
         setMaximumPrices({
             maximumPrice: calculation.maximum_price,
-            maxPricePerSquare: calculation.maximum_price_per_square,
             debtFreePurchasePrice: indexVariables.debt_free_price,
             apartmentShareOfHousingCompanyLoans: indexVariables.apartment_share_of_housing_company_loans,
             index: calculation.index,

--- a/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
@@ -16,7 +16,7 @@ const OwnershipsListFieldSet = ({formObject, disabled}) => {
     formObject.register("ownerships");
 
     // Blank Ownership. This is appended to the list when user clicks "New ownership"
-    const emptyOwnership = {key: uuidv4(), owner: {id: ""} as IOwner, percentage: 0};
+    const emptyOwnership = {key: uuidv4(), owner: {id: ""} as IOwner, percentage: 100};
 
     const ownerships = formObject.getValues("ownerships");
     const formErrors = OwnershipsListSchema.safeParse(formObject.getValues("ownerships"));

--- a/frontend/src/features/apartment/components/ApartmentHeader.tsx
+++ b/frontend/src/features/apartment/components/ApartmentHeader.tsx
@@ -1,5 +1,5 @@
 import {IconLock, StatusLabel} from "hds-react";
-import {Link} from "react-router-dom";
+import {Link, useLocation} from "react-router-dom";
 
 import {EditButton, Heading} from "../../../common/components";
 import {getApartmentStateLabel} from "../../../common/localisation";
@@ -13,12 +13,27 @@ const ApartmentHeader = ({
     apartment: IApartmentDetails;
     showEditButton?: boolean;
 }) => {
+    const {pathname} = useLocation();
+    const isApartmentSubPage = pathname.split("/").pop() !== apartment.id;
+
     return (
         <div className="view--apartment-details">
             <Heading type="main">
-                <Link to={`/housing-companies/${apartment.links.housing_company.id}`}>
-                    <span className="name">{apartment.links.housing_company.display_name}</span>
-                    <span className="address">{apartment && formatAddress(apartment.address)}</span>
+                <div>
+                    <Link to={`/housing-companies/${apartment.links.housing_company.id}`}>
+                        <span className="name">
+                            {apartment.links.housing_company.display_name} {isApartmentSubPage}
+                        </span>
+                    </Link>
+                    {isApartmentSubPage ? (
+                        <Link
+                            to={`/housing-companies/${apartment.links.housing_company.id}/apartments/${apartment.id}`}
+                        >
+                            <span className="address">{apartment && formatAddress(apartment.address)}</span>
+                        </Link>
+                    ) : (
+                        <span className="address">{apartment && formatAddress(apartment.address)}</span>
+                    )}
                     <StatusLabel>{getApartmentStateLabel(apartment.state)}</StatusLabel>
                     {apartment.sell_by_date ? (
                         <StatusLabel
@@ -26,7 +41,7 @@ const ApartmentHeader = ({
                             iconLeft={<IconLock />}
                         />
                     ) : null}
-                </Link>
+                </div>
                 {showEditButton ? <EditButton state={{apartment: apartment}} /> : null}
             </Heading>
         </div>

--- a/frontend/src/features/apartment/components/ConditionsOfSaleStatus.tsx
+++ b/frontend/src/features/apartment/components/ConditionsOfSaleStatus.tsx
@@ -14,8 +14,6 @@ type IConditionsOfSaleStatus =
       };
 
 const ConditionsOfSaleStatus = ({apartment, conditionOfSale}: IConditionsOfSaleStatus) => {
-    if ((conditionOfSale && !conditionOfSale?.sell_by_date) || (apartment && !apartment?.sell_by_date)) return null;
-
     let sellByDate;
     let hasGracePeriod;
     let fulfilled;

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -10,6 +10,10 @@
     font-size: $fontsize-heading-s
     border: 0
 
+    div
+      display: flex
+      flex-direction: row
+
     a
       @include align-items(center)
       display: inherit
@@ -18,6 +22,9 @@
 
     a > span
       display: inline-block
+      margin-right: $spacing-layout-s
+
+    span:not([class*="status-label"])
       margin-right: $spacing-layout-s
 
     .address

--- a/frontend/src/styles/components/_ApartmentNewSalePage.sass
+++ b/frontend/src/styles/components/_ApartmentNewSalePage.sass
@@ -22,8 +22,20 @@
       padding: $spacing-s
       width: 100%
       grid-column: 1
+
+      .row
+        gap: 2em
+        > div
+          width: 50%
+          position: relative
+        p span
+          font-weight: bold
+
       // "Kaupan tiedot" & "Enimmäishintalaskelma" cards (left side)
       .max-prices
+        display: flex
+        flex-flow: column nowrap
+        gap: 1em
         .row--buttons
           margin-bottom: 0
           button
@@ -37,22 +49,13 @@
             font-weight: bold
             font-size: $fontsize-body-xl
         .error-text
-          margin: -1rem 0 0
           svg
             vertical-align: bottom
             margin-right: $spacing-2-xs
+
         &.expired .fieldset--max-prices__value span
           color: $color-black-40 !important
           text-decoration: line-through
-      .row
-        gap: 2em
-        > div
-          width: 50%
-          position: relative
-        &--prompt
-          flex-flow: column nowrap
-          p span
-            font-weight: bold
 
       // "Omistajuudet" card (right side)
       &.ownerships-fieldset

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -288,13 +288,16 @@ header
       display: none
     > ul
       @include flex-grow(1)
-      min-width: 760px
+      min-width: 416px
+      margin-left: 142px
+      margin-right: 142px
       li
         min-width: 40px
     [type="button"]
       border-radius: 40px
       width: 142px
       position: absolute
+      top: -8px
       div
         transition: all 350ms ease-out
       &:hover


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Allow creating a first sale for apartment
  - In the first sale, price is compared to catalogue sales prices
  - If catalogue sales prices are not saved, show a skippable warning
  - If sales price is too high or low show a skippable warning
- Some small refactorings, fixes and improvements

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- Create a first sale for an apartment using the UI, with and without sales catalogue prices given

## Tickets

This pull request resolves all or part of the following ticket(s): HT-419
