### PR TITLE
Make email an optional field in owner edit form

### DIFF
--- a/frontend/src/common/components/ModifyPersonInfoModal.tsx
+++ b/frontend/src/common/components/ModifyPersonInfoModal.tsx
@@ -4,10 +4,10 @@ import {Dispatch, SetStateAction, useState} from "react";
 import {useForm} from "react-hook-form";
 import {z} from "zod";
 import {useSaveOwnerMutation} from "../../app/services";
-import TextInput from "../../common/components/form/TextInput";
-import SaveButton from "../../common/components/SaveButton";
-import {IOwner, OwnerSchema} from "../../common/schemas";
-import {hdsToast, validateSocialSecurityNumber} from "../../common/utils";
+import {IOwner, OwnerSchema} from "../schemas";
+import {hdsToast, validateSocialSecurityNumber} from "../utils";
+import TextInput from "./form/TextInput";
+import SaveButton from "./SaveButton";
 
 interface IOwnerMutateForm {
     owner: IOwner;
@@ -107,7 +107,8 @@ interface IModifyPersonInfoModalProps {
     isVisible: boolean;
     setIsVisible: Dispatch<SetStateAction<boolean>>;
 }
-export const ModifyPersonInfoModal = ({owner, isVisible, setIsVisible}: IModifyPersonInfoModalProps) => {
+
+export default function ModifyPersonInfoModal({owner, isVisible, setIsVisible}: IModifyPersonInfoModalProps) {
     return (
         <Dialog
             id="modify-person-info-modal"
@@ -129,4 +130,4 @@ export const ModifyPersonInfoModal = ({owner, isVisible, setIsVisible}: IModifyP
             </Dialog.Content>
         </Dialog>
     );
-};
+}

--- a/frontend/src/common/components/index.ts
+++ b/frontend/src/common/components/index.ts
@@ -11,6 +11,7 @@ import FormInputField from "./formInputField/FormInputField";
 import Heading from "./Heading";
 import ImprovementsTable from "./ImprovementsTable";
 import ListPageNumbers from "./ListPageNumbers";
+import ModifyPersonInfoModal from "./ModifyPersonInfoModal";
 import NavigateBackButton from "./NavigateBackButton";
 import NewOwnerForm from "./NewOwnerForm";
 import Notifications from "./Notifications";
@@ -33,6 +34,7 @@ export {
     Heading,
     ImprovementsTable,
     ListPageNumbers,
+    ModifyPersonInfoModal,
     NavigateBackButton,
     NewOwnerForm,
     Notifications,

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -335,7 +335,7 @@ const OwnerSchema = object({
     id: APIIdString.optional(),
     name: string({required_error: errorMessages.required}).min(2, errorMessages.stringLength),
     identifier: string({required_error: errorMessages.required}),
-    email: string().email(errorMessages.emailInvalid).optional().or(z.literal("")),
+    email: string().email(errorMessages.emailInvalid).optional().or(z.literal("")).optional(),
 });
 
 const ownershipSchema = object({

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -8,9 +8,14 @@ import {
     useGetApartmentDetailQuery,
     useGetHousingCompanyDetailQuery,
 } from "../../app/services";
-import {DetailField, Divider, ImprovementsTable, QueryStateHandler} from "../../common/components";
+import {
+    DetailField,
+    Divider,
+    ImprovementsTable,
+    ModifyPersonInfoModal,
+    QueryStateHandler,
+} from "../../common/components";
 import {DateInput, TextAreaInput} from "../../common/components/form";
-import {ModifyPersonInfoModal} from "../../common/components/ModifyPersonInfoModal";
 import {
     IApartmentConditionOfSale,
     IApartmentConfirmedMaximumPrice,


### PR DESCRIPTION
# Hitas Pull Request

# Description

Just adds an `.optiona()` to the ownerSchema's email field, as it's not required.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [ ] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated
