### PR TITLE
Adds Functions view, with PriceCeilingPerSquare tab dummy

### DIFF
--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -14,6 +14,7 @@ import {
 } from "./features/apartment";
 import {Codes} from "./features/codes";
 import Documents from "./features/documents/Documents";
+import {Functions} from "./features/functions";
 import {
     HousingCompanyBuildingsPage,
     HousingCompanyCreatePage,
@@ -124,6 +125,10 @@ export default function Router() {
                 <Route
                     path="codes"
                     element={<Codes />}
+                />
+                <Route
+                    path="functions"
+                    element={<Functions />}
                 />
                 <Route
                     index

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -44,6 +44,10 @@ const App = (): JSX.Element => {
                         label="Koodisto"
                         path="codes"
                     />
+                    <NavItem
+                        label="Toiminnot"
+                        path="functions"
+                    />
                 </Navigation.Row>
             </Navigation>
 

--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -14,6 +14,7 @@ import {
     ICodeResponse,
     IConditionOfSale,
     ICreateConditionOfSale,
+    IExternalSalesDataResponse,
     IHousingCompanyApartmentQuery,
     IHousingCompanyDetails,
     IHousingCompanyListResponse,
@@ -200,6 +201,12 @@ const detailApi = hitasApi.injectEndpoints({
                 url: `housing-companies/${housingCompanyId}/apartments/${apartmentId}/maximum-prices/${priceId}`,
             }),
         }),
+        getExternalSalesData: builder.query<IExternalSalesDataResponse, {calculation_date: string}>({
+            query: (params: {calculation_date: string}) => ({
+                url: "external-sales-data",
+                params: params,
+            }),
+        }),
     }),
 });
 
@@ -367,6 +374,15 @@ const mutationApi = hitasApi.injectEndpoints({
             invalidatesTags: (result, error) =>
                 !error && result && result.conditions_of_sale.length ? [{type: "Apartment"}] : [],
         }),
+        saveExternalSalesData: builder.mutation({
+            query: (arg) => ({
+                url: "external-sales-data",
+                method: "POST",
+                body: arg.data,
+                params: {calculation_date: arg.calculation_date},
+                headers: {"Content-type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+            }),
+        }),
     }),
 });
 
@@ -384,8 +400,12 @@ export const {
     useGetFinancingMethodsQuery,
 } = listApi;
 
