### PR TITLE
Switch to django-post-fetch-hook for obfuscation hooks

### DIFF
--- a/backend/hitas/tests/test_owner_obfuscation.py
+++ b/backend/hitas/tests/test_owner_obfuscation.py
@@ -1,0 +1,174 @@
+import re
+
+import pytest
+
+from hitas.models import Owner
+from hitas.tests.factories import OwnerFactory
+
+
+@pytest.mark.django_db
+def test_owner_obfuscation__model__obfuscate():
+    OwnerFactory.create(
+        name="Testi Testinen",
+        identifier="123456-789A",
+        email=None,
+        non_disclosure=True,
+    )
+
+    owner = Owner.objects.first()
+
+    assert owner.name == ""
+    assert owner.identifier is None
+    assert owner.email is None
+
+    assert owner._unobfuscated_data == {"name": "Testi Testinen", "identifier": "123456-789A", "email": None}
+
+
+@pytest.mark.django_db
+def test_owner_obfuscation__model__dont_obfuscate():
+    OwnerFactory.create(
+        name="Testi Testinen",
+        identifier="123456-789A",
+        email=None,
+        non_disclosure=False,
+    )
+
+    owner = Owner.objects.first()
+
+    assert owner.name == "Testi Testinen"
+    assert owner.identifier == "123456-789A"
+    assert owner.email is None
+
+    assert not hasattr(owner, "_unobfuscated_data")
+
+
+@pytest.mark.django_db
+def test_owner_obfuscation__values__obfuscate():
+    OwnerFactory.create(
+        name="Testi Testinen",
+        identifier="123456-789A",
+        email=None,
+        non_disclosure=True,
+    )
+
+    owner = Owner.objects.values("name", "identifier", "email", "non_disclosure").first()
+
+    assert owner["name"] == ""
+    assert owner["identifier"] is None
+    assert owner["email"] is None
+
+    # No cache created when using values()
+    assert not hasattr(owner, "_unobfuscated_data")
+
+
+@pytest.mark.django_db
+def test_owner_obfuscation__values__obfuscate__non_disclosure_missing():
+    OwnerFactory.create(
+        name="Testi Testinen",
+        identifier="123456-789A",
+        email=None,
+        non_disclosure=True,
+    )
+
+    msg = (
+        "Due to owner obfuscation, 'non_disclosure' field should always be included "
+        "when fetching owners. Field not found in fields: ('name', 'identifier', 'email')"
+    )
+
+    with pytest.raises(RuntimeError, match=re.escape(msg)):
+        Owner.objects.values("name", "identifier", "email").first()
+
+
+@pytest.mark.django_db
+def test_owner_obfuscation__values__dont_obfuscate():
+    OwnerFactory.create(
+        name="Testi Testinen",
+        identifier="123456-789A",
+        email=None,
+        non_disclosure=False,
+    )
+
+    # non_disclosure missing, we assume owner should be obfuscated
+    owner = Owner.objects.values("name", "identifier", "email", "non_disclosure").first()
+
+    assert owner["name"] == "Testi Testinen"
+    assert owner["identifier"] == "123456-789A"
+    assert owner["email"] is None
+
+    # No cache created when using values()
+    assert not hasattr(owner, "_unobfuscated_data")
+
+
+@pytest.mark.django_db
+def test_owner_obfuscation__values_list__obfuscate():
+    OwnerFactory.create(
+        name="Testi Testinen",
+        identifier="123456-789A",
+        email=None,
+        non_disclosure=True,
+    )
+
+    owner = Owner.objects.values_list("name", "identifier", "email", "non_disclosure").first()
+
+    assert owner[0] == ""
+    assert owner[1] is None
+    assert owner[2] is None
+
+    # No cache created when using values_list()
+    assert not hasattr(owner, "_unobfuscated_data")
+
+
+@pytest.mark.django_db
+def test_owner_obfuscation__values_list__obfuscate__non_disclosure_missing():
+    OwnerFactory.create(
+        name="Testi Testinen",
+        identifier="123456-789A",
+        email=None,
+        non_disclosure=True,
+    )
+
+    msg = (
+        "Due to owner obfuscation, 'non_disclosure' field should always be included "
+        "when fetching owners. Field not found in fields: ('name', 'identifier', 'email')"
+    )
+
+    with pytest.raises(RuntimeError, match=re.escape(msg)):
+        Owner.objects.values_list("name", "identifier", "email").first()
+
+
+@pytest.mark.django_db
+def test_owner_obfuscation__values_list__dont_obfuscate():
+    OwnerFactory.create(
+        name="Testi Testinen",
+        identifier="123456-789A",
+        email=None,
+        non_disclosure=False,
+    )
+
+    owner = Owner.objects.values_list("name", "identifier", "email", "non_disclosure").first()
+
+    assert owner[0] == "Testi Testinen"
+    assert owner[1] == "123456-789A"
+    assert owner[2] is None
+
+    # No cache created when using values_list()
+    assert not hasattr(owner, "_unobfuscated_data")
+
+
+@pytest.mark.django_db
+def test_owner_obfuscation__values_list_flat():
+    OwnerFactory.create(
+        name="Testi Testinen",
+        identifier="123456-789A",
+        email=None,
+        non_disclosure=True,
+    )
+
+    msg = (
+        "Due to owner obfuscation, 'non_disclosure' field should always be included "
+        "when fetching owners. When using .values_list(..., flat=True), this cannot be done."
+        "Please use some other way to fetch this value."
+    )
+
+    with pytest.raises(RuntimeError, match=re.escape(msg)):
+        Owner.objects.values_list("name", flat=True).first()

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -743,6 +743,21 @@ files = [
 ]
 
 [[package]]
+name = "django-post-fetch-hook"
+version = "0.0.1"
+description = "Modify data fetched from a database after it has been fetched but before it has been cached in django's result cache."
+category = "main"
+optional = false
+python-versions = ">=3.9,<4"
+files = [
+    {file = "django_post_fetch_hook-0.0.1-py3-none-any.whl", hash = "sha256:7959358cbcf5432f962dcabc5a99d5c8e5234567eaffe5e4e5d7db8f34156e36"},
+    {file = "django_post_fetch_hook-0.0.1.tar.gz", hash = "sha256:73e9db90abeb5211887b910db177ff84b2452d6e1b5f36c94c71d93873fcc43d"},
+]
+
+[package.dependencies]
+Django = ">=3.2"
+
+[[package]]
 name = "django-safedelete"
 version = "1.3.2"
 description = "Mask your objects instead of deleting them from your database."
@@ -3166,4 +3181,4 @@ svglib = ">=1.2.1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "beb9f3a1243f758abd97ad71d713c25013b4b76aafaaaa3837f11a38872ab53c"
+content-hash = "20b46e15269f34f393a0897be63caa97abf3fb3e5019db81251212f52bd129e4"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,6 +31,7 @@ sentry-sdk = "^1.13.0"
 tomli = "^2.0.1"
 openpyxl = "^3.0.10"
 django-auditlog = "^2.2.2"
+django-post-fetch-hook = "0.0.1"
 
 [tool.poetry.dependencies.uWSGI]
 version = "^2.0.20"


### PR DESCRIPTION
# Hitas Pull Request

# Description

Switched to [django-post-fetch-hook](https://github.com/MrThearMan/django-post-fetch-hook) for post save obfuscation hooks (library based on the implementation previously in Hitas). More robust and 100% tested.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests

## Tickets

This pull request resolves all or part of the following ticket(s): HT-599
