### PR TITLE
Remove basic auth from frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - "8081:8080"
     volumes:
       - ./frontend/docker-env-config.js:/usr/share/nginx/html/env-config.js:ro
-      - ./frontend/example-htpasswd:/usr/share/nginx/.htpasswd:ro
     depends_on:
       - hitas-backend
     container_name: hitas-frontend

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -9,9 +9,6 @@ server {
     }
 
     location / {
-        auth_basic           "Hitas";
-        auth_basic_user_file /usr/share/nginx/.htpasswd;
-
         root       /usr/share/nginx/html;
         index      index.html index.htm;
         try_files  $uri $uri/ /index.html;


### PR DESCRIPTION
Helsinki profile auth will replace this. Dev tokens will still work.

# Hitas Pull Request

# Description

Removes basic auth (notification box) from Frontend now that Helsinki profile authentication is working.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [ ] Push to dev and see what happens

## Tickets

This pull request resolves all or part of the following ticket(s): -
