### PR TITLE
UI for modifying building information

### DIFF
--- a/backend/hitas/models/utils.py
+++ b/backend/hitas/models/utils.py
@@ -87,7 +87,7 @@ def validate_building_id(value: Optional[str]) -> None:
     building_id_match = re.search(r"^\d{1,4}-\d{1,4}-\d{1,4}-\d{1,4} [A-Za-z0-9] \d{3}$", value)
     if building_id_match is None:
         raise ValidationError(
-            _("%(value)s is not an valid building id"),
+            _("%(value)s is not a valid building id"),
             params={"value": value},
         )
     # TODO: verify building id with the check digit

--- a/backend/hitas/tests/apis/test_api_building.py
+++ b/backend/hitas/tests/apis/test_api_building.py
@@ -324,6 +324,35 @@ def test__api__building__update(api_client: HitasAPIClient):
     assert response.json() == get_response.json()
 
 
+@pytest.mark.django_db
+def test__api__building__update__change_real_estate(api_client: HitasAPIClient):
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    real_estate_1: RealEstate = RealEstateFactory.create(housing_company=housing_company)
+    real_estate_2: RealEstate = RealEstateFactory.create(housing_company=housing_company)
+    building: Building = BuildingFactory.create(real_estate=real_estate_1)
+
+    data = {
+        "address": {
+            "street_address": "test-street-address-1",
+        },
+        "real_estate_id": real_estate_2.uuid.hex,
+    }
+
+    url = reverse(
+        "hitas:building-detail",
+        kwargs={
+            "housing_company_uuid": housing_company.uuid.hex,
+            "real_estate_uuid": real_estate_1.uuid.hex,
+            "uuid": building.uuid.hex,
+        },
+    )
+    response = api_client.put(url, data=data, format="json")
+    assert response.status_code == status.HTTP_200_OK, response.json()
+
+    building.refresh_from_db()
+    assert building.real_estate == real_estate_2
+
+
 # Delete tests
 
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -4412,6 +4412,11 @@ components:
           type: integer
           minimum: 0
           example: 4
+        real_estate_id:
+          description: New ID of this building's real estate
+          type: string
+          writeOnly: true
+          example: c86eaa399ce141d89d962d46bb81ab2b
 
     MinimalHousingCompany:
       description: Housing company identifier

--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -295,13 +295,15 @@ const mutationApi = hitasApi.injectEndpoints({
             }),
             invalidatesTags: (result, error, arg) => [{type: "HousingCompany", id: arg.housingCompanyId}],
         }),
