### PR TITLE
Add X-CSRFTokens to each mutation request

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "react-router-dom": "^6.7.0",
     "sass": "^1.57.1",
     "typescript": "^4.4.2",
+    "typescript-cookie": "^1.0.6",
     "use-immer": "^0.8.1",
     "uuid": "^9.0.0",
     "web-vitals": "^3.1.1",

--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -236,6 +236,11 @@ const detailApi = hitasApi.injectEndpoints({
     }),
 });
 
+const JSONMutationHeaders = {
+    "Content-type": "application/json; charset=UTF-8",
+    "X-CSRFToken": getCookie("csrftoken"),
+};
+
 const mutationApi = hitasApi.injectEndpoints({
     endpoints: (builder) => ({
         saveHousingCompany: builder.mutation<IHousingCompanyDetails, {data: IHousingCompanyWritable; id?: string}>({
@@ -243,10 +248,7 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `housing-companies${idOrBlank(id)}`,
                 method: id === undefined ? "POST" : "PUT",
                 body: data,
-                headers: {
-                    "Content-type": "application/json; charset=UTF-8",
-                    "X-CSRFToken": getCookie("csrftoken"),
-                },
+                headers: JSONMutationHeaders,
             }),
             invalidatesTags: (result, error, arg) => [
                 {type: "HousingCompany", id: "LIST"},
@@ -258,10 +260,7 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `housing-companies/${housingCompanyId}/real-estates`,
                 method: "POST",
                 body: data,
-                headers: {
-                    "Content-type": "application/json; charset=UTF-8",
-                    "X-CSRFToken": getCookie("csrftoken"),
-                },
+                headers: JSONMutationHeaders,
             }),
             invalidatesTags: (result, error, arg) => [
                 {
@@ -274,10 +273,7 @@ const mutationApi = hitasApi.injectEndpoints({
             query: ({id, housingCompanyId}) => ({
                 url: `housing-companies/${housingCompanyId}/real-estates/${id}`,
                 method: "DELETE",
-                headers: {
-                    "Content-type": "application/json; charset=UTF-8",
-                    "X-CSRFToken": getCookie("csrftoken"),
-                },
+                headers: JSONMutationHeaders,
             }),
             invalidatesTags: (result, error, arg) => [{type: "HousingCompany", id: arg.housingCompanyId}],
         }),
@@ -289,10 +285,7 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `housing-companies/${housingCompanyId}/real-estates/${realEstateId}/buildings`,
                 method: "POST",
                 body: data,
-                headers: {
-                    "Content-type": "application/json; charset=UTF-8",
-                    "X-CSRFToken": getCookie("csrftoken"),
-                },
+                headers: JSONMutationHeaders,
             }),
             invalidatesTags: (result, error, arg) => [{type: "HousingCompany", id: arg.housingCompanyId}],
         }),
@@ -300,10 +293,7 @@ const mutationApi = hitasApi.injectEndpoints({
             query: ({id, housingCompanyId, realEstateId}) => ({
                 url: `housing-companies/${housingCompanyId}/real-estates/${realEstateId}/buildings/${id}`,
                 method: "DELETE",
-                headers: {
-                    "Content-type": "application/json; charset=UTF-8",
-                    "X-CSRFToken": getCookie("csrftoken"),
-                },
+                headers: JSONMutationHeaders,
             }),
             invalidatesTags: (result, error, arg) => [{type: "HousingCompany", id: arg.housingCompanyId}],
         }),
@@ -315,10 +305,7 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `housing-companies/${housingCompanyId}/apartments${idOrBlank(id)}`,
                 method: id === undefined ? "POST" : "PUT",
                 body: data,
-                headers: {
-                    "Content-type": "application/json; charset=UTF-8",
-                    "X-CSRFToken": getCookie("csrftoken"),
-                },
+                headers: JSONMutationHeaders,
             }),
             invalidatesTags: (result, error, arg) => [
                 {type: "Apartment", id: "LIST"},
@@ -339,10 +326,7 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `housing-companies/${housingCompanyId}/apartments/${apartmentId}/maximum-prices${idOrBlank(id)}`,
                 method: id === undefined ? "POST" : "PUT",
                 body: data,
-                headers: {
-                    "Content-type": "application/json; charset=UTF-8",
-                    "X-CSRFToken": getCookie("csrftoken"),
-                },
+                headers: JSONMutationHeaders,
             }),
             invalidatesTags: (result, error, arg) => {
                 // Invalidate Apartment Details only when confirming a maximum price
@@ -362,10 +346,7 @@ const mutationApi = hitasApi.injectEndpoints({
             query: ({id, housingCompanyId}) => ({
                 url: `housing-companies/${housingCompanyId}/apartments/${id}`,
                 method: "DELETE",
-                headers: {
-                    "Content-type": "application/json; charset=UTF-8",
-                    "X-CSRFToken": getCookie("csrftoken"),
-                },
+                headers: JSONMutationHeaders,
             }),
             invalidatesTags: (result, error, arg) => [
                 {type: "Apartment", id: "LIST"},
@@ -378,10 +359,7 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `owners`,
                 method: "POST",
                 body: data,
-                headers: {
-                    "Content-type": "application/json; charset=UTF-8",
-                    "X-CSRFToken": getCookie("csrftoken"),
-                },
+                headers: JSONMutationHeaders,
             }),
             invalidatesTags: () => [{type: "Owner"}],
         }),
