### PR TITLE
oracle migration: Modify `no_deductions` improvements rules

### DIFF
--- a/backend/hitas/oracle_migration/runner.py
+++ b/backend/hitas/oracle_migration/runner.py
@@ -717,19 +717,20 @@ def create_apartment_improvements(connection: Connection, converted_data: Conver
                 value=mpi_improvement["value"],
             )
 
-            # Check if improvement value should be moved to apartment.additional_work_during_construction instead
+            # Check if improvement requires special handling:
+            # - If improvement value should be moved to apartment.additional_work_during_construction instead
+            # - If improvement should be marked as having 'no_deductions'
             if (
-                # awdc Improvements have no excess
+                # Improvements have no excess
                 mpi_improvement["excess"] == "000"
-                # and is completed at almost the same time as the apartment
-                and is_date_within_one_month(new.completion_date, monthify(v.completion_date))
                 # and the improvements accepted value should not be less than the original value
                 and mpi_improvement["accepted_value"] >= mpi_improvement["value"]
             ):
                 if new.name == "Ullakkohuoneen rakentaminen":
                     # 'Attic room' improvements are not considered awdc improvements, as they require special handling
                     new.no_deductions = True
-                else:
+                # AWDC improvement must be completed at almost the same time as the apartment
+                elif is_date_within_one_month(new.completion_date, monthify(v.completion_date)):
                     mpi_awdc["improvements"].append(new)
                     mpi_awdc["date"] = mpi_improvement.calculation_date
                     continue


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Now improvements are marked as having `no_deductions` regardless of the date

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [ ] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

-

## Tickets

This pull request resolves all or part of the following ticket(s): Slack messages