### PR TITLE
Make regulation property manager last_modified date nullable

### DIFF
--- a/backend/hitas/services/thirty_year_regulation.py
+++ b/backend/hitas/services/thirty_year_regulation.py
@@ -71,7 +71,7 @@ class PropertyManagerInfo(TypedDict):
     name: str
     email: str
     address: AddressInfo
-    last_modified: datetime.date | str
+    last_modified: datetime.date | str | None
 
 
 class ComparisonData(TypedDict):
@@ -317,7 +317,11 @@ def _split_automatically_released(
                             postal_code=housing_company.property_manager.postal_code,
                             city=housing_company.property_manager.city,
                         ),
-                        last_modified=housing_company.property_manager_last_edited.date(),
+                        last_modified=(
+                            housing_company.property_manager_last_edited.date()
+                            if housing_company.property_manager_last_edited
+                            else None
+                        ),
                     ),
                     letter_fetched=False,
                     current_regulation_status=RegulationStatus.RELEASED_BY_HITAS.value,
@@ -361,7 +365,11 @@ def _get_comparison_values(
                     postal_code=housing_company.property_manager.postal_code,
                     city=housing_company.property_manager.city,
                 ),
-                last_modified=housing_company.property_manager_last_edited.date(),
+                last_modified=(
+                    housing_company.property_manager_last_edited.date()
+                    if housing_company.property_manager_last_edited
+                    else None
+                ),
             ),
             letter_fetched=False,
             current_regulation_status=RegulationStatus.REGULATED.value,  # Changed later if necessary

--- a/backend/hitas/tests/apis/test_api_apartment_sale.py
+++ b/backend/hitas/tests/apis/test_api_apartment_sale.py
@@ -618,8 +618,8 @@ def test__api__apartment_sale__create__replace_old_ownerships(api_client: HitasA
 def test__api__apartment_sale__create__condition_of_sale_fulfilled(api_client: HitasAPIClient):
     owner_1: Owner = OwnerFactory.create()
     owner_2: Owner = OwnerFactory.create()
-    new_ownership: Ownership = OwnershipFactory.create(owner=owner_1)
-    old_ownership: Ownership = OwnershipFactory.create(owner=owner_1)
+    new_ownership: Ownership = OwnershipFactory.create(owner=owner_1, sale__purchase_date=datetime.date(2023, 1, 1))
+    old_ownership: Ownership = OwnershipFactory.create(owner=owner_1, sale__purchase_date=datetime.date(2022, 1, 1))
     condition_of_sale: ConditionOfSale = ConditionOfSaleFactory.create(
         new_ownership=new_ownership,
         old_ownership=old_ownership,

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -7567,6 +7567,7 @@ components:
         last_modified:
           description: When this property manager was last modified on a given housing company?
           type: string
+          nullable: true
           format: date
           example: 2022-01-01
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

Allows last_modified date for housing companies to be null.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests

## Tickets

This pull request resolves all or part of the following ticket(s): -