@@ -390,10 +368,7 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `indices/${index}/${month}`,
                 method: "PUT",
                 body: data,
-                headers: {
-                    "Content-type": "application/json; charset=UTF-8",
-                    "X-CSRFToken": getCookie("csrftoken"),
-                },
+                headers: JSONMutationHeaders,
             }),
             invalidatesTags: (result, error, arg) => [{type: "Apartment"}, {type: "Index", id: "LIST"}],
         }),
@@ -409,10 +384,7 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `housing-companies/${housingCompanyId}/apartments/${apartmentId}/sales`,
                 method: "POST",
                 body: data,
-                headers: {
-                    "Content-type": "application/json; charset=UTF-8",
-                    "X-CSRFToken": getCookie("csrftoken"),
-                },
+                headers: JSONMutationHeaders,
             }),
             invalidatesTags: (result, error, arg) => [
                 {type: "Apartment", id: "LIST"},
@@ -428,10 +400,7 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `conditions-of-sale`,
                 method: "POST",
                 body: data,
-                headers: {
-                    "Content-type": "application/json; charset=UTF-8",
-                    "X-CSRFToken": getCookie("csrftoken"),
-                },
+                headers: JSONMutationHeaders,
             }),
             invalidatesTags: (result, error) =>
                 !error && result && result.conditions_of_sale.length ? [{type: "Apartment"}] : [],

--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -1,5 +1,6 @@
 import {createApi, fetchBaseQuery} from "@reduxjs/toolkit/query/react";
 
