### PR TITLE
Use email as a secondary option for strings if first/last name not found

### DIFF
--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -11,7 +11,7 @@ class User(AbstractUser):
     title = models.CharField(max_length=50, null=True, blank=True, default=None)
 
     def __str__(self) -> str:
-        return f"{self.first_name} {self.last_name}"
+        return f"{self.first_name} {self.last_name}" or self.email
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} ({self.pk}): {self.get_username()}>"


### PR DESCRIPTION
# Hitas Pull Request

# Description

Use email as a secondary option for __str__ if first and last name not found.
This is to enable links in admin panel when user is created from Helsinki profile and their name is not available.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [ ] Go to admin panel and see email for users logged in via helsinki profile in the users list

## Tickets

This pull request resolves all or part of the following ticket(s): -
