### PR TITLE
Api for canceling sales

### DIFF
--- a/backend/hitas/models/apartment_sale.py
+++ b/backend/hitas/models/apartment_sale.py
@@ -4,12 +4,15 @@ from decimal import Decimal
 from auditlog.registry import auditlog
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+from safedelete import SOFT_DELETE_CASCADE
 
 from hitas.models._base import ExternalSafeDeleteHitasModel, HitasModelDecimalField
 
 
 # 'Asunnon myyntitapahtuma' / 'Kauppakirja' / 'Uusi myynti'
 class ApartmentSale(ExternalSafeDeleteHitasModel):
+    _safedelete_policy = SOFT_DELETE_CASCADE
+
     # 'Asunto'
     apartment = models.ForeignKey("Apartment", related_name="sales", on_delete=models.CASCADE, editable=False)
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1877,6 +1877,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

Make sale cancellation work properly.

Adds the following rules for sale cancellation:
- Sale cannot be canceled if it's not the latest sale
- Sale can always be canceled if the apartment has not been completed
- Sale must be at most three months old from the completion date or sale
  purchase date, whichever is later, in order to be cancellable

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] Try to cancel sales and observe the effects 

## Tickets

This pull request resolves all or part of the following ticket(s): HT-604