### PR TITLE
Add is_sent to audit log additional data for ElasticSearch component

### DIFF
--- a/backend/hitas/models/_base.py
+++ b/backend/hitas/models/_base.py
@@ -1,6 +1,6 @@
 import datetime
 from decimal import Decimal
-from typing import Any, Iterable, Optional, TypeAlias, TypeVar
+from typing import Any, Iterable, Optional, TypeAlias, TypedDict, TypeVar
 from uuid import UUID, uuid4
 
 from auditlog.diff import model_instance_diff
@@ -148,7 +148,20 @@ class PostFetchModelMixin(mixins.PostFetchModelMixin):
         return NotImplemented
 
 
-class HitasModel(PostFetchModelMixin, Model):
+class AuditLogAdditionalDataT(TypedDict):
+    is_sent: bool
+
+
+class AuditLogAdditionalDataMixin:
+    @staticmethod
+    def get_additional_data() -> AuditLogAdditionalDataT:
+        """Get additional data to be saved with the log entry."""
+        return AuditLogAdditionalDataT(
+            is_sent=False,
+        )
+
+
+class HitasModel(PostFetchModelMixin, AuditLogAdditionalDataMixin, Model):
     """
     Model with bulk auditing capabilities.
     """
@@ -190,7 +203,7 @@ class HitasSafeDeleteDeletedManager(SafeDeleteDeletedManager):
     _queryset_class = HitasSafeDeleteQuerySet
 
 
-class HitasSafeDeleteModel(PostFetchModelMixin, SafeDeleteModel):
+class HitasSafeDeleteModel(PostFetchModelMixin, AuditLogAdditionalDataMixin, SafeDeleteModel):
     """
     Abstract model for Hitas entities without an externally visible ID
     """


### PR DESCRIPTION
# Hitas Pull Request

# Description

Add additional data to log entries for ElasticSearch integration.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [ ] Check that all audit log entries set additional data to `{"is_sent": false}` on creation.

## Tickets

This pull request resolves all or part of the following ticket(s): -
