### PR TITLE
Endpoint for regulation postal codes

### DIFF
--- a/backend/hitas/services/thirty_year_regulation.py
+++ b/backend/hitas/services/thirty_year_regulation.py
@@ -109,12 +109,12 @@ def perform_thirty_year_regulation(calculation_date: datetime.date) -> Regulatio
     :param calculation_date: Date to check regulation from.
     """
 
-    this_quarter = business_quarter(calculation_date)
-    this_quarter_previous_year = this_quarter - relativedelta(years=1)
-    previous_quarter = this_quarter - relativedelta(months=3)
-
     calculation_month = hitas_calculation_quarter(calculation_date)
     regulation_month = calculation_month - relativedelta(years=30)
+
+    this_quarter = business_quarter(calculation_month)
+    this_quarter_previous_year = this_quarter - relativedelta(years=1)
+    previous_quarter = this_quarter - relativedelta(months=3)
 
     check_existing_regulation_data(calculation_month)
 

--- a/backend/hitas/tests/apis/test_api_thirty_year_regulation.py
+++ b/backend/hitas/tests/apis/test_api_thirty_year_regulation.py
@@ -2602,6 +2602,7 @@ def test__api__regulation__end_of_period(api_client: HitasAPIClient, freezer):
                         city=sale.apartment.housing_company.property_manager.city,
                     ),
                 ),
+                letter_fetched=False,
             )
         ],
         skipped=[],

--- a/backend/hitas/tests/apis/test_api_thirty_year_regulation.py
+++ b/backend/hitas/tests/apis/test_api_thirty_year_regulation.py
@@ -2505,3 +2505,105 @@ def test__api__regulation__regulation_already_made(api_client: HitasAPIClient, f
         "reason": "Conflict",
         "status": 409,
     }
+
+
+@pytest.mark.django_db
+def test__api__regulation__end_of_period(api_client: HitasAPIClient, freezer):
+    first_day = datetime.date(2023, 2, 1)
+    last_day = datetime.datetime(2023, 4, 30)
+    # Calculation is made on the last day of the hitas calculation period.
+    # It should still work just the same as if it was the first day of the period.
+    freezer.move_to(last_day)
+
+    this_month = first_day
+    previous_year_last_month = this_month - relativedelta(months=2)
+    regulation_month = this_month - relativedelta(years=30)
+
+    # Create necessary indices
+    MarketPriceIndexFactory.create(month=regulation_month, value=100)
+    MarketPriceIndexFactory.create(month=this_month, value=200)
+    SurfaceAreaPriceCeilingFactory.create(month=this_month, value=5000)
+
+    # Sale for the apartment in a housing company that will be under regulation checking
+    # Index adjusted price for the housing company will be: (50_000 + 10_000) / 10 * (200 / 100) = 12_000
+    sale: ApartmentSale = ApartmentSaleFactory.create(
+        purchase_date=regulation_month,
+        purchase_price=50_000,
+        apartment_share_of_housing_company_loans=10_000,
+        apartment__surface_area=10,
+        apartment__completion_date=regulation_month,
+        apartment__building__real_estate__housing_company__postal_code__value="00001",
+        apartment__building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
+        apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+    )
+
+    # Apartment where sales happened in the previous year
+    apartment: Apartment = ApartmentFactory.create(
+        completion_date=previous_year_last_month,
+        building__real_estate__housing_company__postal_code__value="00001",
+        building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sales__purchase_date=previous_year_last_month,  # first sale, not counted
+    )
+
+    # Sale in the previous year, which affect the average price per square meter
+    # Average sales price will be: (40_000 + 9_000) / 1 = 49_000
+    ApartmentSaleFactory.create(
+        apartment=apartment,
+        purchase_date=previous_year_last_month + relativedelta(days=1),
+        purchase_price=40_000,
+        apartment_share_of_housing_company_loans=9_000,
+    )
+
+    # Create necessary external sales data (no external sales)
+    ExternalSalesData.objects.create(
+        calculation_quarter=to_quarter(previous_year_last_month),
+        quarter_1=QuarterData(quarter=to_quarter(previous_year_last_month - relativedelta(months=9)), areas=[]),
+        quarter_2=QuarterData(quarter=to_quarter(previous_year_last_month - relativedelta(months=6)), areas=[]),
+        quarter_3=QuarterData(quarter=to_quarter(previous_year_last_month - relativedelta(months=3)), areas=[]),
+        quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
+    )
+
+    url = reverse("hitas:thirty-year-regulation-list")
+
+    response = api_client.post(url, data={}, format="json")
+
+    #
+    # Since the housing company's index adjusted acquisition price is 12_000, which is higher than the
+    # surface area price ceiling of 5_000, the acquisition price will be used in the comparison.
+    #
+    # Since the average sales price per square meter for the area in the last year (49_000) is higher than the
+    # housing company's compared value (in this case the index adjusted acquisition price of 12_000),
+    # the company stays regulated.
+    #
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == RegulationResults(
+        automatically_released=[],
+        released_from_regulation=[],
+        stays_regulated=[
+            ComparisonData(
+                id=sale.apartment.housing_company.uuid.hex,
+                display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
+                price=Decimal("12000.0"),
+                old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                ),
+            )
+        ],
+        skipped=[],
+        obfuscated_owners=[],
+    )

--- a/backend/hitas/tests/apis/test_api_thirty_year_requlation_postal_codes.py
+++ b/backend/hitas/tests/apis/test_api_thirty_year_requlation_postal_codes.py
@@ -1,0 +1,134 @@
+import datetime
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.urls import reverse
+from rest_framework import status
+
+from hitas.models import Apartment, ExternalSalesData
+from hitas.models.external_sales_data import CostAreaData, QuarterData
+from hitas.models.housing_company import HitasType, RegulationStatus
+from hitas.tests.apis.helpers import HitasAPIClient, count_queries
+from hitas.tests.factories import ApartmentFactory, ApartmentSaleFactory
+from hitas.utils import to_quarter
+
+
+@pytest.mark.django_db
+def test__api__regulation_postal_codes(api_client: HitasAPIClient, freezer):
+    day = datetime.datetime(2023, 2, 1)
+    freezer.move_to(day)
+
+    this_month = day.date()
+    previous_year_last_month = this_month - relativedelta(months=2)
+
+    # Apartment where sales happened in the previous year
+    apartment: Apartment = ApartmentFactory.create(
+        completion_date=previous_year_last_month,
+        building__real_estate__housing_company__postal_code__value="00001",
+        building__real_estate__housing_company__postal_code__cost_area=1,
+        building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sales__purchase_date=previous_year_last_month,  # first sale, not counted
+    )
+
+    # Sale in the previous year, which affect the average price per square meter
+    # Average sales price will be: (40_000 + 9_000) / 1 = 49_000
+    ApartmentSaleFactory.create(
+        apartment=apartment,
+        purchase_date=previous_year_last_month + relativedelta(days=1),
+        purchase_price=40_000,
+        apartment_share_of_housing_company_loans=9_000,
+    )
+
+    # Create necessary external sales data
+    # Average sales price will be: (15_000 + 30_000) / (1 + 2) = 15_000
+    ExternalSalesData.objects.create(
+        calculation_quarter=to_quarter(previous_year_last_month),
+        quarter_1=QuarterData(quarter=to_quarter(previous_year_last_month - relativedelta(months=9)), areas=[]),
+        quarter_2=QuarterData(quarter=to_quarter(previous_year_last_month - relativedelta(months=6)), areas=[]),
+        quarter_3=QuarterData(
+            quarter=to_quarter(previous_year_last_month - relativedelta(months=3)),
+            areas=[CostAreaData(postal_code="00002", sale_count=1, price=15_000)],
+        ),
+        quarter_4=QuarterData(
+            quarter=to_quarter(previous_year_last_month),
+            areas=[
+                CostAreaData(postal_code="00002", sale_count=2, price=30_000),
+            ],
+        ),
+    )
+
+    url = reverse("hitas:thirty-year-regulation-postal-codes-list")
+
+    with count_queries(3):
+        response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == [
+        {
+            "postal_code": "00001",
+            "price_by_area": 49000.0,
+            "cost_area": 1,
+        },
+        {
+            "postal_code": "00002",
+            "price_by_area": 15000.0,
+            "cost_area": None,
+        },
+    ]
+
+
+@pytest.mark.django_db
+def test__api__regulation_postal_codes__missing_external_sales_data(api_client: HitasAPIClient, freezer):
+    day = datetime.datetime(2023, 2, 1)
+    freezer.move_to(day)
+
+    url = reverse("hitas:thirty-year-regulation-postal-codes-list")
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+    assert response.json() == {
+        "error": "external_sales_data_not_found",
+        "message": "External sales data not found",
+        "reason": "Not Found",
+        "status": 404,
+    }
+
+
+@pytest.mark.django_db
+def test__api__regulation_postal_codes__wrong_calculation_date(api_client: HitasAPIClient, freezer):
+    day = datetime.datetime(2023, 2, 1)
+    freezer.move_to(day)
+
+    this_month = day.date()
+    previous_year_last_month = this_month - relativedelta(months=2)
+
+    # Create necessary external sales data
+    ExternalSalesData.objects.create(
+        calculation_quarter=to_quarter(previous_year_last_month),
+        quarter_1=QuarterData(quarter=to_quarter(previous_year_last_month - relativedelta(months=9)), areas=[]),
+        quarter_2=QuarterData(quarter=to_quarter(previous_year_last_month - relativedelta(months=6)), areas=[]),
+        quarter_3=QuarterData(
+            quarter=to_quarter(previous_year_last_month - relativedelta(months=3)),
+            areas=[CostAreaData(postal_code="00002", sale_count=1, price=15_000)],
+        ),
+        quarter_4=QuarterData(
+            quarter=to_quarter(previous_year_last_month),
+            areas=[
+                CostAreaData(postal_code="00002", sale_count=2, price=30_000),
+            ],
+        ),
+    )
+
+    url = reverse("hitas:thirty-year-regulation-postal-codes-list") + "?calculation_date=2022-02-01"
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+    assert response.json() == {
+        "error": "external_sales_data_not_found",
+        "message": "External sales data not found",
+        "reason": "Not Found",
+        "status": 404,
+    }

--- a/backend/hitas/urls.py
+++ b/backend/hitas/urls.py
@@ -11,6 +11,11 @@ router.register(r"apartments", views.ApartmentListViewSet, basename="apartment")
 router.register(r"owners", views.OwnerViewSet, basename="owner")
 router.register(r"conditions-of-sale", views.ConditionOfSaleViewSet, basename="conditions-of-sale")
 router.register(r"thirty-year-regulation", views.ThirtyYearRegulationView, basename="thirty-year-regulation")
+router.register(
+    r"thirty-year-regulation/postal-codes",
+    views.ThirtyYearRegulationPostalCodesView,
+    basename="thirty-year-regulation-postal-codes",
+)
 router.register(r"indices/maximum-price-index", views.MaximumPriceIndexViewSet, basename="maximum-price-index")
 router.register(r"indices/market-price-index", views.MarketPriceIndexViewSet, basename="market-price-index")
 router.register(

--- a/backend/hitas/utils.py
+++ b/backend/hitas/utils.py
@@ -133,7 +133,7 @@ def business_quarter(date: datetime.date) -> datetime.date:
 
 
 def hitas_calculation_quarter(date: datetime.date) -> datetime.date:
-    """Get hitas calculation quarter (yyyy-[2,5,8,11]-01) from the given date.
+    """Get hitas calculation quarter (yyyy-[02,05,08,11]-01) from the given date.
 
     Hitas calculation quarters are different from business quarters, since hitas calculations
     have to be made at least one month after business quarters start due to delays in receiving index

--- a/backend/hitas/views/__init__.py
+++ b/backend/hitas/views/__init__.py
@@ -21,4 +21,4 @@ from hitas.views.postal_code import HitasPostalCodeViewSet
 from hitas.views.property_manager import PropertyManagerViewSet
 from hitas.views.real_estate import RealEstateViewSet
 from hitas.views.sales_catalog import SalesCatalogCreateView, SalesCatalogValidateView
-from hitas.views.thirty_year_regulation import ThirtyYearRegulationView
+from hitas.views.thirty_year_regulation import ThirtyYearRegulationPostalCodesView, ThirtyYearRegulationView

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2490,6 +2490,37 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/v1/thirty-year-regulation/postal-codes:
+    get:
+      description: List all postal codes available from the sales data
+      operationId: read-regulation-postal-codes
+      tags:
+        - Thirty Year Regulation
+      parameters:
+        - name: calculation_date
+          required: false
+          in: query
+          description: Calculation date of the regulation, use current date if not given
+          schema:
+            type: string
+            example: 2023-01-01
+      responses:
+        '200':
+          description: Successfully read postal codes
+          content:
+            application/json:
+              schema:
+                description: List of postal codes with additional information
+                type: array
+                items:
+                  $ref: '#/components/schemas/ThirtyYearRegulationPostalCodes'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   # Property Manager
 
   /api/v1/property-managers:
@@ -7381,6 +7412,32 @@ components:
           description: Has the regulation letter been fetched for this housing company?
           type: boolean
           example: false
+
+    ThirtyYearRegulationPostalCodes:
+      description: Thirty year regulation postal codes
+      type: object
+      additionalProperties: false
+      required:
+        - postal_code
+        - price_by_area
+        - cost_area
+      properties:
+        postal_code:
+          description: Postal code
+          type: string
+          example: 00230
+        price_by_area:
+          description: Average price per square meter for the postal code
+          type: number
+          minimum: 0
+          example: 143535.00
+        cost_area:
+          description: Cost area of the postal code
+          type: integer
+          nullable: true
+          minimum: 1
+          maximum: 4
+          example: 2
 
     ObfuscatedOwner:
       description: Owner that has been obfuscated due to no longer owning any regulated apartments

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2306,6 +2306,14 @@ paths:
       operationId: create-external-sales-data
       tags:
         - External Sales Data
+      parameters:
+        - name: calculation_date
+          required: false
+          in: query
+          description: Calculation date, use current date if not given.
+          schema:
+            type: string
+            example: 2023-01-01
       requestBody:
         required: true
         content:


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds the ability to fetch postal codes with their price per square meter and cost area, so replacement postal codes can be added if some housing companies cannot be regulated due to a lack of sales data.

Also fixes a bug in thirty-year regulation where if regulation is made in the last month of the Hitas-quarter, the range of sales dates would be off.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] Create external sales data and try the new endpoint.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-542