-        createBuilding: builder.mutation<
+        saveBuilding: builder.mutation<
             IBuilding,
             {data: IBuildingWritable; housingCompanyId: string; realEstateId: string}
         >({
             query: ({data, housingCompanyId, realEstateId}) => ({
-                url: `housing-companies/${housingCompanyId}/real-estates/${realEstateId}/buildings`,
-                method: "POST",
+                url: `housing-companies/${housingCompanyId}/real-estates/${realEstateId}/buildings${idOrBlank(
+                    data.id
+                )}`,
+                method: data.id === undefined ? "POST" : "PUT",
                 body: data,
                 headers: mutationApiJsonHeaders(),
             }),
@@ -472,7 +474,7 @@ export const {
     useSaveHousingCompanyMutation,
     useCreateRealEstateMutation,
     useDeleteRealEstateMutation,
-    useCreateBuildingMutation,
+    useSaveBuildingMutation,
     useDeleteBuildingMutation,
     useSaveApartmentMutation,
     useDeleteApartmentMutation,

--- a/frontend/src/common/components/CancelButton.tsx
+++ b/frontend/src/common/components/CancelButton.tsx
@@ -1,0 +1,30 @@
+import {Button} from "hds-react";
+
+interface CancelButtonProps {
+    onClick?: (unknown) => unknown;
+    isLoading?: boolean;
+    disabled?: boolean;
+    buttonText?: string;
+    size?: "small" | "default";
+}
+
+export default function CancelButton({
+    onClick,
+    isLoading = false,
+    disabled = false,
+    buttonText,
+    size = "default",
+}: CancelButtonProps): JSX.Element {
+    return (
+        <Button
+            className="cancel-button"
+            theme="black"
+            variant="secondary"
+            isLoading={isLoading}
+            size={size}
+            onClick={onClick}
+        >
+            {buttonText ?? "Peruuta"}
+        </Button>
+    );
+}

--- a/frontend/src/common/components/SaveDialogModal.tsx
+++ b/frontend/src/common/components/SaveDialogModal.tsx
@@ -51,7 +51,7 @@ const ActionSuccess = ({linkURL, linkText, baseURL, data}) => {
                         variant="secondary"
                         theme="black"
                     >
-                        Syötä uusi
+                        Uusi
                     </Button>
                     <NavigateBackButton />
                 </>

--- a/frontend/src/common/components/SaveDialogModal.tsx
+++ b/frontend/src/common/components/SaveDialogModal.tsx
@@ -37,7 +37,7 @@ const ActionSuccess = ({linkURL, linkText, baseURL, data}) => {
         <>
             <Dialog.Content>Tiedot tallennettu onnistuneesti!</Dialog.Content>
             <Dialog.ActionButtons>
-                <>
+                {(linkURL || baseURL) && (
                     <Link to={linkURL || baseURL + data.id}>
                         <Button
                             variant="secondary"
@@ -46,15 +46,15 @@ const ActionSuccess = ({linkURL, linkText, baseURL, data}) => {
                             {linkText}
                         </Button>
                     </Link>
-                    <Button
-                        onClick={() => window.location.reload()}
-                        variant="secondary"
-                        theme="black"
-                    >
-                        Uusi
-                    </Button>
-                    <NavigateBackButton />
-                </>
+                )}
+                <Button
+                    onClick={() => window.location.reload()}
+                    variant="secondary"
+                    theme="black"
+                >
+                    Uusi
+                </Button>
+                <NavigateBackButton />
             </Dialog.ActionButtons>
         </>
     );

--- a/frontend/src/common/components/formInputField/FormInputField.tsx
+++ b/frontend/src/common/components/formInputField/FormInputField.tsx
@@ -124,6 +124,9 @@ export default function FormInputField({
             if (errorMessage) {
                 setIsInvalid(true);
             }
+        } else {
+            setErrorMessage("");
+            setIsInvalid(false);
         }
     }, [error, errorMessage, setErrorMessage, fieldPath]);
 

--- a/frontend/src/features/housingCompany/HousingCompanyBuildingsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyBuildingsPage.tsx
@@ -55,7 +55,7 @@ const HousingCompanyBuildingsPage = (): JSX.Element => {
         saveBuilding({
             data: formData,
             housingCompanyId: params.housingCompanyId as string,
-            realEstateId: formData.real_estate_id as string,
+            realEstateId: editing ? (editing.realEstate.id as string) : (formData.real_estate_id as string),
         });
         setIsEndModalVisible(true);
     };
@@ -144,26 +144,37 @@ const HousingCompanyBuildingsPage = (): JSX.Element => {
             <h2>{editing ? "Muokkaa rakennuksen tietoja" : "Uusi rakennus"}</h2>
             <div className="field-sets">
                 <Fieldset heading="">
-                    {editing ? (
-                        <>
-                            <h4>
-                                Kiinteistö: {editing.realEstate.address.street_address} (
-                                {editing.realEstate.property_identifier})
-                            </h4>
-                            <h3>
-                                Rakennus: {editing.building.address.street_address}
-                                {editing.building.building_identifier
-                                    ? ` (${editing.building.building_identifier})`
-                                    : ""}
-                            </h3>
-                        </>
-                    ) : (
+                    {editing && (
+                        <h3>
+                            Rakennus: {editing.building.address.street_address}
+                            {editing.building.building_identifier ? ` (${editing.building.building_identifier})` : ""}
+                        </h3>
+                    )}
+                    {!editing && (
                         <div className="row">
                             <FormInputField
                                 inputType="select"
                                 label="Kiinteistö"
                                 fieldPath="real_estate_id"
                                 options={realEstateOptions}
+                                required
+                                formData={formData}
+                                setFormData={setFormData}
+                                error={error}
+                            />
+                        </div>
+                    )}
+                    {editing && (
+                        <div className="row">
+                            <FormInputField
+                                inputType="select"
+                                label="Kiinteistö"
+                                fieldPath="real_estate_id"
+                                options={realEstateOptions}
+                                defaultValue={{
+                                    label: `${editing.realEstate.address.street_address} (${editing.realEstate.property_identifier})`,
+                                    value: editing.realEstate.id,
+                                }}
                                 required
                                 formData={formData}
                                 setFormData={setFormData}

--- a/frontend/src/features/housingCompany/HousingCompanyBuildingsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyBuildingsPage.tsx
@@ -223,8 +223,6 @@ const HousingCompanyBuildingsPage = (): JSX.Element => {
             <SaveDialogModal
                 data={data}
                 error={error}
-                linkURL={"/housing-companies/" + params.housingCompanyId}
-                linkText="Takaisin yhtiön sivulle"
                 isLoading={isLoading}
                 isVisible={isEndModalVisible}
                 setIsVisible={setIsEndModalVisible}

--- a/frontend/src/styles/base/_general.sass
+++ b/frontend/src/styles/base/_general.sass
@@ -79,6 +79,9 @@ ul, ol
     >*:only-child
       margin-left: auto
       margin-right: auto
+    .cancel-button
+      margin-right: $spacing-s
+
 
 .pull-right
   float: right

--- a/frontend/src/styles/components/_CreatePage.sass
+++ b/frontend/src/styles/components/_CreatePage.sass
@@ -107,7 +107,6 @@
 
   > button
     margin: $spacing-layout-s auto
-
 .view--create-improvements
   .field-sets
     @include flex-direction(column)
@@ -177,8 +176,13 @@
     .remove-icon
       cursor: pointer
       height: 24px
+      margin-left: $spacing-xs
       &:hover
         color: $color-error
+    .edit-icon
+      @extend .remove-icon
+      &:hover
+        color: $color-info
 
 .view--real-estates
   .real-estates-list


### PR DESCRIPTION
# Hitas Pull Request

# Description

Added ui for modifying building information and fixed the validation error in the building id field.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- At the buildings view click the pen icon on the building row and  modify the address or change the id to some valid id or change the real estate and click Save button. Check that the information changed at the buildings list and the create building view becomes again visible
- If you start modifying the building information and click the Cancel button, check that no changes are made and you will see the create building view
- For invalid building id values, check that an error message is shown on the modal. When closing the modal, check that the modify building view stays visible and shows the error message below the invalid field with border of error color

## Tickets

This pull request resolves all or part of the following ticket(s): HT-546
