### PR TITLE
Add request dates to pdf downloads

### DIFF
--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -75,22 +75,30 @@ const getFetchInit = () => {
     };
 };
 
-export const downloadApartmentUnconfirmedMaximumPricePDF = (apartment: IApartmentDetails, additionalInfo?: string) => {
+export const downloadApartmentUnconfirmedMaximumPricePDF = (
+    apartment: IApartmentDetails,
+    additionalInfo?: string,
+    requestDate?: string
+) => {
     const url = `${Config.api_v1_url}/housing-companies/${apartment.links.housing_company.id}/apartments/${apartment.id}/reports/download-latest-unconfirmed-prices`;
     const init = {
         ...getFetchInit(),
-        body: JSON.stringify({additional_info: additionalInfo}),
+        body: JSON.stringify({additional_info: additionalInfo, request_date: requestDate}),
     };
     fetch(url, init).then(handleDownloadPDF);
 };
 
-export const downloadApartmentMaximumPricePDF = (apartment: IApartmentDetails) => {
+export const downloadApartmentMaximumPricePDF = (apartment: IApartmentDetails, requestDate?: string) => {
     if (!apartment.prices.maximum_prices.confirmed) {
         hitasToast("Enimmäishintalaskelmaa ei ole olemassa", "error");
         return;
     }
     const url = `${Config.api_v1_url}/housing-companies/${apartment.links.housing_company.id}/apartments/${apartment.id}/reports/download-latest-confirmed-prices`;
-    fetch(url, getFetchInit()).then(handleDownloadPDF);
+    const init = {
+        ...getFetchInit(),
+        body: JSON.stringify({request_date: requestDate}),
+    };
+    fetch(url, init).then(handleDownloadPDF);
 };
 
 export const hitasApi = createApi({

--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -77,8 +77,8 @@ const getFetchInit = () => {
 
 export const downloadApartmentUnconfirmedMaximumPricePDF = (
     apartment: IApartmentDetails,
-    additionalInfo?: string,
-    requestDate?: string
+    requestDate: string,
+    additionalInfo?: string
 ) => {
     const url = `${Config.api_v1_url}/housing-companies/${apartment.links.housing_company.id}/apartments/${apartment.id}/reports/download-latest-unconfirmed-prices`;
     const init = {

--- a/frontend/src/common/components/form/DateInput.tsx
+++ b/frontend/src/common/components/form/DateInput.tsx
@@ -10,7 +10,7 @@ interface DateInputProps extends FormInputProps {
     minDate?: Date;
 }
 
-const DateInput = ({id, name, label, required, maxDate, minDate, formObject, disabled}: DateInputProps) => {
+const DateInput = ({id, name, label, formObject, required, ...rest}: DateInputProps) => {
     const hdsFormat = "d.M.yyyy";
     const apiFormat = "yyyy-MM-dd";
 
@@ -68,9 +68,7 @@ const DateInput = ({id, name, label, required, maxDate, minDate, formObject, dis
                 errorText={!!fieldError && fieldError.message}
                 invalid={!!fieldError}
                 required={required}
-                maxDate={maxDate}
-                minDate={minDate}
-                disabled={disabled}
+                {...rest}
             />
         </div>
     );

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -189,6 +189,7 @@ const UnconfirmedPricesDownloadModal = ({apartment, isVisible, setIsVisible}: Do
             downloadForm.getValues("additional_info"),
             downloadForm.getValues("request_date")
         );
+        setIsVisible(false);
     };
 
     return (
@@ -256,6 +257,7 @@ const MaximumPriceDownloadModal = ({apartment, isVisible, setIsVisible}: Downloa
     };
     const onSubmit = () => {
         downloadApartmentMaximumPricePDF(apartment, downloadForm.getValues("request_date"));
+        setIsVisible(false);
     };
 
     return (

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -225,3 +225,7 @@
 
   [class^="Tabs-module_tablistBar"]
     background: white
+
+#unconfirmed-prices-download-modal
+  .input-field
+    height: auto

--- a/frontend/src/styles/components/_ApartmentNewSalePage.sass
+++ b/frontend/src/styles/components/_ApartmentNewSalePage.sass
@@ -25,6 +25,8 @@
 
       .row
         gap: 2em
+        &--prompt
+          @include flex-flow(column nowrap)
         > div
           width: 50%
           position: relative


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds a field for the request date for the pdf-downloads on the apartment detail page. The confirmed maximum prices button now opens a modal with the above mentioned request date field instead of directly downloading the pdf. 
The unconfirmed prices download is updated to use react hook form. This PR also fixes DateInput to show tooltips properly.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [X] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [X] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Go to any apartment page and try out both of the pdf downloads.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-566, HT-513