-export const {useGetHousingCompanyDetailQuery, useGetApartmentDetailQuery, useGetApartmentMaximumPriceQuery} =
-    detailApi;
+export const {
+    useGetHousingCompanyDetailQuery,
+    useGetApartmentDetailQuery,
+    useGetApartmentMaximumPriceQuery,
+    useGetExternalSalesDataQuery,
+} = detailApi;
 
 export const {
     useSaveHousingCompanyMutation,
@@ -400,4 +420,5 @@ export const {
     useSaveIndexMutation,
     useCreateSaleMutation,
     useCreateConditionOfSaleMutation,
+    useSaveExternalSalesDataMutation,
 } = mutationApi;

--- a/frontend/src/common/components/SaveButton.tsx
+++ b/frontend/src/common/components/SaveButton.tsx
@@ -1,13 +1,20 @@
 import {Button, IconSaveDisketteFill} from "hds-react";
 
 interface SaveButtonProps {
-    onClick?: () => void;
+    onClick?: (unknown) => unknown;
     isLoading?: boolean;
     disabled?: boolean;
     type?: "submit";
+    buttonText?: string;
 }
 
-export default function SaveButton({onClick, isLoading = false, disabled = false, type}: SaveButtonProps): JSX.Element {
+export default function SaveButton({
+    onClick,
+    isLoading = false,
+    disabled = false,
+    type,
+    buttonText,
+}: SaveButtonProps): JSX.Element {
     return (
         <Button
             iconLeft={<IconSaveDisketteFill />}
@@ -23,7 +30,7 @@ export default function SaveButton({onClick, isLoading = false, disabled = false
             disabled={disabled}
             type={type || "button"}
         >
-            Tallenna
+            {buttonText ?? "Tallenna"}
         </Button>
     );
 }

--- a/frontend/src/common/components/form/FileInput.tsx
+++ b/frontend/src/common/components/form/FileInput.tsx
@@ -1,0 +1,44 @@
+import {FileInput as HDSFileInput} from "hds-react";
+
+import {FormInputProps} from "./";
+
+interface FileInputProps extends FormInputProps {
+    buttonLabel?: string;
+}
+const FileInput = ({
+    name,
+    id = name,
+    label = "",
+    invalid,
+    required,
+    formObject,
+    onChange,
+    ...rest
+}: FileInputProps): JSX.Element => {
+    const {
+        register,
+        formState: {errors},
+    } = formObject;
+    register(name, {required: required});
+    const handleChange = (e) => {
+        // Set the value of the input to the file selected
+        formObject.setValue(name, e[0]);
+        // If there is an onChange handler, call it
+        onChange && onChange(e);
+    };
+    return (
+        <div className="input-field--file">
+            <HDSFileInput
+                id={id}
+                label={label}
+                onChange={handleChange}
+                errorText={errors[name] && errors[name].message}
+                required={required}
+                multiple={false}
+                {...rest}
+            />
+        </div>
+    );
+};
+
+export default FileInput;

--- a/frontend/src/common/components/form/SelectInput.tsx
+++ b/frontend/src/common/components/form/SelectInput.tsx
@@ -63,8 +63,9 @@ const Select = ({
                         {...inputProps}
                         label={label}
                         onChange={handleChange}
-                        invalid={invalid ?? !!fieldError}
-                        required={true}
+                        invalid={invalid ?? !!errors[name]}
+                        required={required}
+                        clearable={!required}
                     />
                     {!!fieldError && <p className="text-input_hds-text-input__error-text">{fieldError.message}</p>}
                 </>

--- a/frontend/src/common/components/form/SelectInput.tsx
+++ b/frontend/src/common/components/form/SelectInput.tsx
@@ -64,8 +64,6 @@ const Select = ({
                         label={label}
                         onChange={handleChange}
                         invalid={invalid ?? !!errors[name]}
-                        required={required}
-                        clearable={!required}
                     />
                     {!!fieldError && <p className="text-input_hds-text-input__error-text">{fieldError.message}</p>}
                 </>

--- a/frontend/src/common/components/form/index.ts
+++ b/frontend/src/common/components/form/index.ts
@@ -1,5 +1,6 @@
 import Checkbox from "./Checkbox";
 import DateInput from "./DateInput";
+import FileInput from "./FileInput";
 import NumberInput from "./NumberInput";
 import RelatedModelInput from "./RelatedModelInput";
 import Select from "./SelectInput";
@@ -17,6 +18,7 @@ export type FormInputProps = {
     errorText?: string;
     key?: string;
     tooltipText?: string;
+    className?: string;
     placeholder?;
     value?;
     disabled?;
@@ -25,4 +27,4 @@ export type FormInputProps = {
     onBlur?;
 };
 
-export {TextInput, TextAreaInput, NumberInput, DateInput, Select, Checkbox, ToggleInput, RelatedModelInput};
+export {TextInput, TextAreaInput, NumberInput, DateInput, Select, Checkbox, ToggleInput, RelatedModelInput, FileInput};

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -16,6 +16,25 @@ export const housingCompanyStates = [
     "ready_no_statistics",
 ] as const;
 
+export const hitasQuarters = [
+    {
+        value: "02-01",
+        label: "1.2. - 30.4.",
+    },
+    {
+        value: "05-01",
+        label: "1.5. - 31.7.",
+    },
+    {
+        value: "08-01",
+        label: "1.8. - 31.10.",
+    },
+    {
+        value: "11-01",
+        label: "1.11. - 31.1.",
+    },
+] as const;
+
 export const indexNames = ["market_price_index", "construction_price_index", "surface_area_price_ceiling"] as const;
 
 const CostAreas = ["1", "2", "3", "4"] as const;
@@ -851,6 +870,23 @@ const ApartmentMaximumPriceWritableSchema = object({
 
 const IndexSchema = object({indexType: string(), month: string(), value: number().nullable()});
 
+const QuarterSchema = string().regex(/\d{4}Q\d/);
+const ExternalSalesQuarterSchema = object({
+    quarter: QuarterSchema,
+    areas: object({
+        postal_code: string().regex(/\d{3}/),
+        sale_count: number(),
+        price: number(),
+    }).array(),
+});
+const ExternalSalesDataResponseSchema = object({
+    calculation_quarter: QuarterSchema,
+    quarter_1: ExternalSalesQuarterSchema,
+    quarter_2: ExternalSalesQuarterSchema,
+    quarter_3: ExternalSalesQuarterSchema,
+    quarter_4: ExternalSalesQuarterSchema,
+});
+
 // ********************************
 // * Request / Response schemas
 // ********************************
@@ -1016,6 +1052,7 @@ export type IHousingCompanyApartmentQuery = z.infer<typeof HousingCompanyApartme
 export type IApartmentQuery = z.infer<typeof ApartmentQuerySchema>;
 export type IIndexQuery = z.infer<typeof IndexQuerySchema>;
 
+export type IExternalSalesDataResponse = z.infer<typeof ExternalSalesDataResponseSchema>;
 export type IApartmentConditionOfSale = z.infer<typeof ApartmentConditionOfSaleSchema>;
 export type IConditionOfSale = z.infer<typeof ConditionOfSaleSchema>;
 export type ICreateConditionOfSale = z.infer<typeof CreateConditionOfSaleSchema>;

--- a/frontend/src/features/functions/Functions.tsx
+++ b/frontend/src/features/functions/Functions.tsx
@@ -1,6 +1,6 @@
 import {Tabs} from "hds-react";
 import Heading from "../../common/components/Heading";
-import {PriceCeilingPerSquare} from "./";
+import {PriceCeilingPerSquare, ThirtyYearComparison} from "./";
 
 const Functions = () => {
     return (
@@ -15,11 +15,7 @@ const Functions = () => {
                     <PriceCeilingPerSquare />
                 </Tabs.TabPanel>
                 <Tabs.TabPanel>
-                    <div className="view--functions__thirty-year-regulation">
-                        <div className="regulation">
-                            <Heading type="body">Vapautumisen tarkistus</Heading>
-                        </div>
-                    </div>
+                    <ThirtyYearComparison />
                 </Tabs.TabPanel>
             </Tabs>
         </div>

--- a/frontend/src/features/functions/Functions.tsx
+++ b/frontend/src/features/functions/Functions.tsx
@@ -1,0 +1,29 @@
+import {Tabs} from "hds-react";
+import Heading from "../../common/components/Heading";
+import {PriceCeilingPerSquare} from "./";
+
+const Functions = () => {
+    return (
+        <div className="view--functions">
+            <Heading>Järjestelmän toiminnot</Heading>
+            <Tabs>
+                <Tabs.TabList>
+                    <Tabs.Tab>Rajaneliöhinnan laskenta</Tabs.Tab>
+                    <Tabs.Tab>Vapautumisen tarkistus</Tabs.Tab>
+                </Tabs.TabList>
+                <Tabs.TabPanel>
+                    <PriceCeilingPerSquare />
+                </Tabs.TabPanel>
+                <Tabs.TabPanel>
+                    <div className="view--functions__thirty-year-regulation">
+                        <div className="regulation">
+                            <Heading type="body">Vapautumisen tarkistus</Heading>
+                        </div>
+                    </div>
+                </Tabs.TabPanel>
+            </Tabs>
+        </div>
+    );
+};
+
+export default Functions;

--- a/frontend/src/features/functions/PriceCeilingPerSquare.jsx
+++ b/frontend/src/features/functions/PriceCeilingPerSquare.jsx
@@ -1,0 +1,101 @@
+import {Button, LoadingSpinner} from "hds-react";
+import {useState} from "react";
+import {useForm} from "react-hook-form";
+
+import {hitasQuarters} from "../../common/schemas";
+
+import {Heading} from "../../common/components";
+import {Select} from "../../common/components/form";
+
+export const years = Array.from({length: 34}, (_, index) => {
+    const year = 2023 - index;
+    return {
+        value: year.toString(),
+        label: year.toString(),
+    };
+});
+
+const PriceCeilingPerSquare = () => {
+    const [isLoading, setIsLoading] = useState(false);
+    const formObject = useForm({
+        defaultValues: {year: years[1], quarter: hitasQuarters[0]},
+        mode: "all",
+    });
+    const CalculateButton = () => (
+        <Button
+            className="calculate-button"
+            theme="black"
+            variant="secondary"
+            onClick={() => setIsLoading(!isLoading)}
+            disabled={isLoading}
+        >
+            <span>Laske{isLoading && "taan..."}</span>
+            {isLoading && (
+                <div className="spinner-wrap">
+                    <LoadingSpinner />
+                </div>
+            )}
+        </Button>
+    );
+    const ListItem = ({quarter, year, value}) => {
+        return (
+            <li className="results-list__item">
+                <div className="period">
+                    {hitasQuarters[quarter].label}
+                    {years[new Date().getFullYear() - year].label}
+                </div>
+                <div className="value">{value !== undefined ? value : <CalculateButton />}</div>
+            </li>
+        );
+    };
+    return (
+        <div className="view--functions__price-ceiling-per-square">
+            <Heading type="body">Rajaneliöhinnan laskenta</Heading>
+            <div className="list">
+                <div className="list-headers">
+                    <div className="period">Ajanjakso</div>
+                    <div className="value">Rajaneliöhinta (€)</div>
+                </div>
+                <ul className="results-list">
+                    <ListItem
+                        quarter={0}
+                        year={2023}
+                    />
+                    <ListItem
+                        quarter={3}
+                        year={2022}
+                        value="123"
+                    />
+                    <ListItem
+                        quarter={2}
+                        year={2022}
+                        value="123"
+                    />
+                </ul>
+            </div>
+            <form>
+                <div>
+                    <Select
+                        label="Vuosi"
+                        options={years}
+                        name="year"
+                        formObject={formObject}
+                        defaultValue={years[0]}
+                        clearable={false}
+                    />
+                    <Select
+                        label="Ajanjakso"
+                        options={hitasQuarters}
+                        name="period"
+                        formObject={formObject}
+                        defaultValue={hitasQuarters[0]}
+                        clearable={false}
+                    />
+                    <CalculateButton />
+                </div>
+            </form>
+        </div>
+    );
+};
+
+export default PriceCeilingPerSquare;

--- a/frontend/src/features/functions/ThirtyYearComparison.tsx
+++ b/frontend/src/features/functions/ThirtyYearComparison.tsx
@@ -1,0 +1,187 @@
+import {Tooltip} from "hds-react";
+import {useForm} from "react-hook-form";
+import {hitasQuarters} from "../../common/schemas";
+
+import {useState} from "react";
+
+import {useGetExternalSalesDataQuery, useSaveExternalSalesDataMutation} from "../../app/services";
+import {Divider, Heading, SaveButton, SaveDialogModal} from "../../common/components";
+
+import {FileInput, Select} from "../../common/components/form";
+import {hdsToast} from "../../common/utils";
+import {priceCeilings} from "./simulatedResponses";
+
+const ThirtyYearComparison = () => {
+    const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
+    const years = [
+        {label: "2023", value: "2023"},
+        {label: "2022", value: "2022"},
+        {label: "2021", value: "2021"},
+    ];
+
+    // React hook form
+    const formObject = useForm({
+        defaultValues: {year: years[0], quarter: {label: "1.2. - 30.4.", value: "02-01"}, file: undefined},
+        mode: "all",
+    });
+    const {watch, handleSubmit} = formObject;
+    const formTimePeriod: {label: string; value: string} = watch("quarter");
+    const formYear: {label: string; value: string} = watch("year");
+    const formDate = `${formYear.value}-${formTimePeriod.value}`;
+    const formFile: File | undefined = watch("file");
+
+    // Function for adding a time period select option
+    const addQuarterOption = (option) => {
+        // If it's the last quarter, add the years to the date string in the label since the later date is in the next year
+        const labelToAdd =
+            option.value === "11-01"
+                ? `${option.label.split(" ")[0]}${formYear.value} - ${option.label.split(" ")[2]}${
+                      Number(formYear.value) + 1
+                  }`
+                : option.label;
+        hitasQuarterOptions.push({value: option.value, label: labelToAdd});
+    };
+
+    // Populate the time quarter select with options, if current year is selected in the year selector
+    const hitasQuarterOptions: {label: string; value: string}[] = [];
+    const currentTime = new Date();
+    // If the current year is not selected, add all quarters to the time period select options...
+    if (currentTime.getFullYear().toString() !== formYear.value && !isNaN(Number(formYear.label))) {
+        hitasQuarters.forEach((quarter) => addQuarterOption(quarter));
+    } else {
+        // ...otherwise add only the quarters that have passed
+        for (let i = 0; i < 4; i++) {
+            if (currentTime.getMonth() + 1 >= (i + 1) * 3 - 1) {
+                addQuarterOption(hitasQuarters[i]);
+            }
+        }
+    }
+
+    // Queries and mutations
+    const {
+        data: externalSalesData,
+        isLoading: isExternalSalesDataLoading,
+        error: externalSalesDataLoadError,
+    } = useGetExternalSalesDataQuery({
+        calculation_date: formDate,
+    });
+    const [
+        saveExternalSalesData,
+        {data: savedExternalSalesData, isLoading: isExternalSalesDataSaving, error: saveExternalSalesDataError},
+    ] = useSaveExternalSalesDataMutation();
+
+    const hasTimePeriodFile = !isExternalSalesDataLoading && !externalSalesDataLoadError && !!externalSalesData;
+
+    // Simulated comparison API responses
+    const priceCeiling = priceCeilings[formYear.value][formTimePeriod.value];
+
+    // ******************
+    // * Event handlers *
+    // ******************
+
+    // Submit = upload file
+    const onSubmit = (data) => {
+        const fileWithDate = {
+            data: data.file,
+            calculation_date: formDate,
+        };
+        console.log("File + date:", fileWithDate);
+        saveExternalSalesData(fileWithDate)
+            .catch((error) => {
+                console.warn("Caught error:", error);
+                setIsSaveModalOpen(true);
+            })
+            .then((data) => {
+                if ("error" in (data as object)) {
+                    setIsSaveModalOpen(true);
+                } else {
+                    // Successful upload
+                    hdsToast.success("Postinumeroalueiden keskinumerohinnat ladattu onnistuneesti");
+                    formObject.setValue("file", undefined, {shouldValidate: true});
+                }
+            });
+    };
+
+    return (
+        <div className="view--functions__thirty-year-regulation">
+            <div className="regulation">
+                <Heading type="body">Vapautumisen tarkistus</Heading>
+                <form
+                    className="actions"
+                    onSubmit={handleSubmit(onSubmit)}
+                >
+                    <div className="time-period">
+                        <label>
+                            Ajanjakso
+                            <Tooltip placement="bottom-start">
+                                Valitse vuosi ja jakso jonka vapautumisia haluat tarkastella, tai jolle haluat suorittaa
+                                vertailun mikäli sitä ei ole vielä tehty.
+                            </Tooltip>
+                        </label>
+                        <Select
+                            label=""
+                            options={years}
+                            name="year"
+                            formObject={formObject}
+                            defaultValue={years[0]}
+                            value={formYear}
+                        />
+                        <Select
+                            label=""
+                            options={hitasQuarterOptions}
+                            name="quarter"
+                            formObject={formObject}
+                            defaultValue={hitasQuarterOptions[0]}
+                            value={formTimePeriod}
+                        />
+                    </div>
+                    <div className="price-ceiling">
+                        <label>
+                            Rajaneliöhinta
+                            {` (${formObject.getValues("quarter").label}${formObject.getValues("year").label})`}
+                        </label>
+                        <div className="value">{priceCeiling ?? "---"} €/m²</div>
+                    </div>
+                </form>
+                <Divider size="l" />
+                {!hasTimePeriodFile ? (
+                    <form
+                        className={`file${formFile === undefined ? "" : " file--selected"}`}
+                        onSubmit={handleSubmit(onSubmit)}
+                    >
+                        <FileInput
+                            name="file"
+                            id="file-input"
+                            buttonLabel="Valitse tiedosto"
+                            formObject={formObject}
+                            label="Syötä postinumeroalueiden keskineliöhinnat"
+                            tooltipText="Tilastokeskukselta saatu excel-tiedosto (.xslx)"
+                        />
+                        <SaveButton
+                            type="submit"
+                            isLoading={isExternalSalesDataSaving}
+                            onClick={(e) => {
+                                e.preventDefault();
+                                return;
+                            }}
+                            disabled={formFile === undefined}
+                            buttonText="Tallenna keskineliöhinnat"
+                        />
+                    </form>
+                ) : (
+                    <h3 className="external-sales-data-exists">{`Ajanjaksolle ${formTimePeriod.label} on tallennettu postinumeroalueiden keskineliöhinnat.`}</h3>
+                )}
+            </div>
+            <SaveDialogModal
+                title="Tallennetaan excel-tiedostoa"
+                data={savedExternalSalesData}
+                error={saveExternalSalesDataError}
+                isLoading={isExternalSalesDataSaving}
+                isVisible={isSaveModalOpen}
+                setIsVisible={setIsSaveModalOpen}
+            />
+        </div>
+    );
+};
+
+export default ThirtyYearComparison;

--- a/frontend/src/features/functions/index.ts
+++ b/frontend/src/features/functions/index.ts
@@ -1,4 +1,5 @@
 import Functions from "./Functions";
 import PriceCeilingPerSquare from "./PriceCeilingPerSquare";
+import ThirtyYearComparison from "./ThirtyYearComparison";
 
-export {Functions, PriceCeilingPerSquare};
+export {Functions, PriceCeilingPerSquare, ThirtyYearComparison};

--- a/frontend/src/features/functions/index.ts
+++ b/frontend/src/features/functions/index.ts
@@ -1,0 +1,4 @@
+import Functions from "./Functions";
+import PriceCeilingPerSquare from "./PriceCeilingPerSquare";
+
+export {Functions, PriceCeilingPerSquare};

--- a/frontend/src/features/functions/simulatedResponses.ts
+++ b/frontend/src/features/functions/simulatedResponses.ts
@@ -1,0 +1,371 @@
+const comparisonResponses = {
+    success: {
+        automatically_released: [
+            {
+                id: "dccd2cbc98264f28b097da8209441bbf",
+                display_name: "Helsingin Rumpupolun palvelutalo",
+                address: {
+                    street_address: "Fakestreet 123",
+                    postal_code: "00100",
+                    city: "Helsinki",
+                },
+                price: 0.0,
+                old_ruleset: false,
+                completion_date: "2014-06-02",
+                property_manager: {
+                    id: "dc1072975bab4ba69f64814f021c6785",
+                    name: "Ismo Isännöitsijät Oy",
+                    email: "ismo@example.com",
+                    address: {
+                        street_address: "Torikatu 16 B 4",
+                        postal_code: "90100",
+                        city: "Oulu",
+                    },
+                },
+            },
+        ],
+        released_from_regulation: [
+            {
+                id: "7938b3fd2b774139b0b7f410758e09c6",
+                display_name: "Karjalainen",
+                address: {
+                    street_address: "Yrttimaanpolku 020",
+                    postal_code: "00530",
+                    city: "Helsinki",
+                },
+                price: 12000.0,
+                old_ruleset: true,
+                completion_date: "2014-06-02",
+                property_manager: {
+                    id: "dc1072975bab4ba69f64814f021c6785",
+                    name: "Ismo Isännöitsijät Oy",
+                    email: "ismo@example.com",
+                    address: {
+                        street_address: "Torikatu 16 B 4",
+                        postal_code: "90100",
+                        city: "Oulu",
+                    },
+                },
+            },
+        ],
+        stays_regulated: [
+            {
+                id: "01c9168e637b4ce0947802e9b417d15a",
+                display_name: "Jokela",
+                address: {
+                    street_address: "Biologinkuja 3",
+                    postal_code: "00200",
+                    city: "Helsinki",
+                },
+                price: 1337.0,
+                old_ruleset: true,
+                completion_date: "2014-06-02",
+                property_manager: {
+                    id: "dc1072975bab4ba69f64814f021c6785",
+                    name: "Ismo Isännöitsijät Oy",
+                    email: "ismo@example.com",
+                    address: {
+                        street_address: "Torikatu 16 B 4",
+                        postal_code: "90100",
+                        city: "Oulu",
+                    },
+                },
+            },
+        ],
+        skipped: [],
+        obfuscated_owners: [
+            {
+                name: "Olavi Toivonen",
+                identifier: "7107925-4",
+                email: "zoinonen@example.com",
+            },
+            {
+                name: "Eemeli Rinne",
+                identifier: "7107925-4",
+                email: "teemumakinen@example.com",
+            },
+        ],
+    },
+    get: {
+        automatically_released: [],
+        released_from_regulation: [
+            {
+                id: "7938b3fd2b774139b0b7f410758e09c6",
+                display_name: "Karjalainen",
+                address: {
+                    street_address: "Yrttimaanpolku 020",
+                    postal_code: "00530",
+                    city: "Helsinki",
+                },
+                price: 12000.0,
+                old_ruleset: true,
+                completion_date: "2014-06-02",
+                property_manager: {
+                    id: "dc1072975bab4ba69f64814f021c6785",
+                    name: "Ismo Isännöitsijät Oy",
+                    email: "ismo@example.com",
+                    address: {
+                        street_address: "Torikatu 16 B 4",
+                        postal_code: "90100",
+                        city: "Oulu",
+                    },
+                },
+            },
+            {
+                id: "dccd2cbc98264f28b097da8209441bbf",
+                display_name: "Helsingin Rumpupolun palvelutalo",
+                address: {
+                    street_address: "Fakestreet 123",
+                    postal_code: "00100",
+                    city: "Helsinki",
+                },
+                price: 0.0,
+                old_ruleset: false,
+                completion_date: "2014-06-02",
+                property_manager: {
+                    id: "dc1072975bab4ba69f64814f021c6785",
+                    name: "Ismo Isännöitsijät Oy",
+                    email: "ismo@example.com",
+                    address: {
+                        street_address: "Torikatu 16 B 4",
+                        postal_code: "90100",
+                        city: "Oulu",
+                    },
+                },
+            },
+        ],
+        stays_regulated: [
+            {
+                id: "01c9168e637b4ce0947802e9b417d15a",
+                display_name: "Jokela",
+                address: {
+                    street_address: "Biologinkuja 3",
+                    postal_code: "00200",
+                    city: "Helsinki",
+                },
+                price: 1337.0,
+                old_ruleset: true,
+                completion_date: "2014-06-02",
+                property_manager: {
+                    id: "dc1072975bab4ba69f64814f021c6785",
+                    name: "Ismo Isännöitsijät Oy",
+                    email: "ismo@example.com",
+                    address: {
+                        street_address: "Torikatu 16 B 4",
+                        postal_code: "90100",
+                        city: "Oulu",
+                    },
+                },
+            },
+        ],
+        skipped: [],
+        obfuscated_owners: [],
+    },
+    failure: {
+        skippedCompany: {
+            automatically_released: [],
+            obfuscated_owners: [],
+            released_from_regulation: [],
+            skipped: [
+                {
+                    address: {
+                        city: "Helsinki",
+                        postal_code: "00001",
+                        street_address: "Disankuja 14",
+                    },
+                    completion_date: "1993-02-01",
+                    display_name: "Test Housing company 000",
+                    id: "e3c34b7f47c74ef796bd51e8fbbe0929",
+                    old_ruleset: true,
+                    price: 12000.0,
+                    property_manager: {
+                        address: {
+                            city: "Liperi",
+                            postal_code: "95024",
+                            street_address: "Edelfeltinkatu 7",
+                        },
+                        email: "kari06@example.net",
+                        id: "216f86ca32ff49cea26fe8e2d9447e8f",
+                        name: "Maria Kyll\u00f6nen-Jokinen",
+                    },
+                },
+            ],
+            stays_regulated: [],
+        },
+        noCompanies: {
+            automatically_released: [],
+            obfuscated_owners: [],
+            released_from_regulation: [],
+            skipped: [],
+            stays_regulated: [],
+        },
+        missingIndex: {
+            error: "missing_values",
+            fields: [
+                {
+                    field: "non_field_errors",
+                    message: "Pre 2011 market price indices missing for months: '1993-02', '2023-02'.",
+                },
+            ],
+            message: "Missing required indices",
+            reason: "Conflict",
+            status: 409,
+        },
+        missingExcel: {
+            error: "external_sales_data_not_found",
+            message: "External sales data not found",
+            reason: "Not Found",
+            status: 404,
+        },
+        missingPriceCeiling: {
+            error: "surface_area_price_ceiling_not_found",
+            message: "Surface area price ceiling not found",
+            reason: "Not Found",
+            status: 404,
+        },
+        missingSurfaceArea: {
+            error: "missing_values",
+            fields: [
+                {
+                    field: "non_field_errors",
+                    message:
+                        "Average price per square meter could not be calculated for 'Test Housing company 000': Apartment 'Uurtajanpolku 5 t 75' does not have surface area set.",
+                },
+            ],
+            message: "Missing apartment details",
+            reason: "Conflict",
+            status: 409,
+        },
+        zeroSurfaceArea: {
+            error: "bad_request",
+            fields: [
+                {
+                    field: "non_field_errors",
+                    message:
+                        "Average price per square meter zero or missing for these housing companies: 'Test Housing company 000'. Index adjustments cannot be made.",
+                },
+            ],
+            message: "Bad request",
+            reason: "Bad Request",
+            status: 400,
+        },
+        alreadyCompared: {
+            error: "unique",
+            message: "Previous regulation exists. Cannot re-check regulation for this quarter.",
+            reason: "Conflict",
+            status: 409,
+        },
+    },
+};
+
+const fileImportResponses = {
+    success: {
+        calculation_quarter: "2022Q4",
+        quarter_1: {
+            quarter: "2022Q1",
+            areas: [
+                {postal_code: "00180", sale_count: 77, price: 8304},
+                {postal_code: "00220", sale_count: 19, price: 8255},
+                {postal_code: "00280", sale_count: 19, price: 6747},
+                {postal_code: "00300", sale_count: 17, price: 5577},
+                {postal_code: "00310", sale_count: 8, price: 4222},
+                {postal_code: "00540", sale_count: 18, price: 7684},
+                {postal_code: "00570", sale_count: 34, price: 6527},
+                {postal_code: "00580", sale_count: 29, price: 8156},
+                {postal_code: "00650", sale_count: 21, price: 3810},
+                {postal_code: "00680", sale_count: 12, price: 4072},
+                {postal_code: "00690", sale_count: 10, price: 3608},
+                {postal_code: "00870", sale_count: 20, price: 3556},
+            ],
+        },
+        quarter_2: {
+            quarter: "2022Q2",
+            areas: [
+                {postal_code: "00180", sale_count: 82, price: 8101},
+                {postal_code: "00220", sale_count: 22, price: 7369},
+                {postal_code: "00280", sale_count: 16, price: 6573},
+                {postal_code: "00300", sale_count: 26, price: 5745},
+                {postal_code: "00310", sale_count: 7, price: 4674},
+                {postal_code: "00540", sale_count: 26, price: 8841},
+                {postal_code: "00570", sale_count: 31, price: 6642},
+                {postal_code: "00580", sale_count: 24, price: 8399},
+                {postal_code: "00590", sale_count: 12, price: 5073},
+                {postal_code: "00650", sale_count: 22, price: 4108},
+                {postal_code: "00680", sale_count: 10, price: 3841},
+                {postal_code: "00690", sale_count: 10, price: 3931},
+                {postal_code: "00870", sale_count: 18, price: 3316},
+            ],
+        },
+        quarter_3: {
+            quarter: "2022Q3",
+            areas: [
+                {postal_code: "00180", sale_count: 62, price: 8504},
+                {postal_code: "00220", sale_count: 22, price: 8842},
+                {postal_code: "00280", sale_count: 16, price: 6341},
+                {postal_code: "00300", sale_count: 15, price: 5807},
+                {postal_code: "00540", sale_count: 13, price: 8941},
+                {postal_code: "00570", sale_count: 25, price: 6589},
+                {postal_code: "00580", sale_count: 21, price: 7808},
+                {postal_code: "00650", sale_count: 18, price: 5129},
+                {postal_code: "00690", sale_count: 6, price: 3827},
+                {postal_code: "00850", sale_count: 11, price: 4566},
+                {postal_code: "00870", sale_count: 19, price: 3521},
+            ],
+        },
+        quarter_4: {
+            quarter: "2022Q4",
+            areas: [
+                {postal_code: "00180", sale_count: 33, price: 7919},
+                {postal_code: "00220", sale_count: 17, price: 8115},
+                {postal_code: "00570", sale_count: 13, price: 6129},
+                {postal_code: "00580", sale_count: 13, price: 7777},
+            ],
+        },
+    },
+    failure: {
+        fileExists: {
+            error: "unique",
+            message: "External sales data already exists for '2023Q1'",
+            reason: "Conflict",
+            status: 409,
+        },
+        wrongQuarter: {
+            error: "bad_request",
+            fields: [
+                {
+                    field: "calculation_date",
+                    message: "Given Excel is not for this Hitas quarter.",
+                },
+            ],
+            message: "Bad request",
+            reason: "Bad Request",
+            status: 400,
+        },
+    },
+};
+
+const priceCeilings = {
+    2023: {
+        "02-01": 4621,
+    },
+    2022: {
+        "02-01": 2201,
+        "05-01": 2202,
+        "08-01": 2203,
+        "11-01": 2204,
+    },
+    2021: {
+        "02-01": 2101,
+        "05-01": 2102,
+        "08-01": 2103,
+        "11-01": 2104,
+    },
+    TEST: {
+        "02-01": "TEST",
+        "05-01": "TEST",
+        "08-01": "TEST",
+        "11-01": "TEST",
+    },
+};
+
+export {comparisonResponses, fileImportResponses, priceCeilings};

--- a/frontend/src/styles/abstracts/_typography.sass
+++ b/frontend/src/styles/abstracts/_typography.sass
@@ -23,6 +23,9 @@ body
   .company &
     margin-bottom: 16px
 
+[class^="heading--body"]
+  font-size: $fontsize-heading-l
+
 .query-handler-error
   font-size: 2rem
   font-weight: 700

--- a/frontend/src/styles/base/_general.sass
+++ b/frontend/src/styles/base/_general.sass
@@ -50,6 +50,7 @@ ul, ol
       color: $color-engel-medium-light
       --spinner-color: $color-engel-medium-light
 
+
 [class^="view--"]
   @include flexbox()
   @include flex-flow(column nowrap)
@@ -60,6 +61,18 @@ ul, ol
       --spinner-size: 12rem
       --spinner-color: var(--color-engel)
       --spinner-thickness: 1.4rem
+    button &
+      height: 1em
+      margin-left: $spacing-2-xs
+      [class*="LoadingSpinner-module_loadingSpinner"]
+        --spinner-size: 1.5em
+        --spinner-thickness: 3px
+    [class*="Button-module_secondary"] & [class*="LoadingSpinner-module_loadingSpinner"]
+      color: $color-engel-dark
+      --spinner-color: $color-engel-dark
+    [class*="Button-module_secondary"]:not(:disabled):hover & [class*="LoadingSpinner-module_loadingSpinner"]
+      color: $color-engel-medium-light
+      --spinner-color: $color-engel-medium-light
 
 .query-handler-error
   @include flexbox()

--- a/frontend/src/styles/base/_general.sass
+++ b/frontend/src/styles/base/_general.sass
@@ -37,6 +37,18 @@ ul, ol
       --spinner-size: 12rem
       --spinner-color: var(--color-engel)
       --spinner-thickness: 1.4rem
+    button &
+      height: 1em
+      margin-left: $spacing-2-xs
+      [class*="LoadingSpinner-module_loadingSpinner"]
+        --spinner-size: 1.5em
+        --spinner-thickness: 3px
+    [class*="Button-module_secondary"] & [class*="LoadingSpinner-module_loadingSpinner"]
+      color: $color-engel-dark
+      --spinner-color: $color-engel-dark
+    [class*="Button-module_secondary"]:not(:disabled):hover & [class*="LoadingSpinner-module_loadingSpinner"]
+      color: $color-engel-medium-light
+      --spinner-color: $color-engel-medium-light
 
 .query-handler-error
   @include flexbox()

--- a/frontend/src/styles/base/_general.sass
+++ b/frontend/src/styles/base/_general.sass
@@ -50,6 +50,17 @@ ul, ol
       color: $color-engel-medium-light
       --spinner-color: $color-engel-medium-light
 
+[class^="view--"]
+  @include flexbox()
+  @include flex-flow(column nowrap)
+  flex-grow: 1
+  > .spinner-wrap
+    flex-grow: 1
+    [class*="LoadingSpinner-module_loadingSpinner"]
+      --spinner-size: 12rem
+      --spinner-color: var(--color-engel)
+      --spinner-thickness: 1.4rem
+
 .query-handler-error
   @include flexbox()
   @include flex-flow(column)

--- a/frontend/src/styles/components/_Forms.sass
+++ b/frontend/src/styles/components/_Forms.sass
@@ -30,3 +30,14 @@ div .disabled
   cursor: not-allowed
   *
     cursor: not-allowed !important
+
+[class*="FileInput-module"]
+  button:not(:disabled)
+    color: black
+    border-color: black
+
+#file-input-list
+  margin: $spacing-2-xs 0 $spacing-s 0
+  li
+    background-color: $color-engel-light
+    width: auto !important

--- a/frontend/src/styles/components/_Functions.sass
+++ b/frontend/src/styles/components/_Functions.sass
@@ -1,0 +1,74 @@
+@use "../imports" as *
+
+.view--functions
+  @include flexbox()
+  @include flex-flow(column nowrap)
+  @include flex-grow(1)
+  [class^="Tabs-module"]
+    [class*="tablistBar"]
+      background-color: white
+      padding: 0
+    [class*="active"]
+      background-color: $codes-background-color
+      span
+        font-weight: 700
+        &:before
+          display: none
+
+  [class^="Tabs-module_tabs"]
+    @include flexbox()
+    @include flex-flow(column nowrap)
+    @include flex-grow(1)
+    > [id^="tab-"]
+      @include flexbox()
+      padding: 0
+      > div
+        @include flex-grow(1)
+
+  label
+    font-weight: 700
+
+  &__price-ceiling-per-square
+    padding: $spacing-m
+    background: $color-black-10
+    .calculate-button
+      margin: -10px 0
+      min-height: auto
+      span
+        @include flexbox()
+        @include flex-flow(row nowrap)
+        @include align-items(center)
+        height: 38px
+        margin: 0
+        padding: 7px 0
+      &:not(:disabled):hover
+        background-color: black
+        color: white
+    .results-list
+      margin-bottom: $spacing-m
+      &__item
+        @include align-items(center)
+    form
+      @include flexbox()
+      @include justify-content(center)
+      @include align-items(center)
+      > div
+        @include flexbox()
+        @include justify-content(space-between)
+        @include align-items(center)
+      .input-field--dropdown
+        width: 200px
+        margin: 0 $spacing-xs 0 0
+      legend
+        margin-bottom: $spacing-2-xs
+      > button
+        margin-top: $spacing-2-xs
+
+  &__thirty-year-regulation
+    flex-grow: 1
+    .regulation, .companies
+      padding: $spacing-m
+      background-color: $color-engel-medium-light
+    .regulation
+      background: $color-black-10
+      margin-bottom: $spacing-m

--- a/frontend/src/styles/components/_Functions.sass
+++ b/frontend/src/styles/components/_Functions.sass
@@ -68,7 +68,100 @@
     flex-grow: 1
     .regulation, .companies
       padding: $spacing-m
-      background-color: $color-engel-medium-light
+
     .regulation
       background: $color-black-10
-      margin-bottom: $spacing-m
+      .actions
+        display: grid
+        grid-template-columns: 1fr 1fr
+        grid-template-rows: auto auto
+        gap: $spacing-l
+        label
+          @include flexbox()
+          @include justify-content(space-between)
+          width: 100%
+        .input-field
+          margin: 0
+          height: auto
+        .time-period
+          @include flexbox()
+          @include flex-flow(row wrap)
+          @include justify-content(space-between)
+          @include align-content(flex-start)
+          column-gap: $spacing-m
+          row-gap: $spacing-xs
+          grid-column: 1
+          grid-row: 1
+          > *
+            flex-grow: 1
+        .price-ceiling
+          @include flexbox()
+          @include flex-flow(column nowrap)
+          grid-row: 1
+          grid-column: 2
+          .value
+            @include flexbox()
+            @include align-items(center)
+            height: 56px
+            margin-top: $spacing-xs
+            font-size: $fontsize-heading-l
+      .file
+        position: relative
+        grid-row: 2
+        grid-column: 1 / span 2
+        display: flex
+        flex-flow: column nowrap
+        .input-field--file
+          position: relative
+          display: grid
+          grid-template-columns: 1fr 1fr
+          grid-template-rows: auto auto
+          gap: $spacing-l
+        button[type="submit"]
+          //display: none
+        &--selected
+          [class*="FileInput-module_fileInputContainer"]
+            //display: none
+          button[type="submit"]
+            display: flex
+            margin: auto
+        label
+          width: 100%
+          margin-bottom: $spacing-s
+        #file-input-list
+          grid-column: 2
+          grid-row: 1
+        [class^="TextInput-module_root"]
+          @include flexbox()
+          @include flex-flow(column nowrap)
+          grid-column: 1
+          grid-row: 1 / span 2
+
+        [class^="FileInput-module_fileInputWrapper"]
+          width: 100%
+        button[type="submit"]
+          margin-left: auto
+          margin-right: 0
+        #file-input-info
+          position: absolute
+          top: 3.25rem
+          right: 0
+        #file-input-success
+          display: none
+        .buttons
+          @include flexbox()
+          @include justify-content(flex-end)
+          gap: $spacing-m
+          grid-column: 2
+          grid-row: 2
+      .external-sales-data-exists
+        grid-row: 2
+        color: $color-black-50
+        font-size: $fontsize-body-m
+    .spinner-wrap
+      flex-grow: 1
+      [class*="LoadingSpinner-module_loadingSpinner"]
+        --spinner-size: 7rem
+        --spinner-thickness: 1rem
+        --spinner-color: $color-engel
+        color: $color-engel

--- a/frontend/src/styles/components/index.sass
+++ b/frontend/src/styles/components/index.sass
@@ -10,3 +10,4 @@
 @forward "HousingCompanyPage"
 @forward "ImprovementsTable"
 @forward "OwnershipsList"
+@forward "Functions"

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -408,3 +408,18 @@ footer
       width: 74px
       opacity: 1
       transition: width 200ms, opacity 200ms 100ms
+    display: none
+  &:hover > .sell-by-date
+    display: inline-block
+
+#save-modal
+  [class^="DialogContent"] span
+    font-weight: 700
+
+.error-modal
+  background: $color-error-light !important
+  border-color: $color-error !important
+  [class^="Button-module_button"]
+    background: white
+    &:hover
+      background: $color-black-10

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -437,3 +437,17 @@ footer
       width: 74px
       opacity: 1
       transition: width 200ms, opacity 200ms 100ms
+  &:hover > .sell-by-date
+    display: inline-block
+
+#save-modal
+  [class^="DialogContent"] span
+    font-weight: 700
+
+.error-modal
+  background: $color-error-light !important
+  border-color: $color-error !important
+  [class^="Button-module_button"]
+    background: white
+    &:hover
+      background: $color-black-10

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -423,3 +423,17 @@ footer
     background: white
     &:hover
       background: $color-black-10
+    overflow: hidden
+    width: 0px
+    opacity: 0
+    text-align: center
+    transition: width 200ms 100ms, opacity 200ms
+  &:hover
+    [class*="hds-status-label-icon"]
+      width: 0px
+      opacity: 0
+      transition: width 100ms, opacity 100ms
+    .sell-by-date
+      width: 74px
+      opacity: 1
+      transition: width 200ms, opacity 200ms 100ms


### PR DESCRIPTION
# Hitas Pull Request

# Description
 
Adds the "Functions/Toiminnot" sub-pages, and the PriceCeilingPerSquare and ThirtyYearComparison tabs.
Includes excel-importing on the thirty year comparison side.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [X] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Click on the new "Toiminnot" link in the top level navigation. You should be transported directly to the price ceiling tab, as it is the first one. There's also "Vapautumisen tarkistus" which will be filled with the thirty year regulation comparison once it's done.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-429 (doesn't resolve it, but makes development on it possible as the routing and dummy content is there), HT-444