### PR TITLE
Don't allow removing conditions of sale between ownerships of the same owner

### DIFF
--- a/backend/hitas/services/condition_of_sale.py
+++ b/backend/hitas/services/condition_of_sale.py
@@ -70,9 +70,13 @@ def determine_conditions_of_sale(ownerships: list[Ownership]) -> list[ConditionO
 
         for other_ownership in ownerships:
             if (
+                # Don't create conditions of sale to unregulated housing companies.
                 other_ownership.apartment.housing_company.regulation_status != RegulationStatus.REGULATED
                 # Don't create circular conditions of sale
                 or ownership.id == other_ownership.id
+                # Don't create conditions of sale between two ownerships to the same apartment.
+                # They are in the same sale but for different owners.
+                or other_ownership.apartment == apartment
             ):
                 continue
 

--- a/backend/hitas/tests/apis/test_api_condition_of_sale.py
+++ b/backend/hitas/tests/apis/test_api_condition_of_sale.py
@@ -1265,11 +1265,17 @@ def test__api__condition_of_sale__update__invalid(api_client: HitasAPIClient, in
 
 
 @pytest.mark.django_db
-def test__api__condition_of_sale__delete(api_client: HitasAPIClient, freezer, settings):
+def test__api__condition_of_sale__delete__different_owners(api_client: HitasAPIClient, freezer, settings):
     freezer.move_to("2023-01-01 00:00:00+00:00")
     old_time = timezone.now()
 
-    condition_of_sale: ConditionOfSale = ConditionOfSaleFactory.create()
+    owner_1: Owner = OwnerFactory.create()
+    owner_2: Owner = OwnerFactory.create()
+
+    condition_of_sale: ConditionOfSale = ConditionOfSaleFactory.create(
+        new_ownership__owner=owner_1,
+        old_ownership__owner=owner_2,
+    )
 
     url = reverse(
         "hitas:conditions-of-sale-detail",
@@ -1278,6 +1284,7 @@ def test__api__condition_of_sale__delete(api_client: HitasAPIClient, freezer, se
         },
     )
     response_1 = api_client.delete(url)
+    # Deletion is allowed since the old and new owners are not the same (created through a household)
     assert response_1.status_code == status.HTTP_204_NO_CONTENT, response_1.json()
 
     freezer.move_to(old_time + settings.SHOW_FULFILLED_CONDITIONS_OF_SALE_FOR_MONTHS)
@@ -1291,6 +1298,33 @@ def test__api__condition_of_sale__delete(api_client: HitasAPIClient, freezer, se
     # Can't find it over 3 months after
     response_2 = api_client.get(url)
     assert response_2.status_code == status.HTTP_404_NOT_FOUND, response_2.json()
+
+
+@pytest.mark.django_db
+def test__api__condition_of_sale__delete__same_owners(api_client: HitasAPIClient, settings):
+    owner: Owner = OwnerFactory.create()
+
+    condition_of_sale: ConditionOfSale = ConditionOfSaleFactory.create(
+        new_ownership__owner=owner,
+        old_ownership__owner=owner,
+    )
+
+    url = reverse(
+        "hitas:conditions-of-sale-detail",
+        kwargs={
+            "uuid": condition_of_sale.uuid.hex,
+        },
+    )
+    response = api_client.delete(url)
+    # Deletion is not allowed since the old and new owners are the same (created through a sale)
+    assert response.status_code == status.HTTP_409_CONFLICT, response.json()
+
+    assert response.json() == {
+        "error": "invalid",
+        "message": "Cannot delete condition of sale between the same owner.",
+        "reason": "Conflict",
+        "status": 409,
+    }
 
 
 @pytest.mark.django_db

--- a/backend/hitas/views/condition_of_sale.py
+++ b/backend/hitas/views/condition_of_sale.py
@@ -8,6 +8,7 @@ from enumfields.drf import EnumField, EnumSupportSerializerMixin
 from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer
 
+from hitas.exceptions import ModelConflict
 from hitas.models.apartment import Apartment
 from hitas.models.condition_of_sale import ConditionOfSale, GracePeriod
 from hitas.models.owner import Owner
@@ -129,6 +130,12 @@ class ConditionOfSaleViewSet(HitasModelViewSet):
     serializer_class = ConditionOfSaleSerializer
     create_serializer_class = ConditionOfSaleCreateSerializer
     model_class = ConditionOfSale
+
+    def perform_destroy(self, instance: ConditionOfSale) -> None:
+        if instance.new_ownership.owner == instance.old_ownership.owner:
+            raise ModelConflict("Cannot delete condition of sale between the same owner.", error_code="invalid")
+
+        super().perform_destroy(instance)
 
     def get_queryset(self):
         return condition_of_sale_queryset()

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2358,6 +2358,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

Don't allow removing conditions of sale between ownerships of the same owner.

Also fixes a bug that would create a condition of sale between two owners to the same new apartment (two people buying the same new apartment), creating a lock that could not be resolved.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] Try to delete conditions of sale created through sales. This should not be allowed.
- [ ] Try to delete conditions of sale created manually though households. These should be allowed.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-579