+import {getCookie} from "typescript-cookie";
 import {
     IApartmentDetails,
     IApartmentListResponse,
@@ -66,12 +67,14 @@ const getFetchInit = () => {
     return {
         headers: new Headers({
             "Content-Type": "application/json",
+            ...(getCookie("csrftoken") && {"X-CSRFToken": getCookie("csrftoken")}),
             ...(Config.token && {Authorization: "Bearer " + Config.token}),
         }),
         method: "POST",
         ...(!Config.token && {credentials: "include" as RequestCredentials}),
     };
 };
+
 export const downloadApartmentUnconfirmedMaximumPricePDF = (apartment: IApartmentDetails, additionalInfo?: string) => {
     const url = `${Config.api_v1_url}/housing-companies/${apartment.links.housing_company.id}/apartments/${apartment.id}/reports/download-latest-unconfirmed-prices`;
     const init = {
@@ -240,7 +243,10 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `housing-companies${idOrBlank(id)}`,
                 method: id === undefined ? "POST" : "PUT",
                 body: data,
-                headers: {"Content-type": "application/json; charset=UTF-8"},
+                headers: {
+                    "Content-type": "application/json; charset=UTF-8",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
             }),
             invalidatesTags: (result, error, arg) => [
                 {type: "HousingCompany", id: "LIST"},
@@ -252,7 +258,10 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `housing-companies/${housingCompanyId}/real-estates`,
                 method: "POST",
                 body: data,
-                headers: {"Content-type": "application/json; charset=UTF-8"},
+                headers: {
+                    "Content-type": "application/json; charset=UTF-8",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
             }),
             invalidatesTags: (result, error, arg) => [
                 {
@@ -265,7 +274,10 @@ const mutationApi = hitasApi.injectEndpoints({
             query: ({id, housingCompanyId}) => ({
                 url: `housing-companies/${housingCompanyId}/real-estates/${id}`,
                 method: "DELETE",
-                headers: {"Content-type": "application/json; charset=UTF-8"},
+                headers: {
+                    "Content-type": "application/json; charset=UTF-8",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
             }),
             invalidatesTags: (result, error, arg) => [{type: "HousingCompany", id: arg.housingCompanyId}],
         }),
@@ -277,7 +289,10 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `housing-companies/${housingCompanyId}/real-estates/${realEstateId}/buildings`,
                 method: "POST",
                 body: data,
-                headers: {"Content-type": "application/json; charset=UTF-8"},
+                headers: {
+                    "Content-type": "application/json; charset=UTF-8",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
             }),
             invalidatesTags: (result, error, arg) => [{type: "HousingCompany", id: arg.housingCompanyId}],
         }),
@@ -285,7 +300,10 @@ const mutationApi = hitasApi.injectEndpoints({
             query: ({id, housingCompanyId, realEstateId}) => ({
                 url: `housing-companies/${housingCompanyId}/real-estates/${realEstateId}/buildings/${id}`,
                 method: "DELETE",
-                headers: {"Content-type": "application/json; charset=UTF-8"},
+                headers: {
+                    "Content-type": "application/json; charset=UTF-8",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
             }),
             invalidatesTags: (result, error, arg) => [{type: "HousingCompany", id: arg.housingCompanyId}],
         }),
@@ -297,7 +315,10 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `housing-companies/${housingCompanyId}/apartments${idOrBlank(id)}`,
                 method: id === undefined ? "POST" : "PUT",
                 body: data,
-                headers: {"Content-type": "application/json; charset=UTF-8"},
+                headers: {
+                    "Content-type": "application/json; charset=UTF-8",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
             }),
             invalidatesTags: (result, error, arg) => [
                 {type: "Apartment", id: "LIST"},
@@ -318,7 +339,10 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `housing-companies/${housingCompanyId}/apartments/${apartmentId}/maximum-prices${idOrBlank(id)}`,
                 method: id === undefined ? "POST" : "PUT",
                 body: data,
-                headers: {"Content-type": "application/json; charset=UTF-8"},
+                headers: {
+                    "Content-type": "application/json; charset=UTF-8",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
             }),
             invalidatesTags: (result, error, arg) => {
                 // Invalidate Apartment Details only when confirming a maximum price
@@ -338,7 +362,10 @@ const mutationApi = hitasApi.injectEndpoints({
             query: ({id, housingCompanyId}) => ({
                 url: `housing-companies/${housingCompanyId}/apartments/${id}`,
                 method: "DELETE",
-                headers: {"Content-type": "application/json; charset=UTF-8"},
+                headers: {
+                    "Content-type": "application/json; charset=UTF-8",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
             }),
             invalidatesTags: (result, error, arg) => [
                 {type: "Apartment", id: "LIST"},
@@ -351,7 +378,10 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `owners`,
                 method: "POST",
                 body: data,
-                headers: {"Content-type": "application/json; charset=UTF-8"},
+                headers: {
+                    "Content-type": "application/json; charset=UTF-8",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
             }),
             invalidatesTags: () => [{type: "Owner"}],
         }),
@@ -360,7 +390,10 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `indices/${index}/${month}`,
                 method: "PUT",
                 body: data,
-                headers: {"Content-type": "application/json; charset=UTF-8"},
+                headers: {
+                    "Content-type": "application/json; charset=UTF-8",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
             }),
             invalidatesTags: (result, error, arg) => [{type: "Apartment"}, {type: "Index", id: "LIST"}],
         }),
@@ -376,7 +409,10 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `housing-companies/${housingCompanyId}/apartments/${apartmentId}/sales`,
                 method: "POST",
                 body: data,
-                headers: {"Content-type": "application/json; charset=UTF-8"},
+                headers: {
+                    "Content-type": "application/json; charset=UTF-8",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
             }),
             invalidatesTags: (result, error, arg) => [
                 {type: "Apartment", id: "LIST"},
@@ -392,7 +428,10 @@ const mutationApi = hitasApi.injectEndpoints({
                 url: `conditions-of-sale`,
                 method: "POST",
                 body: data,
-                headers: {"Content-type": "application/json; charset=UTF-8"},
+                headers: {
+                    "Content-type": "application/json; charset=UTF-8",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
             }),
             invalidatesTags: (result, error) =>
                 !error && result && result.conditions_of_sale.length ? [{type: "Apartment"}] : [],
@@ -403,7 +442,10 @@ const mutationApi = hitasApi.injectEndpoints({
                 method: "POST",
                 body: arg.data,
                 params: {calculation_date: arg.calculation_date},
-                headers: {"Content-type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+                headers: {
+                    "Content-type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "X-CSRFToken": getCookie("csrftoken"),
+                },
             }),
         }),
     }),

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9157,6 +9157,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript-cookie@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/typescript-cookie/-/typescript-cookie-1.0.6.tgz#009b0665706b2cc856f796e76cf408a16ef011c5"
+  integrity sha512-s+BZr7/9BUG6Kg7jGGcOY/4XJcP+iZRFdF3q4FPTfRSP83ivLWF94OcH8PrzGmnS8Ab9qP7ENu/ikLwNFsIafA==
+
 typescript@^4.4.2:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"


### PR DESCRIPTION
# Hitas Pull Request

# Description

This is done so that authentication using Helsinki profile session tokens works with the current backend setup.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [ ] Run frontend without `REACT_APP_AUTH_TOKEN` in `.env`, so that session authentication with Helsinki profile is needed. Make mutation requests, like modifying indices. 

## Tickets

This pull request resolves all or part of the following ticket(s): -
