### PR TITLE
Add date to price estimation

### DIFF
--- a/backend/hitas/tests/apis/apartment_max_price/test_api_unconfirmed_max_price_pdf.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_unconfirmed_max_price_pdf.py
@@ -1,0 +1,432 @@
+# ruff: noqa: E501
+import datetime
+from inspect import cleandoc
+from io import BytesIO
+from typing import Literal, NamedTuple
+
+import pytest
+from django.urls import reverse
+from pypdf import PdfReader
+from rest_framework import status
+
+from hitas.models import Apartment, Ownership
+from hitas.models.housing_company import HitasType
+from hitas.tests.apis.helpers import HitasAPIClient, parametrize_helper
+from hitas.tests.factories import ApartmentFactory
+from hitas.tests.factories.indices import (
+    ConstructionPriceIndex2005Equal100Factory,
+    MarketPriceIndex2005Equal100Factory,
+    SurfaceAreaPriceCeilingFactory,
+)
+from users.models import User
+
+
+@pytest.mark.django_db
+def test__api__unconfirmed_max_price_pdf(api_client: HitasAPIClient, freezer):
+    freezer.move_to("2022-01-01")
+    api_user: User = api_client.handler._force_user
+
+    apartment: Apartment = ApartmentFactory.create(
+        completion_date=datetime.date(2021, 1, 1),
+        additional_work_during_construction=5000,
+        interest_during_construction_6=1000,
+        interest_during_construction_14=2000,
+        surface_area=50,
+        building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
+        sales__purchase_price=80000,
+        sales__apartment_share_of_housing_company_loans=15000,
+    )
+
+    ownership: Ownership = apartment.latest_sale(include_first_sale=True).ownerships.first()
+
+    this_month = datetime.date.today().replace(day=1)
+    completion_month = apartment.completion_date.replace(day=1)
+
+    # Completion month indices
+    ConstructionPriceIndex2005Equal100Factory.create(month=completion_month, value=100)
+    MarketPriceIndex2005Equal100Factory.create(month=completion_month, value=200)
+    # Current month indices
+    ConstructionPriceIndex2005Equal100Factory.create(month=this_month, value=150)
+    MarketPriceIndex2005Equal100Factory.create(month=this_month, value=250)
+    SurfaceAreaPriceCeilingFactory.create(month=this_month, value=3000)
+
+    url = reverse(
+        "hitas:apartment-download-latest-unconfirmed-prices",
+        kwargs={"housing_company_uuid": apartment.housing_company.uuid.hex, "uuid": apartment.uuid.hex},
+    )
+
+    data = {
+        "request_date": "2022-01-01",
+        "additional_info": "This is additional information",
+    }
+
+    response = api_client.post(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response["content-type"] == "application/pdf"
+
+    letter = PdfReader(BytesIO(response.content))
+    assert len(letter.pages) == 1
+
+    page_1 = letter.pages[0].extract_text()
+    page_1 = cleandoc("\n".join(item.strip() for item in page_1.split("\n")))
+
+    assert page_1 == cleandoc(
+        f"""
+        01.01.2022
+        Postiosoite
+        Käyntiosoite
+        Puh. (09) 310 13033
+        Asuntopalvelut
+        Työpajankatu 8
+        Email hitas@hel.fi
+        PL 58231
+        00580 Helsinki
+        Url http://www.hel.fi/hitas
+        00099 HELSINGIN KAUPUNKI
+        Helsingin kaupunki
+        {apartment.address}
+        {apartment.postal_code.value} HELSINKI
+        HITAS-HUONEISTON ENIMMÄISHINTA
+        \x7f ilman yhtiökohtaisia parannuksia ja mahdollista yhtiölainaosuutta
+        Omistaja ja omistusosuus (%)
+        {ownership.owner.name}
+        {float(ownership.percentage):.2f}
+
+        Asunto-osakeyhtiö
+        {apartment.housing_company.display_name}, Helsinki
+        Huoneiston osoite
+        {apartment.address}, {apartment.postal_code.value} HELSINKI
+        Huoneiston valmistumisajankohta
+        {apartment.completion_date.strftime("%d.%m.%Y")}
+        Huoneiston ensimmäinen kaupantekoajankohta
+        {apartment.first_sale().purchase_date.strftime("%d.%m.%Y")}
+        Alkuperäinen velaton hankintahinta, euroa
+        95 000,00
+        Rakennuttajalta tilatut lisä- ja muutostyöt
+        5 000,00
+        Rakennusaikainen korko, euroa
+        1 000,00
+        Hitas-huoneiston hinta rakennuskustannusindeksillä
+        laskettuna, euroa
+        150 000,00
+        This is additional information
+        Hitas-huoneistonne velaton enimmäishinta on 150 000 euroa rakennuskustannusindeksillä laskettuna.
+        Mikäli tarvitsette huoneistonne vahvistetun enimmäishinnan, teidän tulee toimittaa isännöitsijäntodistus tai
+        Hitas-enimmäishinnan vahvistamislomake. Näiden tietojen perusteella vahvistetaan huoneistonne lopullinen
+        enimmäishinta. Laskelma tulee huoneistoa myytäessä esittää ostajille.
+        Teillä on mahdollisuus myydä huoneistonne myös ilman enimmäishinnan vahvistamista enintään kaupantekoajankohtana
+        voimassaolevalla rajahinnalla. Rajahinnan alittavasta velattomasta huoneiston hinnasta voidaan myyjän ja ostajan välillä
+        sopia vapaasti.
+        Mikäli osakkeisiin kohdistuu yhtiölainaosuutta, tulee sen osuus vähentää huoneiston velattomasta hinnasta kauppahintaa
+        laskettaessa.
+        Rajahintaa tarkistetaan neljännesvuosittain 1.2., 1.5., 1.8. ja 1.11. ja se on voimassa kolme kuukautta kerrallaan.
+        {api_user.first_name} {api_user.last_name}
+        {api_user.title}
+        """
+    )
+
+
+class MissingIndexParameters(NamedTuple):
+    missing_index: Literal[
+        "completion_date_construction_price_index_missing",
+        "completion_date_market_price_index_missing",
+        "current_date_construction_price_index_missing",
+        "current_date_market_price_index_missing",
+        "surface_area_price_ceiling_missing",
+    ]
+    error: str
+    message: str
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    **parametrize_helper(
+        {
+            "completion_date_construction_price_index_missing": MissingIndexParameters(
+                missing_index="completion_date_construction_price_index_missing",
+                error="cpi2005eq100.2022-01",
+                message="One or more indices required for max price calculation is missing.",
+            ),
+            "completion_date_market_price_index_missing": MissingIndexParameters(
+                missing_index="completion_date_market_price_index_missing",
+                error="mpi2005eq100.2022-01",
+                message="One or more indices required for max price calculation is missing.",
+            ),
+            "current_date_construction_price_index_missing": MissingIndexParameters(
+                missing_index="current_date_construction_price_index_missing",
+                error="cpi2005eq100.2022-01",
+                message="One or more indices required for max price calculation is missing.",
+            ),
+            "current_date_market_price_index_missing": MissingIndexParameters(
+                missing_index="current_date_market_price_index_missing",
+                error="mpi2005eq100.2022-01",
+                message="One or more indices required for max price calculation is missing.",
+            ),
+            "surface_area_price_ceiling_missing": MissingIndexParameters(
+                missing_index="surface_area_price_ceiling_missing",
+                error="sapc.2022-01",
+                message="One or more indices required for max price calculation is missing.",
+            ),
+        }
+    )
+)
+def test__api__unconfirmed_max_price_pdf__indices_missing(
+    api_client: HitasAPIClient,
+    freezer,
+    missing_index: str,
+    error: str,
+    message: str,
+):
+    freezer.move_to("2022-01-01")
+
+    apartment: Apartment = ApartmentFactory.create(
+        completion_date=datetime.date(2021, 1, 1),
+        additional_work_during_construction=5000,
+        interest_during_construction_6=1000,
+        interest_during_construction_14=2000,
+        surface_area=50,
+        building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
+        sales__purchase_price=80000,
+        sales__apartment_share_of_housing_company_loans=15000,
+    )
+
+    this_month = datetime.date.today().replace(day=1)
+    completion_month = apartment.completion_date.replace(day=1)
+
+    # Completion month indices
+    if missing_index != "completion_date_construction_price_index_missing":
+        ConstructionPriceIndex2005Equal100Factory.create(month=completion_month, value=100)
+    if missing_index != "completion_date_market_price_index_missing":
+        MarketPriceIndex2005Equal100Factory.create(month=completion_month, value=200)
+
+    # Current month indices
+    if missing_index != "current_date_construction_price_index_missing":
+        ConstructionPriceIndex2005Equal100Factory.create(month=this_month, value=150)
+    if missing_index != "current_date_market_price_index_missing":
+        MarketPriceIndex2005Equal100Factory.create(month=this_month, value=250)
+    if missing_index != "surface_area_price_ceiling_missing":
+        SurfaceAreaPriceCeilingFactory.create(month=this_month, value=3000)
+
+    url = reverse(
+        "hitas:apartment-download-latest-unconfirmed-prices",
+        kwargs={"housing_company_uuid": apartment.housing_company.uuid.hex, "uuid": apartment.uuid.hex},
+    )
+
+    data = {
+        "request_date": "2022-01-01",
+        "additional_info": "This is additional information",
+    }
+
+    response = api_client.post(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_409_CONFLICT, response.json()
+    assert response.json() == {
+        "error": error,
+        "message": message,
+        "reason": "Conflict",
+        "status": 409,
+    }
+
+
+@pytest.mark.django_db
+def test__api__unconfirmed_max_price_pdf__past_date(api_client: HitasAPIClient, freezer):
+    freezer.move_to("2022-01-01")
+    api_user: User = api_client.handler._force_user
+
+    apartment: Apartment = ApartmentFactory.create(
+        completion_date=datetime.date(2021, 1, 1),
+        additional_work_during_construction=5000,
+        interest_during_construction_6=1000,
+        interest_during_construction_14=2000,
+        surface_area=50,
+        building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
+        sales__purchase_price=80000,
+        sales__apartment_share_of_housing_company_loans=15000,
+    )
+
+    ownership: Ownership = apartment.latest_sale(include_first_sale=True).ownerships.first()
+
+    this_month = datetime.date.today().replace(day=1)
+    past_month = datetime.date(2021, 5, 1)
+    completion_month = apartment.completion_date.replace(day=1)
+
+    # Completion month indices
+    ConstructionPriceIndex2005Equal100Factory.create(month=completion_month, value=100)
+    MarketPriceIndex2005Equal100Factory.create(month=completion_month, value=200)
+    # Past month indices
+    ConstructionPriceIndex2005Equal100Factory.create(month=past_month, value=150)
+    MarketPriceIndex2005Equal100Factory.create(month=past_month, value=250)
+    SurfaceAreaPriceCeilingFactory.create(month=past_month, value=3000)
+    # Current month indices (should not be used in calculation)
+    ConstructionPriceIndex2005Equal100Factory.create(month=this_month, value=200)
+    MarketPriceIndex2005Equal100Factory.create(month=this_month, value=300)
+    SurfaceAreaPriceCeilingFactory.create(month=this_month, value=4000)
+
+    url = reverse(
+        "hitas:apartment-download-latest-unconfirmed-prices",
+        kwargs={"housing_company_uuid": apartment.housing_company.uuid.hex, "uuid": apartment.uuid.hex},
+    )
+
+    data = {
+        "request_date": "2022-01-01",
+        "calculation_date": past_month.isoformat(),
+        "additional_info": "This is additional information",
+    }
+
+    response = api_client.post(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response["content-type"] == "application/pdf"
+
+    letter = PdfReader(BytesIO(response.content))
+    assert len(letter.pages) == 1
+
+    page_1 = letter.pages[0].extract_text()
+    page_1 = cleandoc("\n".join(item.strip() for item in page_1.split("\n")))
+
+    assert page_1 == cleandoc(
+        f"""
+        01.01.2022
+        Postiosoite
+        Käyntiosoite
+        Puh. (09) 310 13033
+        Asuntopalvelut
+        Työpajankatu 8
+        Email hitas@hel.fi
+        PL 58231
+        00580 Helsinki
+        Url http://www.hel.fi/hitas
+        00099 HELSINGIN KAUPUNKI
+        Helsingin kaupunki
+        {apartment.address}
+        {apartment.postal_code.value} HELSINKI
+        HITAS-HUONEISTON ENIMMÄISHINTA
+        \x7f ilman yhtiökohtaisia parannuksia ja mahdollista yhtiölainaosuutta
+        Omistaja ja omistusosuus (%)
+        {ownership.owner.name}
+        {float(ownership.percentage):.2f}
+
+        Asunto-osakeyhtiö
+        {apartment.housing_company.display_name}, Helsinki
+        Huoneiston osoite
+        {apartment.address}, {apartment.postal_code.value} HELSINKI
+        Huoneiston valmistumisajankohta
+        {apartment.completion_date.strftime("%d.%m.%Y")}
+        Huoneiston ensimmäinen kaupantekoajankohta
+        {apartment.first_sale().purchase_date.strftime("%d.%m.%Y")}
+        Alkuperäinen velaton hankintahinta, euroa
+        95 000,00
+        Rakennuttajalta tilatut lisä- ja muutostyöt
+        5 000,00
+        Rakennusaikainen korko, euroa
+        1 000,00
+        Hitas-huoneiston hinta rakennuskustannusindeksillä
+        laskettuna, euroa
+        150 000,00
+        This is additional information
+        Hitas-huoneistonne velaton enimmäishinta on 150 000 euroa rakennuskustannusindeksillä laskettuna.
+        Mikäli tarvitsette huoneistonne vahvistetun enimmäishinnan, teidän tulee toimittaa isännöitsijäntodistus tai
+        Hitas-enimmäishinnan vahvistamislomake. Näiden tietojen perusteella vahvistetaan huoneistonne lopullinen
+        enimmäishinta. Laskelma tulee huoneistoa myytäessä esittää ostajille.
+        Teillä on mahdollisuus myydä huoneistonne myös ilman enimmäishinnan vahvistamista enintään kaupantekoajankohtana
+        voimassaolevalla rajahinnalla. Rajahinnan alittavasta velattomasta huoneiston hinnasta voidaan myyjän ja ostajan välillä
+        sopia vapaasti.
+        Mikäli osakkeisiin kohdistuu yhtiölainaosuutta, tulee sen osuus vähentää huoneiston velattomasta hinnasta kauppahintaa
+        laskettaessa.
+        Rajahintaa tarkistetaan neljännesvuosittain 1.2., 1.5., 1.8. ja 1.11. ja se on voimassa kolme kuukautta kerrallaan.
+        {api_user.first_name} {api_user.last_name}
+        {api_user.title}
+        """
+    )
+
+
+@pytest.mark.django_db
+def test__api__unconfirmed_max_price_pdf__request_date_in_the_future(api_client: HitasAPIClient, freezer):
+    freezer.move_to("2022-01-01")
+
+    apartment: Apartment = ApartmentFactory.create(
+        completion_date=datetime.date(2021, 1, 1),
+        additional_work_during_construction=5000,
+        interest_during_construction_6=1000,
+        interest_during_construction_14=2000,
+        surface_area=50,
+        building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
+        sales__purchase_price=80000,
+        sales__apartment_share_of_housing_company_loans=15000,
+    )
+
+    past_month = datetime.date(2021, 5, 1)
+    future_month = datetime.date(2022, 5, 1)
+
+    url = reverse(
+        "hitas:apartment-download-latest-unconfirmed-prices",
+        kwargs={"housing_company_uuid": apartment.housing_company.uuid.hex, "uuid": apartment.uuid.hex},
+    )
+
+    data = {
+        "request_date": future_month.isoformat(),
+        "calculation_date": past_month.isoformat(),
+        "additional_info": "This is additional information",
+    }
+
+    response = api_client.post(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.json() == {
+        "error": "bad_request",
+        "fields": [
+            {
+                "field": "request_date",
+                "message": "Date cannot be in the future.",
+            },
+        ],
+        "message": "Bad request",
+        "reason": "Bad Request",
+        "status": 400,
+    }
+
+
+@pytest.mark.django_db
+def test__api__unconfirmed_max_price_pdf__calculation_date_in_the_future(api_client: HitasAPIClient, freezer):
+    freezer.move_to("2022-01-01")
+
+    apartment: Apartment = ApartmentFactory.create(
+        completion_date=datetime.date(2021, 1, 1),
+        additional_work_during_construction=5000,
+        interest_during_construction_6=1000,
+        interest_during_construction_14=2000,
+        surface_area=50,
+        building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
+        sales__purchase_price=80000,
+        sales__apartment_share_of_housing_company_loans=15000,
+    )
+
+    future_month = datetime.date(2022, 5, 1)
+
+    url = reverse(
+        "hitas:apartment-download-latest-unconfirmed-prices",
+        kwargs={"housing_company_uuid": apartment.housing_company.uuid.hex, "uuid": apartment.uuid.hex},
+    )
+
+    data = {
+        "request_date": "2022-01-01",
+        "calculation_date": future_month.isoformat(),
+        "additional_info": "This is additional information",
+    }
+
+    response = api_client.post(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.json() == {
+        "error": "bad_request",
+        "fields": [
+            {
+                "field": "calculation_date",
+                "message": "Date cannot be in the future.",
+            },
+        ],
+        "message": "Bad request",
+        "reason": "Bad Request",
+        "status": 400,
+    }

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -996,16 +996,16 @@ class ConfirmedPriceSerializer(serializers.Serializer):
     @staticmethod
     def validate_request_date(value):
         if value > timezone.now().date():
-            raise serializers.ValidationError("Request date cannot be in the future.")
+            raise serializers.ValidationError("Date cannot be in the future.")
         return value
 
 
 class UnconfirmedPriceSerializer(ConfirmedPriceSerializer):
-    calculation_date = serializers.DateField(default=timezone.now().date())
+    calculation_date = serializers.DateField(default=lambda: timezone.now().date())
     additional_info = serializers.CharField(required=False, allow_blank=True, default="")
 
     @staticmethod
     def validate_calculation_date(value):
         if value > timezone.now().date():
-            raise serializers.ValidationError("Request date cannot be in the future.")
+            raise serializers.ValidationError("Date cannot be in the future.")
         return value

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1100,7 +1100,10 @@ paths:
                   description: When was this document requested?
                   type: string
                   format: date
-                  example: Example text
+                calculation_date:
+                  description: Date to use in calculation. Default is today.
+                  type: string
+                  format: date
                 additional_info:
                   description: Additional textual information to be displayed on the generated PDF
                   type: string

--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -80,12 +80,17 @@ const getFetchInit = () => {
 export const downloadApartmentUnconfirmedMaximumPricePDF = (
     apartment: IApartmentDetails,
     requestDate: string,
-    additionalInfo?: string
+    additionalInfo?: string,
+    calculationDate?: string
 ) => {
     const url = `${Config.api_v1_url}/housing-companies/${apartment.links.housing_company.id}/apartments/${apartment.id}/reports/download-latest-unconfirmed-prices`;
     const init = {
         ...getFetchInit(),
-        body: JSON.stringify({additional_info: additionalInfo, request_date: requestDate}),
+        body: JSON.stringify({
+            additional_info: additionalInfo,
+            request_date: requestDate,
+            calculation_date: calculationDate,
+        }),
     };
     fetch(url, init)
         .then(handleDownloadPDF)

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -186,7 +186,9 @@ interface DownloadModalProps {
 
 const UnconfirmedPricesDownloadModal = ({apartment, isVisible, setIsVisible}: DownloadModalProps) => {
     const formRef = useRef<HTMLFormElement>(null);
-    const downloadForm = useForm({defaultValues: {request_date: today(), additional_info: ""}});
+    const downloadForm = useForm({
+        defaultValues: {calculation_date: today(), request_date: today(), additional_info: ""},
+    });
     const {handleSubmit} = downloadForm;
     const handleDownloadButtonClick = () => {
         formRef.current && formRef.current.dispatchEvent(new Event("submit", {cancelable: true, bubbles: true}));
@@ -194,8 +196,9 @@ const UnconfirmedPricesDownloadModal = ({apartment, isVisible, setIsVisible}: Do
     const onSubmit = () => {
         downloadApartmentUnconfirmedMaximumPricePDF(
             apartment,
+            downloadForm.getValues("request_date"),
             downloadForm.getValues("additional_info"),
-            downloadForm.getValues("request_date")
+            downloadForm.getValues("calculation_date")
         );
         setIsVisible(false);
     };
@@ -218,18 +221,26 @@ const UnconfirmedPricesDownloadModal = ({apartment, isVisible, setIsVisible}: Do
                     ref={formRef}
                     onSubmit={handleSubmit(onSubmit)}
                 >
+                    <DateInput
+                        name="calculation_date"
+                        label="Hinta-arvion päivämäärä"
+                        formObject={downloadForm}
+                        maxDate={new Date()}
+                        tooltipText="Päivämäärä jolle hinta-arvio lasketaan."
+                        required
+                    />
                     <TextAreaInput
                         name="additional_info"
                         label="Lisätietoja"
                         formObject={downloadForm}
-                        tooltipText="Lisätietokenttään kirjoitetaan, jos laskelmassa on jotain erityistä, mitä osakkaan on syytä tietää. Kentän teksti lisätään tulostettavaan hinta-arvio PDF:ään."
+                        tooltipText="Lisätietokenttään kirjoitetaan jos laskelmassa on jotain erityistä mitä osakkaan on syytä tietää. Kentän teksti lisätään hinta-arviotulosteeseen."
                     />
                     <DateInput
                         name="request_date"
                         label="Pyynnön vastaanottamispäivä"
                         formObject={downloadForm}
                         maxDate={new Date()}
-                        tooltipText="Päivämäärä, jolloin hinta-arvio pyyntö on vastaanotettu."
+                        tooltipText="Päivämäärä jolloin hinta-arvio pyyntö on vastaanotettu."
                         required
                     />
                 </form>


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds the ability to calculate max price estimates for past dates.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [x] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [ ] Make a max price calculation, setting the "Hinta-arvion päivämäärä" first to the present, and then to the past, and see the difference in reported price and surface area price ceiling.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-576, HT-577
