### PR TITLE
Add sales report endpoint

### DIFF
--- a/backend/hitas/services/apartment_sale.py
+++ b/backend/hitas/services/apartment_sale.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+from hitas.models import ApartmentSale
+
+
+def find_sales_on_interval_for_reporting(start_date: datetime.date, end_date: datetime.date) -> list[ApartmentSale]:
+    return list(
+        ApartmentSale.objects.select_related("apartment__building__real_estate__housing_company__postal_code")
+        .filter(
+            purchase_date__gte=start_date,
+            purchase_date__lte=end_date,
+            exclude_from_statistics=False,
+            apartment__building__real_estate__housing_company__exclude_from_statistics=False,
+        )
+        .order_by(
+            "apartment__building__real_estate__housing_company__postal_code__cost_area",
+            "apartment__building__real_estate__housing_company__postal_code__value",
+        )
+    )

--- a/backend/hitas/services/reports.py
+++ b/backend/hitas/services/reports.py
@@ -1,0 +1,212 @@
+import datetime
+import string
+from decimal import Decimal
+from functools import cache
+from statistics import mean
+from typing import Any, Callable, Iterable, NamedTuple, TypeVar
+
+from openpyxl.styles import Alignment, Border, Side
+from openpyxl.workbook import Workbook
+from openpyxl.worksheet.worksheet import Worksheet
+from rest_framework.exceptions import ValidationError
+from rest_framework.settings import api_settings
+
+from hitas.models import ApartmentSale
+from hitas.utils import format_sheet, resize_columns
+
+
+class SalesReportColumns(NamedTuple):
+    cost_area: int | str
+    postal_code: str
+    apartment_address: str
+    notification_date: datetime.date | str
+    purchase_date: datetime.date | str
+    purchase_price_per_square_meter: Decimal | str
+    total_price_per_square_meter: Decimal | str
+
+
+T = TypeVar("T")
+
+
+class SalesReportSummaryDefinition(NamedTuple):
+    func: Callable[[Iterable[T]], T]
+    title: str = ""
+    subtitle: str = ""
+
+
+def build_sales_report_excel(sales: list[ApartmentSale]) -> Workbook:
+    workbook = Workbook()
+    worksheet: Worksheet = workbook.active
+
+    column_headers = SalesReportColumns(
+        cost_area="Kalleusalue",
+        postal_code="Postinumero",
+        apartment_address="Osoite",
+        notification_date="Ilmoituspäivä",
+        purchase_date="Kauppapäivä",
+        purchase_price_per_square_meter="Kaupan neliöhinta",
+        total_price_per_square_meter="Velaton neliöhinta",
+    )
+    worksheet.append(column_headers)
+
+    for sale in sales:
+        if not sale.apartment.surface_area:
+            raise ValidationError(
+                detail={
+                    api_settings.NON_FIELD_ERRORS_KEY: (
+                        f"Surface are zero or missing for apartment {sale.apartment.address!r}. "
+                        f"Cannot calculate price per square meter."
+                    )
+                },
+            )
+
+        worksheet.append(
+            SalesReportColumns(
+                cost_area=sale.apartment.postal_code.cost_area,
+                postal_code=sale.apartment.postal_code.value,
+                apartment_address=sale.apartment.address,
+                notification_date=sale.notification_date,
+                purchase_date=sale.purchase_date,
+                purchase_price_per_square_meter=sale.purchase_price / sale.apartment.surface_area,
+                total_price_per_square_meter=sale.total_price / sale.apartment.surface_area,
+            )
+        )
+
+    last_row = worksheet.max_row
+    worksheet.auto_filter.ref = worksheet.dimensions
+
+    empty_row = SalesReportColumns(
+        cost_area="",
+        postal_code="",
+        apartment_address="",
+        notification_date="",
+        purchase_date="",
+        purchase_price_per_square_meter="",
+        total_price_per_square_meter="",
+    )
+
+    # There needs to be an empty row for sorting and filtering to work properly
+    worksheet.append(empty_row)
+
+    @cache
+    def unwrap_range(cell_range: str) -> list[Any]:
+        return [cell.value for row in worksheet[cell_range] for cell in row]
+
+    @cache
+    def conditional_range(value_range: str, **comparison_ranges_to_values: Any) -> list[Any]:
+        """
+        Returns values from `value_range` where the given comparison ranges
+        contain all values as indicated by the mapping.
+        """
+        comparison_values: list[Any] = list(comparison_ranges_to_values.values())
+        unwrapped_comparison_ranges = zip(*(unwrap_range(rang) for rang in comparison_ranges_to_values))
+        zipped_ranges = zip(unwrap_range(value_range), unwrapped_comparison_ranges, strict=True)
+        return [
+            value
+            for value, range_values in zipped_ranges
+            if all(range_value == comparison_values[i] for i, range_value in enumerate(range_values))
+        ]
+
+    summary_start = worksheet.max_row + 1
+
+    summary_rows: list[SalesReportSummaryDefinition] = [
+        SalesReportSummaryDefinition(
+            title="Kaikki kaupat",
+            subtitle="Lukumäärä",
+            func=lambda x: len(unwrap_range(x)),
+        ),
+        SalesReportSummaryDefinition(
+            subtitle="Summa",
+            func=lambda x: sum(unwrap_range(x)),
+        ),
+        SalesReportSummaryDefinition(
+            subtitle="Keskiarvo",
+            func=lambda x: mean(unwrap_range(x) or [0]),
+        ),
+        SalesReportSummaryDefinition(
+            subtitle="Maksimi",
+            func=lambda x: max(unwrap_range(x), default=0),
+        ),
+        SalesReportSummaryDefinition(
+            subtitle="Minimi",
+            func=lambda x: min(unwrap_range(x), default=0),
+        ),
+    ]
+
+    for cost_area in range(1, 5):
+        summary_rows += [
+            None,  # empty row
+            SalesReportSummaryDefinition(
+                title=f"Kalleusalue {cost_area}",
+                subtitle="Lukumäärä",
+                func=lambda x, y=cost_area: len(conditional_range(x, **{f"A2:A{last_row}": y})),
+            ),
+            SalesReportSummaryDefinition(
+                subtitle="Summa",
+                func=lambda x, y=cost_area: sum(conditional_range(x, **{f"A2:A{last_row}": y})),
+            ),
+            SalesReportSummaryDefinition(
+                subtitle="Keskiarvo",
+                func=lambda x, y=cost_area: mean(conditional_range(x, **{f"A2:A{last_row}": y}) or [0]),
+            ),
+            SalesReportSummaryDefinition(
+                subtitle="Maksimi",
+                func=lambda x, y=cost_area: max(conditional_range(x, **{f"A2:A{last_row}": y}), default=0),
+            ),
+            SalesReportSummaryDefinition(
+                subtitle="Minimi",
+                func=lambda x, y=cost_area: min(conditional_range(x, **{f"A2:A{last_row}": y}), default=0),
+            ),
+        ]
+
+    sales_count_rows: list[int] = []
+
+    for definition in summary_rows:
+        if definition is None:
+            worksheet.append(empty_row)
+            continue
+
+        if definition.subtitle == "Lukumäärä":
+            sales_count_rows.append(worksheet.max_row + 1)
+
+        worksheet.append(
+            SalesReportColumns(
+                cost_area="",
+                postal_code="",
+                apartment_address="",
+                notification_date=definition.title,
+                purchase_date=definition.subtitle,
+                purchase_price_per_square_meter=definition.func(f"F2:F{last_row}"),
+                total_price_per_square_meter=definition.func(f"G2:G{last_row}"),
+            ),
+        )
+
+    euro_per_square_meter_format = "#,##0.00\\ \\€\\/\\m²"
+    date_format = "DD.MM.YYYY"
+    column_letters = string.ascii_uppercase[: len(column_headers)]
+
+    format_sheet(
+        worksheet,
+        formatting_rules={
+            # Add a border to the header row
+            **{f"{letter}1": {"border": Border(bottom=Side(style="thin"))} for letter in column_letters},
+            # Add a border to the last data row
+            **{f"{letter}{last_row}": {"border": Border(bottom=Side(style="thin"))} for letter in column_letters},
+            # Align the summary titles to the right
+            **{
+                f"E{summary_start + i}": {"alignment": Alignment(horizontal="right")}
+                for i in range(0, len(summary_rows))
+            },
+            "B": {"alignment": Alignment(horizontal="right")},
+            "D": {"number_format": date_format},
+            "E": {"number_format": date_format},
+            "F": {"number_format": euro_per_square_meter_format},
+            "G": {"number_format": euro_per_square_meter_format},
+            # Reset number format for sales count cells
+            **{f"{letter}{row}": {"number_format": "General"} for row in sales_count_rows for letter in "FG"},
+        },
+    )
+
+    resize_columns(worksheet)
+    worksheet.protection.sheet = True
+    return workbook

