### PR TITLE
Handle half hitas

### DIFF
--- a/backend/hitas/services/owner.py
+++ b/backend/hitas/services/owner.py
@@ -1,8 +1,10 @@
+from dateutil.relativedelta import relativedelta
 from django.db import models
-from django.db.models import Count, OuterRef, QuerySet
+from django.db.models import Count, Max, OuterRef, Q, QuerySet, Subquery
 from django.db.models.functions import Coalesce
+from django.utils import timezone
 
-from hitas.models.housing_company import RegulationStatus
+from hitas.models.housing_company import HitasType, RegulationStatus
 from hitas.models.owner import Owner, OwnerT
 from hitas.models.ownership import Ownership
 from hitas.utils import SQSum
@@ -11,7 +13,7 @@ from hitas.utils import SQSum
 def obfuscate_owners_without_regulated_apartments() -> list[OwnerT]:
     """Remove any personal information from owners which do not own any regulated hitas apartments."""
     owners: QuerySet[Owner] = Owner.objects.annotate(
-        owned_regulated_housing_companies=Coalesce(
+        _owned_regulated_apartments=Coalesce(
             SQSum(
                 queryset=(
                     Ownership.objects.select_related(
@@ -31,11 +33,34 @@ def obfuscate_owners_without_regulated_apartments() -> list[OwnerT]:
                 sum_field="__count",
             ),
             0,
-        )
-    ).filter(owned_regulated_housing_companies=0)
+        ),
+        _latest_half_hitas_sale_purchase_date=Subquery(
+            queryset=(
+                Ownership.objects.select_related(
+                    "owner",
+                    "sale__apartment__building__real_estate__housing_company",
+                )
+                .filter(
+                    owner__id=OuterRef("id"),
+                    sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.HALF_HITAS,
+                )
+                .annotate(_latest_purchase_date=Max("sale__purchase_date"))
+                .values_list("_latest_purchase_date", flat=True)
+            ),
+            output_field=models.DateField(null=True),
+        ),
+    ).filter(
+        (
+            # If owner owns any half-hitas apartments, they must have been purchased
+            # at least 2 years ago so that the owner is allowed to be obfuscated
+            Q(_latest_half_hitas_sale_purchase_date__isnull=True)
+            | Q(_latest_half_hitas_sale_purchase_date__lte=timezone.now().date() - relativedelta(years=2))
+        ),
+        _owned_regulated_apartments=0,
+    )
 
     # 'non_disclosure' needs to be included temporarily so that we can determine
-    # if obfuscation is needed in 'owner.post_fetch_hook'
+    # if obfuscation is needed in 'hitas.models.owner.Owner.post_fetch_values_hook'
     obfuscated_owners: list[OwnerT] = list(owners.values("name", "identifier", "email", "non_disclosure"))
 
     if obfuscated_owners:

--- a/backend/hitas/tests/apis/test_api_apartment_sale.py
+++ b/backend/hitas/tests/apis/test_api_apartment_sale.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from hitas.models import Apartment, ApartmentSale, ConditionOfSale, Owner, Ownership
-from hitas.models.housing_company import RegulationStatus
+from hitas.models.housing_company import HitasType, RegulationStatus
 from hitas.tests.apis.helpers import HitasAPIClient, InvalidInput, parametrize_helper
 from hitas.tests.factories import (
     ApartmentFactory,
@@ -169,6 +169,7 @@ def test__api__apartment_sale__retrieve(api_client: HitasAPIClient):
 def test__api__apartment_sale__create(api_client: HitasAPIClient):
     apartment: Apartment = ApartmentFactory.create(
         building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         sales=[],
     )
     owner: Owner = OwnerFactory.create()
@@ -227,6 +228,7 @@ def test__api__apartment_sale__create(api_client: HitasAPIClient):
 def test__api__apartment_sale__create__multiple_owners(api_client: HitasAPIClient):
     apartment: Apartment = ApartmentFactory.create(
         building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         sales=[],
     )
     owner_1: Owner = OwnerFactory.create()
@@ -519,6 +521,7 @@ def test__api__apartment_sale__create__multiple_owners(api_client: HitasAPIClien
 def test__api__apartment_sale__create__invalid_data(api_client: HitasAPIClient, invalid_data: dict, fields: list):
     apartment: Apartment = ApartmentFactory.create(
         building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     owner: Owner = OwnerFactory.create()
 
@@ -572,6 +575,7 @@ def test__api__apartment_sale__create__replace_old_ownerships(api_client: HitasA
 
     apartment: Apartment = ApartmentFactory.create(
         building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         completion_date=datetime.date(2022, 1, 1),
         sales=[],
     )
@@ -633,11 +637,13 @@ def test__api__apartment_sale__create__condition_of_sale_fulfilled(api_client: H
     owner_2: Owner = OwnerFactory.create()
     new_ownership: Ownership = OwnershipFactory.create(
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         owner=owner_1,
         sale__purchase_date=datetime.date(2023, 1, 1),
     )
     old_ownership: Ownership = OwnershipFactory.create(
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         owner=owner_1,
         sale__purchase_date=datetime.date(2022, 1, 1),
     )
@@ -690,9 +696,11 @@ def test__api__apartment_sale__create__condition_of_sale_fulfilled(api_client: H
 def test__api__apartment_sale__create__new_apartment__create_condition_of_sale(api_client: HitasAPIClient):
     old_ownership: Ownership = OwnershipFactory.create(
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     new_apartment: Apartment = ApartmentFactory.create(
         building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         completion_date=None,
         sales=[],
     )
@@ -803,6 +811,7 @@ def test__api__apartment_sale__create__new_apartment__no_other_apartments(api_cl
     owner: Owner = OwnerFactory.create()
     new_apartment: Apartment = ApartmentFactory.create(
         building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         completion_date=None,
         sales=[],
     )
@@ -868,10 +877,12 @@ def test__api__apartment_sale__create__multiple_owners__new_apartment(api_client
     # One owner has an old apartment
     old_ownership: Ownership = OwnershipFactory.create(
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         owner=owner_1,
     )
     new_apartment: Apartment = ApartmentFactory.create(
         building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         completion_date=None,
         sales=[],
     )
@@ -944,12 +955,14 @@ def test__api__apartment_sale__create__new_apartment__is_new_before_cos_fulfille
     owner: Owner = OwnerFactory.create()
     old_apartment: Apartment = ApartmentFactory.create(
         building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         completion_date=datetime.date(2022, 1, 1),
         sales__purchase_date=datetime.date(2022, 1, 1),
         sales__ownerships__owner=owner,
     )
     new_apartment: Apartment = ApartmentFactory.create(
         building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         completion_date=datetime.date(2022, 1, 1),
         sales=[],
     )
@@ -1022,6 +1035,7 @@ def test__api__apartment_sale__create__second_sale_sets_last_latest_purchase_dat
     owner: Owner = OwnerFactory.create()
     new_apartment: Apartment = ApartmentFactory.create(
         building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         sales=[],
     )
 
@@ -1089,6 +1103,7 @@ def test__api__apartment_sale__create__second_sale_sets_last_latest_purchase_dat
 def test__api__apartment_sale__create__second_sale_older_than_first(api_client: HitasAPIClient):
     apartment: Apartment = ApartmentFactory.create(
         building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         sales=[],
     )
     owner: Owner = OwnerFactory.create()
@@ -1140,6 +1155,7 @@ def test__api__apartment_sale__create__second_sale_older_than_first(api_client: 
 def test__api__apartment_sale__create__cannot_sell_unregulated_apartment(api_client: HitasAPIClient):
     apartment: Apartment = ApartmentFactory.create(
         building__real_estate__housing_company__regulation_status=RegulationStatus.RELEASED_BY_HITAS,
+        building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         sales=[],
     )
     owner: Owner = OwnerFactory.create()
@@ -1175,6 +1191,69 @@ def test__api__apartment_sale__create__cannot_sell_unregulated_apartment(api_cli
         "reason": "Conflict",
         "status": 409,
     }
+
+
+@pytest.mark.django_db
+def test__api__apartment_sale__create__half_hitas__last_apartment_sold(api_client: HitasAPIClient):
+    apartment_1: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        building__real_estate__housing_company__hitas_type=HitasType.HALF_HITAS,
+        sales=[],
+    )
+    apartment_2: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=apartment_1.housing_company,
+        sales=[],
+    )
+
+    owner: Owner = OwnerFactory.create()
+
+    data = {
+        "ownerships": [
+            {
+                "owner": {
+                    "id": owner.uuid.hex,
+                },
+                "percentage": 100.0,
+            },
+        ],
+        "notification_date": "2023-01-01",
+        "purchase_date": "2023-01-01",
+        "purchase_price": 100_000,
+        "apartment_share_of_housing_company_loans": 50_000,
+        "exclude_from_statistics": True,
+    }
+
+    # First apartment is sold
+    url_1 = reverse(
+        "hitas:apartment-sale-list",
+        kwargs={
+            "housing_company_uuid": apartment_1.housing_company.uuid.hex,
+            "apartment_uuid": apartment_1.uuid.hex,
+        },
+    )
+    response_1 = api_client.post(url_1, data=data, format="json")
+
+    assert response_1.status_code == status.HTTP_201_CREATED, response_1.json()
+
+    # Apartment housing company is still regulated
+    apartment_1.housing_company.refresh_from_db()
+    assert apartment_1.housing_company.regulation_status == RegulationStatus.REGULATED
+
+    # First apartment is sold
+    url_2 = reverse(
+        "hitas:apartment-sale-list",
+        kwargs={
+            "housing_company_uuid": apartment_2.housing_company.uuid.hex,
+            "apartment_uuid": apartment_2.uuid.hex,
+        },
+    )
+    response_2 = api_client.post(url_2, data=data, format="json")
+
+    assert response_2.status_code == status.HTTP_201_CREATED, response_2.json()
+
+    # Apartment housing company is now released from regulation
+    apartment_1.housing_company.refresh_from_db()
+    assert apartment_1.housing_company.regulation_status == RegulationStatus.RELEASED_BY_HITAS
 
 
 # Update tests

--- a/backend/hitas/tests/apis/test_api_apartment_sale.py
+++ b/backend/hitas/tests/apis/test_api_apartment_sale.py
@@ -1303,6 +1303,50 @@ def test__api__apartment_sale__create__half_hitas__dont_create_condition_of_sale
     assert len(conditions_of_sale) == 0
 
 
+@pytest.mark.django_db
+def test__api__apartment_sale__create__half_hitas__cant_resell(api_client: HitasAPIClient, freezer):
+    freezer.move_to("2023-01-01 00:00:00+00:00")
+
+    apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        building__real_estate__housing_company__hitas_type=HitasType.HALF_HITAS,
+        sales__purchase_date=datetime.date(2022, 1, 1),
+    )
+    owner: Owner = OwnerFactory.create()
+
+    data = {
+        "ownerships": [
+            {
+                "owner": {
+                    "id": owner.uuid.hex,
+                },
+                "percentage": 100.0,
+            },
+        ],
+        "notification_date": "2023-01-01",
+        "purchase_date": "2023-01-01",
+        "purchase_price": 100_000,
+        "apartment_share_of_housing_company_loans": 50_000,
+        "exclude_from_statistics": True,
+    }
+
+    url_1 = reverse(
+        "hitas:apartment-sale-list",
+        kwargs={
+            "housing_company_uuid": apartment.housing_company.uuid.hex,
+            "apartment_uuid": apartment.uuid.hex,
+        },
+    )
+    response = api_client.post(url_1, data=data, format="json")
+    assert response.status_code == status.HTTP_409_CONFLICT, response.json()
+    assert response.json() == {
+        "error": "invalid",
+        "message": "Cannot re-sell a half-hitas housing company apartment.",
+        "reason": "Conflict",
+        "status": 409,
+    }
+
+
 # Update tests
 
 

--- a/backend/hitas/tests/apis/test_api_apartment_sale.py
+++ b/backend/hitas/tests/apis/test_api_apartment_sale.py
@@ -167,7 +167,10 @@ def test__api__apartment_sale__retrieve(api_client: HitasAPIClient):
 
 @pytest.mark.django_db
 def test__api__apartment_sale__create(api_client: HitasAPIClient):
-    apartment: Apartment = ApartmentFactory.create(sales=[])
+    apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sales=[],
+    )
     owner: Owner = OwnerFactory.create()
 
     data = {
@@ -222,7 +225,10 @@ def test__api__apartment_sale__create(api_client: HitasAPIClient):
 
 @pytest.mark.django_db
 def test__api__apartment_sale__create__multiple_owners(api_client: HitasAPIClient):
-    apartment: Apartment = ApartmentFactory.create(sales=[])
+    apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sales=[],
+    )
     owner_1: Owner = OwnerFactory.create()
     owner_2: Owner = OwnerFactory.create()
 
@@ -511,7 +517,9 @@ def test__api__apartment_sale__create__multiple_owners(api_client: HitasAPIClien
 )
 @pytest.mark.django_db
 def test__api__apartment_sale__create__invalid_data(api_client: HitasAPIClient, invalid_data: dict, fields: list):
-    apartment: Apartment = ApartmentFactory.create()
+    apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+    )
     owner: Owner = OwnerFactory.create()
 
     data = {
@@ -562,7 +570,11 @@ def test__api__apartment_sale__create__invalid_data(api_client: HitasAPIClient, 
 def test__api__apartment_sale__create__replace_old_ownerships(api_client: HitasAPIClient, freezer):
     freezer.move_to("2023-01-01 00:00:00+00:00")
 
-    apartment: Apartment = ApartmentFactory.create(completion_date=datetime.date(2022, 1, 1), sales=[])
+    apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        completion_date=datetime.date(2022, 1, 1),
+        sales=[],
+    )
     owner_1: Owner = OwnerFactory.create()
     owner_2: Owner = OwnerFactory.create()
     owner_3: Owner = OwnerFactory.create()
@@ -619,8 +631,16 @@ def test__api__apartment_sale__create__replace_old_ownerships(api_client: HitasA
 def test__api__apartment_sale__create__condition_of_sale_fulfilled(api_client: HitasAPIClient):
     owner_1: Owner = OwnerFactory.create()
     owner_2: Owner = OwnerFactory.create()
-    new_ownership: Ownership = OwnershipFactory.create(owner=owner_1, sale__purchase_date=datetime.date(2023, 1, 1))
-    old_ownership: Ownership = OwnershipFactory.create(owner=owner_1, sale__purchase_date=datetime.date(2022, 1, 1))
+    new_ownership: Ownership = OwnershipFactory.create(
+        sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        owner=owner_1,
+        sale__purchase_date=datetime.date(2023, 1, 1),
+    )
+    old_ownership: Ownership = OwnershipFactory.create(
+        sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        owner=owner_1,
+        sale__purchase_date=datetime.date(2022, 1, 1),
+    )
     condition_of_sale: ConditionOfSale = ConditionOfSaleFactory.create(
         new_ownership=new_ownership,
         old_ownership=old_ownership,
@@ -672,9 +692,9 @@ def test__api__apartment_sale__create__new_apartment__create_condition_of_sale(a
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
     )
     new_apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
         completion_date=None,
         sales=[],
-        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
     )
 
     data = {
@@ -781,7 +801,11 @@ def test__api__apartment_sale__create__new_apartment__condition_of_sale_not_crea
 @pytest.mark.django_db
 def test__api__apartment_sale__create__new_apartment__no_other_apartments(api_client: HitasAPIClient):
     owner: Owner = OwnerFactory.create()
-    new_apartment: Apartment = ApartmentFactory.create(completion_date=None, sales=[])
+    new_apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        completion_date=None,
+        sales=[],
+    )
 
     data = {
         "ownerships": [
@@ -842,8 +866,15 @@ def test__api__apartment_sale__create__multiple_owners__new_apartment(api_client
     owner_2: Owner = OwnerFactory.create()
 
     # One owner has an old apartment
-    old_ownership: Ownership = OwnershipFactory.create(owner=owner_1)
-    new_apartment: Apartment = ApartmentFactory.create(completion_date=None, sales=[])
+    old_ownership: Ownership = OwnershipFactory.create(
+        sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        owner=owner_1,
+    )
+    new_apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        completion_date=None,
+        sales=[],
+    )
 
     data = {
         "ownerships": [
@@ -912,11 +943,13 @@ def test__api__apartment_sale__create__new_apartment__is_new_before_cos_fulfille
 
     owner: Owner = OwnerFactory.create()
     old_apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
         completion_date=datetime.date(2022, 1, 1),
         sales__purchase_date=datetime.date(2022, 1, 1),
         sales__ownerships__owner=owner,
     )
     new_apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
         completion_date=datetime.date(2022, 1, 1),
         sales=[],
     )
@@ -987,7 +1020,10 @@ def test__api__apartment_sale__create__new_apartment__is_new_before_cos_fulfille
 @pytest.mark.django_db
 def test__api__apartment_sale__create__second_sale_sets_last_latest_purchase_date(api_client: HitasAPIClient):
     owner: Owner = OwnerFactory.create()
-    new_apartment: Apartment = ApartmentFactory.create(sales=[])
+    new_apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sales=[],
+    )
 
     data = {
         "ownerships": [
@@ -1051,7 +1087,10 @@ def test__api__apartment_sale__create__second_sale_sets_last_latest_purchase_dat
 
 @pytest.mark.django_db
 def test__api__apartment_sale__create__second_sale_older_than_first(api_client: HitasAPIClient):
-    apartment: Apartment = ApartmentFactory.create(sales=[])
+    apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sales=[],
+    )
     owner: Owner = OwnerFactory.create()
 
     # Latest sale, which is later than the sale we are about to create
@@ -1095,6 +1134,47 @@ def test__api__apartment_sale__create__second_sale_older_than_first(api_client: 
     ownerships: list[Ownership] = list(Ownership.objects.all())
     assert len(ownerships) == 1
     assert ownerships[0].sale == sale
+
+
+@pytest.mark.django_db
+def test__api__apartment_sale__create__cannot_sell_unregulated_apartment(api_client: HitasAPIClient):
+    apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company__regulation_status=RegulationStatus.RELEASED_BY_HITAS,
+        sales=[],
+    )
+    owner: Owner = OwnerFactory.create()
+
+    data = {
+        "ownerships": [
+            {
+                "owner": {
+                    "id": owner.uuid.hex,
+                },
+                "percentage": 100.0,
+            },
+        ],
+        "notification_date": "2023-01-01",
+        "purchase_date": "2023-01-01",
+        "purchase_price": 100_000,
+        "apartment_share_of_housing_company_loans": 50_000,
+        "exclude_from_statistics": True,
+    }
+
+    url_1 = reverse(
+        "hitas:apartment-sale-list",
+        kwargs={
+            "housing_company_uuid": apartment.housing_company.uuid.hex,
+            "apartment_uuid": apartment.uuid.hex,
+        },
+    )
+    response = api_client.post(url_1, data=data, format="json")
+    assert response.status_code == status.HTTP_409_CONFLICT, response.json()
+    assert response.json() == {
+        "error": "invalid",
+        "message": "Cannot sell an unregulated apartment.",
+        "reason": "Conflict",
+        "status": 409,
+    }
 
 
 # Update tests

--- a/backend/hitas/tests/apis/test_api_condition_of_sale.py
+++ b/backend/hitas/tests/apis/test_api_condition_of_sale.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from rest_framework import status
 
 from hitas.models.condition_of_sale import ConditionOfSale, GracePeriod
-from hitas.models.housing_company import RegulationStatus
+from hitas.models.housing_company import HitasType, RegulationStatus
 from hitas.models.owner import Owner
 from hitas.models.ownership import Ownership
 from hitas.tests.apis.helpers import HitasAPIClient, InvalidInput, parametrize_helper
@@ -426,12 +426,14 @@ def test__api__condition_of_sale__create__single(api_client: HitasAPIClient, fre
         owner=owner,
         sale__apartment__completion_date=None,
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     old_ownership: Ownership = OwnershipFactory.create(
         owner=owner,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     # when:
@@ -487,12 +489,14 @@ def test__api__condition_of_sale__create__no_new_apartments(api_client: HitasAPI
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     OwnershipFactory.create(
         owner=owner,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     # when:
@@ -521,18 +525,21 @@ def test__api__condition_of_sale__create__some_already_exist(api_client: HitasAP
     new_ownership: Ownership = OwnershipFactory.create(
         owner=owner,
         sale__apartment__completion_date=None,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     old_ownership_1: Ownership = OwnershipFactory.create(
         owner=owner,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     old_ownership_2: Ownership = OwnershipFactory.create(
         owner=owner,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     ConditionOfSaleFactory.create(new_ownership=new_ownership, old_ownership=old_ownership_1)
 
@@ -568,18 +575,21 @@ def test__api__condition_of_sale__create__all_already_exist(api_client: HitasAPI
         owner=owner,
         sale__apartment__completion_date=None,
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     old_ownership_1: Ownership = OwnershipFactory.create(
         owner=owner,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     old_ownership_2: Ownership = OwnershipFactory.create(
         owner=owner,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     ConditionOfSaleFactory.create(new_ownership=new_ownership, old_ownership=old_ownership_1)
     ConditionOfSaleFactory.create(new_ownership=new_ownership, old_ownership=old_ownership_2)
@@ -617,12 +627,14 @@ def test__api__condition_of_sale__create__has_sales__in_the_future(api_client: H
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=timezone.now() + relativedelta(days=1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     old_ownership: Ownership = OwnershipFactory.create(
         owner=owner,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     # when:
@@ -656,12 +668,14 @@ def test__api__condition_of_sale__create__has_sales__in_the_past(api_client: Hit
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=timezone.now() - relativedelta(days=1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     OwnershipFactory.create(
         owner=owner,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     # when:
@@ -691,6 +705,7 @@ def test__api__condition_of_sale__create__only_one_old_apartment(api_client: Hit
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     # when:
@@ -719,6 +734,7 @@ def test__api__condition_of_sale__create__only_one_new_apartment(api_client: Hit
         owner=owner,
         sale__apartment__completion_date=None,
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     # when:
@@ -751,11 +767,13 @@ def test__api__condition_of_sale__create__household_of_two__one_has_new(api_clie
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     new_ownership: Ownership = OwnershipFactory.create(
         owner=owner_2,
         sale__apartment__completion_date=None,
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     # when:
@@ -792,16 +810,19 @@ def test__api__condition_of_sale__create__household_of_two__both_have_new(api_cl
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     new_ownership_1: Ownership = OwnershipFactory.create(
         owner=owner_1,
         sale__apartment__completion_date=None,
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     new_ownership_2: Ownership = OwnershipFactory.create(
         owner=owner_2,
         sale__apartment__completion_date=None,
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     # when:
@@ -844,16 +865,19 @@ def test__api__condition_of_sale__create__household_of_two__one_has_multiple_new
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     new_ownership_1: Ownership = OwnershipFactory.create(
         owner=owner_2,
         sale__apartment__completion_date=None,
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     new_ownership_2: Ownership = OwnershipFactory.create(
         owner=owner_2,
         sale__apartment__completion_date=None,
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     # when:
@@ -897,12 +921,14 @@ def test__api__condition_of_sale__create__household_of_two__neither_have_new(api
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     OwnershipFactory.create(
         owner=owner_2,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     # when:
@@ -933,14 +959,20 @@ def test__api__condition_of_sale__create__household_of_two__same_new_apartment(a
     owner_1_old_ownership: Ownership = OwnershipFactory.create(
         owner=owner_1,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
+        sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         sale__purchase_date=datetime.date(2022, 1, 1),
     )
     owner_1_new_ownership: Ownership = OwnershipFactory.create(
         owner=owner_1,
+        sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         sale__apartment__completion_date=None,
     )
     owner_2_new_ownership: Ownership = OwnershipFactory.create(
         owner=owner_2,
+        sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         sale__apartment=owner_1_new_ownership.sale.apartment,
     )
 
@@ -984,16 +1016,19 @@ def test__api__condition_of_sale__create__two_households(api_client: HitasAPICli
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     new_ownership_1: Ownership = OwnershipFactory.create(
         owner=owner_2,
         sale__apartment__completion_date=None,
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     new_ownership_2: Ownership = OwnershipFactory.create(
         owner=owner_3,
         sale__apartment__completion_date=None,
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     # when:
@@ -1111,12 +1146,14 @@ def test__api__condition_of_sale__create__not_if_flag_set(api_client: HitasAPICl
         owner=owner,
         sale__apartment__completion_date=None,
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     OwnershipFactory.create(
         owner=owner,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     # when:
@@ -1147,17 +1184,20 @@ def test__api__condition_of_sale__create__apartment_new_due_to_condition_of_sale
         owner=owner,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     new_ownership_2: Ownership = OwnershipFactory.create(
         owner=owner,
         sale__apartment__completion_date=None,
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     old_ownership: Ownership = OwnershipFactory.create(
         owner=owner,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     ConditionOfSaleFactory.create(new_ownership=new_ownership_1, old_ownership=old_ownership)
 
@@ -1195,12 +1235,50 @@ def test__api__condition_of_sale__create__not_if_not_regulated(api_client: Hitas
         owner=owner,
         sale__apartment__completion_date=None,
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     OwnershipFactory.create(
         owner=owner,
         sale__apartment__completion_date=datetime.date(2022, 1, 1),
         sale__purchase_date=datetime.date(2022, 1, 1),
         sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.RELEASED_BY_HITAS,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
+    )
+
+    # when:
+    # - New conditions of sale are created for this owner as a household
+    data = {"household": [owner.uuid.hex]}
+    url = reverse("hitas:conditions-of-sale-list")
+    response = api_client.post(url, data=data, format="json")
+
+    # then:
+    # - The response contains no conditions of sale
+    # - The database contains no conditions of sale
+    assert response.status_code == status.HTTP_201_CREATED, response.json()
+    assert len(response.json().get("conditions_of_sale", [])) == 0, response.json()
+    conditions_of_sale: list[ConditionOfSale] = list(ConditionOfSale.objects.all())
+    assert len(conditions_of_sale) == 0
+
+
+@pytest.mark.django_db
+def test__api__condition_of_sale__create__not_to_half_hitas(api_client: HitasAPIClient, freezer):
+    freezer.move_to("2023-01-01 00:00:00+00:00")
+
+    # given:
+    # - An owner with ownerships to one new half-hitas apartment and one old non-half-hitas apartment
+    owner: Owner = OwnerFactory.create()
+    OwnershipFactory.create(
+        owner=owner,
+        sale__apartment__completion_date=None,
+        sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.HALF_HITAS,
+    )
+    OwnershipFactory.create(
+        owner=owner,
+        sale__apartment__completion_date=datetime.date(2022, 1, 1),
+        sale__purchase_date=datetime.date(2022, 1, 1),
+        sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     # when:

--- a/backend/hitas/tests/apis/test_api_thirty_year_regulation.py
+++ b/backend/hitas/tests/apis/test_api_thirty_year_regulation.py
@@ -2986,3 +2986,255 @@ def test__api__regulation__conditions_of_sale_fulfilled(api_client: HitasAPIClie
     # When the old apartment is released from regulation, the condition of sale is fulfilled.
     condition_of_sale.refresh_from_db()
     assert condition_of_sale.fulfilled is not None
+
+
+@pytest.mark.django_db
+def test__api__regulation__owner_still_owns_half_hitas_apartment(api_client: HitasAPIClient, freezer):
+    day = datetime.datetime(2023, 2, 1)
+    freezer.move_to(day)
+
+    this_month = day.date()
+    previous_year_last_month = this_month - relativedelta(months=2)
+    regulation_month = this_month - relativedelta(years=30)
+    less_than_two_years_ago = this_month - relativedelta(years=2) + relativedelta(days=1)
+
+    # Create necessary indices
+    MarketPriceIndexFactory.create(month=regulation_month, value=100)
+    MarketPriceIndexFactory.create(month=this_month, value=200)
+    SurfaceAreaPriceCeilingFactory.create(month=this_month, value=5000)
+
+    # Sale for the apartment in a housing company that will be under regulation checking
+    # Index adjusted price for the housing company will be: (50_000 + 10_000) / 10 * (200 / 100) = 12_000
+    sale: ApartmentSale = ApartmentSaleFactory.create(
+        purchase_date=regulation_month,
+        purchase_price=50_000,
+        apartment_share_of_housing_company_loans=10_000,
+        apartment__surface_area=10,
+        apartment__completion_date=regulation_month,
+        apartment__building__real_estate__housing_company__postal_code__value="00001",
+        apartment__building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
+        apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+    )
+
+    owner: Owner = sale.ownerships.first().owner
+
+    # Sale in a half-hitas apartment for the same owner.
+    ApartmentSaleFactory.create(
+        purchase_date=less_than_two_years_ago,
+        exclude_from_statistics=True,
+        apartment__completion_date=less_than_two_years_ago,
+        apartment__building__real_estate__housing_company__postal_code__value="00001",
+        apartment__building__real_estate__housing_company__hitas_type=HitasType.HALF_HITAS,
+        apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.RELEASED_BY_HITAS,
+        ownerships__owner=owner,
+    )
+
+    # Apartment where sales happened in the previous year
+    apartment: Apartment = ApartmentFactory.create(
+        completion_date=previous_year_last_month,
+        building__real_estate__housing_company__postal_code__value="00001",
+        building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sales__purchase_date=previous_year_last_month,  # first sale, not counted
+    )
+
+    # Sale in the previous year, which affect the average price per square meter
+    # Average sales price will be: (4_000 + 900) / 1 = 4_900
+    ApartmentSaleFactory.create(
+        apartment=apartment,
+        purchase_date=previous_year_last_month + relativedelta(days=1),
+        purchase_price=4_000,
+        apartment_share_of_housing_company_loans=900,
+    )
+
+    # Create necessary external sales data (no external sales)
+    ExternalSalesData.objects.create(
+        calculation_quarter=to_quarter(previous_year_last_month),
+        quarter_1=QuarterData(quarter=to_quarter(previous_year_last_month - relativedelta(months=9)), areas=[]),
+        quarter_2=QuarterData(quarter=to_quarter(previous_year_last_month - relativedelta(months=6)), areas=[]),
+        quarter_3=QuarterData(quarter=to_quarter(previous_year_last_month - relativedelta(months=3)), areas=[]),
+        quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
+    )
+
+    url = reverse("hitas:thirty-year-regulation-list")
+
+    response = api_client.post(url, data={}, format="json")
+
+    #
+    # Since the housing company's index adjusted acquisition price is 12_000, which is higher than the
+    # surface area price ceiling of 5_000, the acquisition price will be used in the comparison.
+    #
+    # Since the average sales price per square meter for the area in the last year (4_900) is lower than the
+    # housing company's compared value (in this case the index adjusted acquisition price of 12_000),
+    # the company is released from regulation.
+    #
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == RegulationResults(
+        automatically_released=[],
+        released_from_regulation=[
+            ComparisonData(
+                id=sale.apartment.housing_company.uuid.hex,
+                display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
+                price=Decimal("12000.0"),
+                old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                    last_modified=this_month.isoformat(),
+                ),
+                letter_fetched=False,
+                current_regulation_status=RegulationStatus.RELEASED_BY_HITAS.value,
+            )
+        ],
+        stays_regulated=[],
+        skipped=[],
+        # Owner is not obfuscated since it has not been
+        # two years from the sale of the owner's half-hitas apartment.
+        obfuscated_owners=[],
+    )
+
+    #
+    # Check that the housing company was freed from regulation
+    #
+    sale.apartment.housing_company.refresh_from_db()
+    assert sale.apartment.housing_company.regulation_status == RegulationStatus.RELEASED_BY_HITAS
+
+
+@pytest.mark.django_db
+def test__api__regulation__owner_still_owns_half_hitas_apartment__over_2_years(api_client: HitasAPIClient, freezer):
+    day = datetime.datetime(2023, 2, 1)
+    freezer.move_to(day)
+
+    this_month = day.date()
+    previous_year_last_month = this_month - relativedelta(months=2)
+    regulation_month = this_month - relativedelta(years=30)
+    two_years_ago = this_month - relativedelta(years=2)
+
+    # Create necessary indices
+    MarketPriceIndexFactory.create(month=regulation_month, value=100)
+    MarketPriceIndexFactory.create(month=this_month, value=200)
+    SurfaceAreaPriceCeilingFactory.create(month=this_month, value=5000)
+
+    # Sale for the apartment in a housing company that will be under regulation checking
+    # Index adjusted price for the housing company will be: (50_000 + 10_000) / 10 * (200 / 100) = 12_000
+    sale: ApartmentSale = ApartmentSaleFactory.create(
+        purchase_date=regulation_month,
+        purchase_price=50_000,
+        apartment_share_of_housing_company_loans=10_000,
+        apartment__surface_area=10,
+        apartment__completion_date=regulation_month,
+        apartment__building__real_estate__housing_company__postal_code__value="00001",
+        apartment__building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
+        apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+    )
+
+    owner: Owner = sale.ownerships.first().owner
+
+    # Sale in a half-hitas apartment for the same owner.
+    ApartmentSaleFactory.create(
+        purchase_date=two_years_ago,
+        exclude_from_statistics=True,
+        apartment__completion_date=two_years_ago,
+        apartment__building__real_estate__housing_company__postal_code__value="00001",
+        apartment__building__real_estate__housing_company__hitas_type=HitasType.HALF_HITAS,
+        apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.RELEASED_BY_HITAS,
+        ownerships__owner=owner,
+    )
+
+    # Apartment where sales happened in the previous year
+    apartment: Apartment = ApartmentFactory.create(
+        completion_date=previous_year_last_month,
+        building__real_estate__housing_company__postal_code__value="00001",
+        building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
+        building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        sales__purchase_date=previous_year_last_month,  # first sale, not counted
+    )
+
+    # Sale in the previous year, which affect the average price per square meter
+    # Average sales price will be: (4_000 + 900) / 1 = 4_900
+    ApartmentSaleFactory.create(
+        apartment=apartment,
+        purchase_date=previous_year_last_month + relativedelta(days=1),
+        purchase_price=4_000,
+        apartment_share_of_housing_company_loans=900,
+    )
+
+    # Create necessary external sales data (no external sales)
+    ExternalSalesData.objects.create(
+        calculation_quarter=to_quarter(previous_year_last_month),
+        quarter_1=QuarterData(quarter=to_quarter(previous_year_last_month - relativedelta(months=9)), areas=[]),
+        quarter_2=QuarterData(quarter=to_quarter(previous_year_last_month - relativedelta(months=6)), areas=[]),
+        quarter_3=QuarterData(quarter=to_quarter(previous_year_last_month - relativedelta(months=3)), areas=[]),
+        quarter_4=QuarterData(quarter=to_quarter(previous_year_last_month), areas=[]),
+    )
+
+    url = reverse("hitas:thirty-year-regulation-list")
+
+    response = api_client.post(url, data={}, format="json")
+
+    #
+    # Since the housing company's index adjusted acquisition price is 12_000, which is higher than the
+    # surface area price ceiling of 5_000, the acquisition price will be used in the comparison.
+    #
+    # Since the average sales price per square meter for the area in the last year (4_900) is lower than the
+    # housing company's compared value (in this case the index adjusted acquisition price of 12_000),
+    # the company is released from regulation.
+    #
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == RegulationResults(
+        automatically_released=[],
+        released_from_regulation=[
+            ComparisonData(
+                id=sale.apartment.housing_company.uuid.hex,
+                display_name=sale.apartment.housing_company.display_name,
+                address=AddressInfo(
+                    street_address=sale.apartment.housing_company.street_address,
+                    postal_code=sale.apartment.housing_company.postal_code.value,
+                    city=sale.apartment.housing_company.postal_code.city,
+                ),
+                price=Decimal("12000.0"),
+                old_ruleset=sale.apartment.housing_company.hitas_type.old_hitas_ruleset,
+                completion_date=regulation_month.isoformat(),
+                property_manager=PropertyManagerInfo(
+                    id=sale.apartment.housing_company.property_manager.uuid.hex,
+                    name=sale.apartment.housing_company.property_manager.name,
+                    email=sale.apartment.housing_company.property_manager.email,
+                    address=AddressInfo(
+                        street_address=sale.apartment.housing_company.property_manager.street_address,
+                        postal_code=sale.apartment.housing_company.property_manager.postal_code,
+                        city=sale.apartment.housing_company.property_manager.city,
+                    ),
+                    last_modified=this_month.isoformat(),
+                ),
+                letter_fetched=False,
+                current_regulation_status=RegulationStatus.RELEASED_BY_HITAS.value,
+            )
+        ],
+        stays_regulated=[],
+        skipped=[],
+        obfuscated_owners=[
+            OwnerT(
+                name=owner.name,
+                identifier=owner.identifier,
+                email=owner.email,
+            ),
+        ],
+    )
+
+    #
+    # Check that the housing company was freed from regulation
+    #
+    sale.apartment.housing_company.refresh_from_db()
+    assert sale.apartment.housing_company.regulation_status == RegulationStatus.RELEASED_BY_HITAS

--- a/backend/hitas/views/apartment_sale.py
+++ b/backend/hitas/views/apartment_sale.py
@@ -88,6 +88,9 @@ class ApartmentSaleCreateSerializer(HitasModelSerializer):
         if apartment.housing_company.regulation_status != RegulationStatus.REGULATED:
             raise ModelConflict("Cannot sell an unregulated apartment.", error_code="invalid")
 
+        if apartment.housing_company.hitas_type == HitasType.HALF_HITAS and apartment.latest_purchase_date is not None:
+            raise ModelConflict("Cannot re-sell a half-hitas housing company apartment.", error_code="invalid")
+
         validated_data["apartment"] = apartment
 
         with transaction.atomic():

--- a/backend/hitas/views/apartment_sale.py
+++ b/backend/hitas/views/apartment_sale.py
@@ -7,10 +7,11 @@ from rest_framework import serializers
 
 from hitas.exceptions import HitasModelNotFound, ModelConflict
 from hitas.models.apartment import Apartment, ApartmentSale
-from hitas.models.housing_company import RegulationStatus
+from hitas.models.housing_company import HitasType, RegulationStatus
 from hitas.models.ownership import Ownership, OwnershipLike, check_ownership_percentages
 from hitas.services.apartment import get_latest_sale_purchase_date, prefetch_first_sale
 from hitas.services.condition_of_sale import create_conditions_of_sale
+from hitas.services.housing_company import get_number_of_unsold_apartments
 from hitas.services.validation import lookup_id_to_uuid, lookup_model_id_by_uuid
 from hitas.views.ownership import OwnershipSerializer
 from hitas.views.utils import HitasModelSerializer, HitasModelViewSet
@@ -117,6 +118,13 @@ class ApartmentSaleCreateSerializer(HitasModelSerializer):
                     for data in ownership_data
                 ],
             )
+
+            # Half hitas housing companies are released from regulation when their last apartment is sold.
+            if apartment.housing_company.hitas_type == HitasType.HALF_HITAS:
+                unsold_apartments = get_number_of_unsold_apartments(apartment.housing_company)
+                if unsold_apartments == 0:
+                    apartment.housing_company.regulation_status = RegulationStatus.RELEASED_BY_HITAS
+                    apartment.housing_company.save()
 
         self.context["conditions_of_sale_created"] = False
 

--- a/backend/hitas/views/apartment_sale.py
+++ b/backend/hitas/views/apartment_sale.py
@@ -128,11 +128,16 @@ class ApartmentSaleCreateSerializer(HitasModelSerializer):
 
         self.context["conditions_of_sale_created"] = False
 
-        if apartment.is_new:
+        if apartment.housing_company.hitas_type != HitasType.HALF_HITAS and apartment.is_new:
             owners = [ownership.owner for ownership in ownerships]
             prefetch_related_objects(
                 owners,
-                Prefetch("ownerships", Ownership.objects.select_related("sale__apartment")),
+                Prefetch(
+                    "ownerships",
+                    Ownership.objects.select_related("sale__apartment__building__real_estate__housing_company").exclude(
+                        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.HALF_HITAS,
+                    ),
+                ),
                 # Ignore the sale we just created so that apartments sold for the first time
                 # after they have been completed are treated as new at this moment.
                 prefetch_first_sale(lookup_prefix="ownerships__sale__apartment__", ignore=[instance.id]),

--- a/backend/hitas/views/condition_of_sale.py
+++ b/backend/hitas/views/condition_of_sale.py
@@ -11,6 +11,7 @@ from rest_framework.serializers import ModelSerializer
 from hitas.exceptions import ModelConflict
 from hitas.models.apartment import Apartment
 from hitas.models.condition_of_sale import ConditionOfSale, GracePeriod
+from hitas.models.housing_company import HitasType
 from hitas.models.owner import Owner
 from hitas.models.ownership import Ownership
 from hitas.services.apartment import prefetch_first_sale
@@ -98,7 +99,12 @@ class ConditionOfSaleCreateSerializer(serializers.Serializer):
         # conditions of sale between their ownerships
         owners = list(
             Owner.objects.prefetch_related(
-                Prefetch("ownerships", Ownership.objects.select_related("sale__apartment")),
+                Prefetch(
+                    "ownerships",
+                    Ownership.objects.select_related("sale__apartment__building__real_estate__housing_company").exclude(
+                        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.HALF_HITAS,
+                    ),
+                ),
                 prefetch_first_sale(lookup_prefix="ownerships__sale__apartment__"),
                 "ownerships__sale__apartment__sales__ownerships",
                 "ownerships__sale__apartment__sales__ownerships__conditions_of_sale_new",

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1738,6 +1738,8 @@ paths:
           $ref: '#/components/responses/NotFound'
         '406':
           $ref: '#/components/responses/NotAcceptable'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '415':
           $ref: '#/components/responses/UnsupportedMediaType'
         '500':


### PR DESCRIPTION
# Hitas Pull Request

# Description

Handle Half-Hitas housing company special cases:
- Apartment sales should not generate conditions of sale
- Housing company should be released from regulation immediately after their last apartment is sold
- Apartments should not be allowed to be resold
- Apartment owners should be obfuscated two years after the sale of the apartment (if they don't own any other apartments in regulated housing companies)

Also, disallow reselling apartments in housing companies that have been released from regulation.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] Check that rules addressed in the description are true

## Tickets

This pull request resolves all or part of the following ticket(s): HT-547