--- a/backend/hitas/services/thirty_year_regulation.py
+++ b/backend/hitas/services/thirty_year_regulation.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import string
 from decimal import Decimal
 from itertools import chain
 from typing import TYPE_CHECKING, Iterable, Literal, NamedTuple, Optional, TypedDict
@@ -771,7 +772,7 @@ def build_thirty_year_regulation_report_excel(results: ThirtyYearRegulationResul
     workbook = Workbook()
     worksheet: Worksheet = workbook.active
 
-    columns = ReportColumns(
+    column_headers = ReportColumns(
         display_name="Yhtiö",
         acquisition_price="Hankinta-arvo",
         apartment_count="Huoneistoja",
@@ -785,7 +786,7 @@ def build_thirty_year_regulation_report_excel(results: ThirtyYearRegulationResul
         completion_date="Valmistumispäivä",
         age="Yhtiön ikä",
     )
-    worksheet.append(columns)
+    worksheet.append(column_headers)
 
     for row in results.rows.all():
         data = ReportColumns(
@@ -849,15 +850,17 @@ def build_thirty_year_regulation_report_excel(results: ThirtyYearRegulationResul
         )
 
     euro_format = "#,##0.00\\ €"
+    euro_per_square_meter_format = "#,##0.00\\ \\€\\/\\m²"
     square_meter_format = "#,##0.00\\ \\m\\²"
+    column_letters = string.ascii_uppercase[: len(column_headers)]
 
     format_sheet(
         worksheet,
         formatting_rules={
             # Add a border to the header row
-            **{f"{letter}1": {"border": Border(bottom=Side(style="thin"))} for letter in "ABCDEFGHIJKL"},
+            **{f"{letter}1": {"border": Border(bottom=Side(style="thin"))} for letter in column_letters},
             # Add a border to the last data row
-            **{f"{letter}{last_row}": {"border": Border(bottom=Side(style="thin"))} for letter in "ABCDEFGHIJKL"},
+            **{f"{letter}{last_row}": {"border": Border(bottom=Side(style="thin"))} for letter in column_letters},
             # Align the summary titles to the right
             **{
                 f"A{summary_start + i}": {"alignment": Alignment(horizontal="right")}
@@ -868,7 +871,7 @@ def build_thirty_year_regulation_report_excel(results: ThirtyYearRegulationResul
             "E": {"number_format": euro_format},
             "F": {"number_format": euro_format},
             "G": {"number_format": square_meter_format},
-            "H": {"number_format": euro_format},
+            "H": {"number_format": euro_per_square_meter_format},
             "I": {"number_format": euro_format},
             "J": {
                 "alignment": Alignment(horizontal="right"),

--- a/backend/hitas/tests/apis/test_api_reports.py
+++ b/backend/hitas/tests/apis/test_api_reports.py
@@ -1,0 +1,425 @@
+import datetime
+from io import BytesIO
+from urllib.parse import urlencode
+
+import pytest
+from django.http import HttpResponse
+from django.urls import reverse
+from openpyxl.reader.excel import load_workbook
+from openpyxl.workbook import Workbook
+from openpyxl.worksheet.worksheet import Worksheet
+from rest_framework import status
+
+from hitas.models import ApartmentSale
+from hitas.tests.apis.helpers import HitasAPIClient
+from hitas.tests.factories import ApartmentSaleFactory
+
+
+@pytest.mark.django_db
+def test__api__sales_report__single_sale(api_client: HitasAPIClient):
+    # Create sales in the report interval
+    sale: ApartmentSale = ApartmentSaleFactory.create(
+        purchase_date=datetime.date(2020, 1, 1),
+        purchase_price=50_000,
+        apartment_share_of_housing_company_loans=10_000,
+        apartment__surface_area=100,
+        apartment__building__real_estate__housing_company__postal_code__value="00001",
+        apartment__building__real_estate__housing_company__postal_code__cost_area=1,
+    )
+
+    data = {
+        "start_date": "2020-01-01",
+        "end_date": "2020-01-31",
+    }
+    url = reverse("hitas:sales-report-list") + "?" + urlencode(data)
+    response: HttpResponse = api_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    workbook: Workbook = load_workbook(BytesIO(response.content), data_only=False)
+    worksheet: Worksheet = workbook.worksheets[0]
+
+    assert list(worksheet.values) == [
+        (
+            "Kalleusalue",
+            "Postinumero",
+            "Osoite",
+            "Ilmoituspäivä",
+            "Kauppapäivä",
+            "Kaupan neliöhinta",
+            "Velaton neliöhinta",
+        ),
+        (
+            sale.apartment.postal_code.cost_area,
+            sale.apartment.postal_code.value,
+            sale.apartment.address,
+            datetime.datetime.fromisoformat(sale.notification_date.isoformat()),
+            datetime.datetime.fromisoformat(sale.purchase_date.isoformat()),
+            500,  # 50_000 / 100
+            600,  # (50_000 + 10_000) / 100
+        ),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kaikki kaupat", "Lukumäärä", 1, 1),
+        (None, None, None, None, "Summa", 500, 600),
+        (None, None, None, None, "Keskiarvo", 500, 600),
+        (None, None, None, None, "Maksimi", 500, 600),
+        (None, None, None, None, "Minimi", 500, 600),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 1", "Lukumäärä", 1, 1),
+        (None, None, None, None, "Summa", 500, 600),
+        (None, None, None, None, "Keskiarvo", 500, 600),
+        (None, None, None, None, "Maksimi", 500, 600),
+        (None, None, None, None, "Minimi", 500, 600),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 2", "Lukumäärä", 0, 0),
+        (None, None, None, None, "Summa", 0, 0),
+        (None, None, None, None, "Keskiarvo", 0, 0),
+        (None, None, None, None, "Maksimi", 0, 0),
+        (None, None, None, None, "Minimi", 0, 0),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 3", "Lukumäärä", 0, 0),
+        (None, None, None, None, "Summa", 0, 0),
+        (None, None, None, None, "Keskiarvo", 0, 0),
+        (None, None, None, None, "Maksimi", 0, 0),
+        (None, None, None, None, "Minimi", 0, 0),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 4", "Lukumäärä", 0, 0),
+        (None, None, None, None, "Summa", 0, 0),
+        (None, None, None, None, "Keskiarvo", 0, 0),
+        (None, None, None, None, "Maksimi", 0, 0),
+        (None, None, None, None, "Minimi", 0, 0),
+    ]
+
+
+@pytest.mark.django_db
+def test__api__sales_report__multiple_sales(api_client: HitasAPIClient):
+    # Create sales in the report interval
+    sale_1: ApartmentSale = ApartmentSaleFactory.create(
+        purchase_date=datetime.date(2020, 1, 1),
+        purchase_price=50_000,
+        apartment_share_of_housing_company_loans=10_000,
+        apartment__surface_area=100,
+        apartment__building__real_estate__housing_company__postal_code__value="00001",
+        apartment__building__real_estate__housing_company__postal_code__cost_area=1,
+    )
+    sale_2: ApartmentSale = ApartmentSaleFactory.create(
+        purchase_date=datetime.date(2020, 1, 15),
+        purchase_price=130_000,
+        apartment_share_of_housing_company_loans=100,
+        apartment__surface_area=100,
+        apartment__building__real_estate__housing_company__postal_code__value="00002",
+        apartment__building__real_estate__housing_company__postal_code__cost_area=1,
+    )
+
+    data = {
+        "start_date": "2020-01-01",
+        "end_date": "2020-01-31",
+    }
+    url = reverse("hitas:sales-report-list") + "?" + urlencode(data)
+    response: HttpResponse = api_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    workbook: Workbook = load_workbook(BytesIO(response.content), data_only=False)
+    worksheet: Worksheet = workbook.worksheets[0]
+
+    assert list(worksheet.values) == [
+        (
+            "Kalleusalue",
+            "Postinumero",
+            "Osoite",
+            "Ilmoituspäivä",
+            "Kauppapäivä",
+            "Kaupan neliöhinta",
+            "Velaton neliöhinta",
+        ),
+        (
+            sale_1.apartment.postal_code.cost_area,
+            sale_1.apartment.postal_code.value,
+            sale_1.apartment.address,
+            datetime.datetime.fromisoformat(sale_1.notification_date.isoformat()),
+            datetime.datetime.fromisoformat(sale_1.purchase_date.isoformat()),
+            500,  # 50_000 / 100
+            600,  # (50_000 + 10_000) / 100
+        ),
+        (
+            sale_2.apartment.postal_code.cost_area,
+            sale_2.apartment.postal_code.value,
+            sale_2.apartment.address,
+            datetime.datetime.fromisoformat(sale_2.notification_date.isoformat()),
+            datetime.datetime.fromisoformat(sale_2.purchase_date.isoformat()),
+            1300,  # 130_000 / 100
+            1301,  # (130_000 + 100) / 100
+        ),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kaikki kaupat", "Lukumäärä", 2, 2),
+        (None, None, None, None, "Summa", 1800, 1901),
+        (None, None, None, None, "Keskiarvo", 900, 950.5),
+        (None, None, None, None, "Maksimi", 1300, 1301),
+        (None, None, None, None, "Minimi", 500, 600),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 1", "Lukumäärä", 2, 2),
+        (None, None, None, None, "Summa", 1800, 1901),
+        (None, None, None, None, "Keskiarvo", 900, 950.5),
+        (None, None, None, None, "Maksimi", 1300, 1301),
+        (None, None, None, None, "Minimi", 500, 600),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 2", "Lukumäärä", 0, 0),
+        (None, None, None, None, "Summa", 0, 0),
+        (None, None, None, None, "Keskiarvo", 0, 0),
+        (None, None, None, None, "Maksimi", 0, 0),
+        (None, None, None, None, "Minimi", 0, 0),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 3", "Lukumäärä", 0, 0),
+        (None, None, None, None, "Summa", 0, 0),
+        (None, None, None, None, "Keskiarvo", 0, 0),
+        (None, None, None, None, "Maksimi", 0, 0),
+        (None, None, None, None, "Minimi", 0, 0),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 4", "Lukumäärä", 0, 0),
+        (None, None, None, None, "Summa", 0, 0),
+        (None, None, None, None, "Keskiarvo", 0, 0),
+        (None, None, None, None, "Maksimi", 0, 0),
+        (None, None, None, None, "Minimi", 0, 0),
+    ]
+
+
+@pytest.mark.django_db
+def test__api__sales_report__multiple_sales__one_excluded_from_sales(api_client: HitasAPIClient):
+    # Create sales in the report interval
+    sale_1: ApartmentSale = ApartmentSaleFactory.create(
+        purchase_date=datetime.date(2020, 1, 1),
+        purchase_price=50_000,
+        apartment_share_of_housing_company_loans=10_000,
+        apartment__surface_area=100,
+        apartment__building__real_estate__housing_company__postal_code__value="00001",
+        apartment__building__real_estate__housing_company__postal_code__cost_area=1,
+    )
+    # Sale not included even though in the report interval because of exclude_from_statistics
+    ApartmentSaleFactory.create(
+        purchase_date=datetime.date(2020, 1, 15),
+        purchase_price=130_000,
+        exclude_from_statistics=True,
+        apartment_share_of_housing_company_loans=100,
+        apartment__surface_area=100,
+        apartment__building__real_estate__housing_company__postal_code__value="00002",
+        apartment__building__real_estate__housing_company__postal_code__cost_area=1,
+    )
+
+    data = {
+        "start_date": "2020-01-01",
+        "end_date": "2020-01-31",
+    }
+    url = reverse("hitas:sales-report-list") + "?" + urlencode(data)
+    response: HttpResponse = api_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    workbook: Workbook = load_workbook(BytesIO(response.content), data_only=False)
+    worksheet: Worksheet = workbook.worksheets[0]
+
+    assert list(worksheet.values) == [
+        (
+            "Kalleusalue",
+            "Postinumero",
+            "Osoite",
+            "Ilmoituspäivä",
+            "Kauppapäivä",
+            "Kaupan neliöhinta",
+            "Velaton neliöhinta",
+        ),
+        (
+            sale_1.apartment.postal_code.cost_area,
+            sale_1.apartment.postal_code.value,
+            sale_1.apartment.address,
+            datetime.datetime.fromisoformat(sale_1.notification_date.isoformat()),
+            datetime.datetime.fromisoformat(sale_1.purchase_date.isoformat()),
+            500,  # 50_000 / 100
+            600,  # (50_000 + 10_000) / 100
+        ),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kaikki kaupat", "Lukumäärä", 1, 1),
+        (None, None, None, None, "Summa", 500, 600),
+        (None, None, None, None, "Keskiarvo", 500, 600),
+        (None, None, None, None, "Maksimi", 500, 600),
+        (None, None, None, None, "Minimi", 500, 600),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 1", "Lukumäärä", 1, 1),
+        (None, None, None, None, "Summa", 500, 600),
+        (None, None, None, None, "Keskiarvo", 500, 600),
+        (None, None, None, None, "Maksimi", 500, 600),
+        (None, None, None, None, "Minimi", 500, 600),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 2", "Lukumäärä", 0, 0),
+        (None, None, None, None, "Summa", 0, 0),
+        (None, None, None, None, "Keskiarvo", 0, 0),
+        (None, None, None, None, "Maksimi", 0, 0),
+        (None, None, None, None, "Minimi", 0, 0),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 3", "Lukumäärä", 0, 0),
+        (None, None, None, None, "Summa", 0, 0),
+        (None, None, None, None, "Keskiarvo", 0, 0),
+        (None, None, None, None, "Maksimi", 0, 0),
+        (None, None, None, None, "Minimi", 0, 0),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 4", "Lukumäärä", 0, 0),
+        (None, None, None, None, "Summa", 0, 0),
+        (None, None, None, None, "Keskiarvo", 0, 0),
+        (None, None, None, None, "Maksimi", 0, 0),
+        (None, None, None, None, "Minimi", 0, 0),
+    ]
+
+
+@pytest.mark.django_db
+def test__api__sales_report__multiple_sales__one_out_of_interval(api_client: HitasAPIClient):
+    # Create sales in the report interval
+    sale: ApartmentSale = ApartmentSaleFactory.create(
+        purchase_date=datetime.date(2020, 1, 1),
+        purchase_price=50_000,
+        apartment_share_of_housing_company_loans=10_000,
+        apartment__surface_area=100,
+        apartment__building__real_estate__housing_company__postal_code__value="00001",
+        apartment__building__real_estate__housing_company__postal_code__cost_area=1,
+    )
+    ApartmentSaleFactory.create(
+        purchase_date=datetime.date(2020, 2, 1),
+        purchase_price=130_000,
+        apartment_share_of_housing_company_loans=100,
+        apartment__surface_area=100,
+        apartment__building__real_estate__housing_company__postal_code__value="00002",
+        apartment__building__real_estate__housing_company__postal_code__cost_area=1,
+    )
+
+    data = {
+        "start_date": "2020-01-01",
+        "end_date": "2020-01-31",
+    }
+    url = reverse("hitas:sales-report-list") + "?" + urlencode(data)
+    response: HttpResponse = api_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    workbook: Workbook = load_workbook(BytesIO(response.content), data_only=False)
+    worksheet: Worksheet = workbook.worksheets[0]
+
+    assert list(worksheet.values) == [
+        (
+            "Kalleusalue",
+            "Postinumero",
+            "Osoite",
+            "Ilmoituspäivä",
+            "Kauppapäivä",
+            "Kaupan neliöhinta",
+            "Velaton neliöhinta",
+        ),
+        (
+            sale.apartment.postal_code.cost_area,
+            sale.apartment.postal_code.value,
+            sale.apartment.address,
+            datetime.datetime.fromisoformat(sale.notification_date.isoformat()),
+            datetime.datetime.fromisoformat(sale.purchase_date.isoformat()),
+            500,  # 50_000 / 100
+            600,  # (50_000 + 10_000) / 100
+        ),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kaikki kaupat", "Lukumäärä", 1, 1),
+        (None, None, None, None, "Summa", 500, 600),
+        (None, None, None, None, "Keskiarvo", 500, 600),
+        (None, None, None, None, "Maksimi", 500, 600),
+        (None, None, None, None, "Minimi", 500, 600),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 1", "Lukumäärä", 1, 1),
+        (None, None, None, None, "Summa", 500, 600),
+        (None, None, None, None, "Keskiarvo", 500, 600),
+        (None, None, None, None, "Maksimi", 500, 600),
+        (None, None, None, None, "Minimi", 500, 600),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 2", "Lukumäärä", 0, 0),
+        (None, None, None, None, "Summa", 0, 0),
+        (None, None, None, None, "Keskiarvo", 0, 0),
+        (None, None, None, None, "Maksimi", 0, 0),
+        (None, None, None, None, "Minimi", 0, 0),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 3", "Lukumäärä", 0, 0),
+        (None, None, None, None, "Summa", 0, 0),
+        (None, None, None, None, "Keskiarvo", 0, 0),
+        (None, None, None, None, "Maksimi", 0, 0),
+        (None, None, None, None, "Minimi", 0, 0),
+        (None, None, None, None, None, None, None),
+        (None, None, None, "Kalleusalue 4", "Lukumäärä", 0, 0),
+        (None, None, None, None, "Summa", 0, 0),
+        (None, None, None, None, "Keskiarvo", 0, 0),
+        (None, None, None, None, "Maksimi", 0, 0),
+        (None, None, None, None, "Minimi", 0, 0),
+    ]
+
+
+@pytest.mark.django_db
+def test__api__sales_report__start_date_after_end_date(api_client: HitasAPIClient):
+    # Create sales in the report interval
+    ApartmentSaleFactory.create(
+        purchase_date=datetime.date(2020, 1, 1),
+        purchase_price=50_000,
+        apartment_share_of_housing_company_loans=10_000,
+        apartment__surface_area=100,
+        apartment__building__real_estate__housing_company__postal_code__value="00001",
+        apartment__building__real_estate__housing_company__postal_code__cost_area=1,
+    )
+
+    data = {
+        "start_date": "2020-01-31",
+        "end_date": "2020-01-01",
+    }
+    url = reverse("hitas:sales-report-list") + "?" + urlencode(data)
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        "error": "bad_request",
+        "fields": [
+            {
+                "field": "non_field_errors",
+                "message": "Start date must be before end date",
+            },
+        ],
+        "message": "Bad request",
+        "reason": "Bad Request",
+        "status": 400,
+    }
+
+
+@pytest.mark.django_db
+def test__api__sales_report__surface_area_missing(api_client: HitasAPIClient):
+    # Create sales in the report interval
+    sale: ApartmentSale = ApartmentSaleFactory.create(
+        purchase_date=datetime.date(2020, 1, 1),
+        purchase_price=50_000,
+        apartment_share_of_housing_company_loans=10_000,
+        apartment__surface_area=None,
+        apartment__building__real_estate__housing_company__postal_code__value="00001",
+        apartment__building__real_estate__housing_company__postal_code__cost_area=1,
+    )
+
+    data = {
+        "start_date": "2020-01-01",
+        "end_date": "2020-01-31",
+    }
+    url = reverse("hitas:sales-report-list") + "?" + urlencode(data)
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        "error": "bad_request",
+        "fields": [
+            {
+                "field": "non_field_errors",
+                "message": (
+                    f"Surface are zero or missing for apartment {sale.apartment.address!r}. "
+                    f"Cannot calculate price per square meter."
+                ),
+            }
+        ],
+        "message": "Bad request",
+        "reason": "Bad Request",
+        "status": 400,
+    }

--- a/backend/hitas/urls.py
+++ b/backend/hitas/urls.py
@@ -50,6 +50,9 @@ router.register(
     basename="external-sales-data",
 )
 
+# /api/v1/reports/download-sales-report
+router.register(r"reports/download-sales-report", views.SalesReportView, basename="sales-report")
+
 # Codes
 router.register(r"postal-codes", views.HitasPostalCodeViewSet, basename="postal-code")
 router.register(r"building-types", views.BuildingTypeViewSet, basename="building-type")

--- a/backend/hitas/views/__init__.py
+++ b/backend/hitas/views/__init__.py
@@ -20,5 +20,6 @@ from hitas.views.owner import DeObfuscatedOwnerView, OwnerViewSet
 from hitas.views.postal_code import HitasPostalCodeViewSet
 from hitas.views.property_manager import PropertyManagerViewSet
 from hitas.views.real_estate import RealEstateViewSet
+from hitas.views.reports import SalesReportView
 from hitas.views.sales_catalog import SalesCatalogCreateView, SalesCatalogValidateView
 from hitas.views.thirty_year_regulation import ThirtyYearRegulationPostalCodesView, ThirtyYearRegulationView

--- a/backend/hitas/views/reports.py
+++ b/backend/hitas/views/reports.py
@@ -1,0 +1,38 @@
+import datetime
+from typing import Any
+
+from django.http import HttpResponse
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.viewsets import ViewSet
+
+from hitas.services.apartment_sale import find_sales_on_interval_for_reporting
+from hitas.services.reports import build_sales_report_excel
+from hitas.types import HitasJSONRenderer
+from hitas.views.utils.excel import ExcelRenderer, get_excel_response
+
+
+class SalesReportSerializer(serializers.Serializer):
+    start_date = serializers.DateField()
+    end_date = serializers.DateField()
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if attrs["start_date"] > attrs["end_date"]:
+            raise serializers.ValidationError("Start date must be before end date")
+        return attrs
+
+
+class SalesReportView(ViewSet):
+    renderer_classes = [HitasJSONRenderer, ExcelRenderer]
+
+    def list(self, request: Request, *args, **kwargs) -> HttpResponse:
+        serializer = SalesReportSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+
+        start: datetime.date = serializer.validated_data["start_date"]
+        end: datetime.date = serializer.validated_data["end_date"]
+
+        sales = find_sales_on_interval_for_reporting(start_date=start, end_date=end)
+        workbook = build_sales_report_excel(sales)
+        filename = f"Hitas kaupat aikavälillä {start.isoformat()} - {end.isoformat()}.xlsx"
+        return get_excel_response(filename=filename, excel=workbook)

--- a/backend/hitas/views/utils/excel.py
+++ b/backend/hitas/views/utils/excel.py
@@ -11,6 +11,7 @@ from openpyxl.workbook import Workbook
 from openpyxl.worksheet.worksheet import Worksheet
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.parsers import BaseParser
+from rest_framework.renderers import BaseRenderer
 from rest_framework.serializers import Serializer
 
 
@@ -41,6 +42,20 @@ class OldExcelParser(_ExcelParser):
 
 class NewExcelParser(_ExcelParser):
     media_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"  # .xlsx
+
+
+class ExcelRenderer(BaseRenderer):
+    media_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    charset = None
+    format = "excel"
+
+    def render(
+        self,
+        data: bytes,
+        accepted_media_type: Optional[str] = None,
+        renderer_context: Optional[str] = None,
+    ) -> bytes:
+        return data
 
 
 def parse_excel_from_bytes(request: WSGIRequest) -> Workbook:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1,4 +1,7 @@
 openapi: 3.0.3
+#servers:
+#  - url: http://localhost:8000
+#    description: Local development server
 info:
   title: Hitas Helsinki APIs
   version: 1.0.0
@@ -3797,6 +3800,44 @@ paths:
           $ref: '#/components/responses/NotFound'
         '406':
           $ref: '#/components/responses/NotAcceptable'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  # Reports
+
+  /api/v1/reports/download-sales-report:
+    get:
+      description: Download hitas sales on a defined interval as an Excel report
+      operationId: fetch-sales-report-excel
+      tags:
+        - Reports
+      parameters:
+        - name: start_date
+          required: true
+          in: query
+          description: Start date for the sales report
+          schema:
+            type: string
+            example: 2022-02-01
+        - name: end_date
+          required: true
+          in: query
+          description: End date for the sales report
+          schema:
+            type: string
+            example: 2023-02-01
+      responses:
+        '200':
+          description: Successfully downloaded a sales report
+          content:
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds endpoint for creating and downloading sales report Excel file.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] Uncomment the lines below from the top of `backend/openapi.yaml` and open the Swagger interface at `localhost:8090`. Add `http://localhost:8090` to `CORS_ALLOWED_ORIGINS` in `backend/.env`. Add `authentication_classes = []` & `permission_classes = []` to `hitas.views.reports.SalesReportView`. Use the new report endpoint from the Swagger interface while the backend is running at `localhost:8000` and observe the downloaded Excel file.

```yaml
#servers:
#  - url: http://localhost:8000
#    description: Local development server
```

## Tickets

This pull request resolves all or part of the following ticket(s): HT-606
