### PR TITLE
Frontend Apartment Sale unconfirmed prices

### DIFF
--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -136,6 +136,7 @@ export const downloadRegulationResults = (calculationDate?: string) => {
     };
     fetch(url, init)
         .then(handleDownloadPDF)
+        // eslint-disable-next-line no-console
         .catch((error) => console.error(error));
 };
 

--- a/frontend/src/common/components/QueryStateHandler.tsx
+++ b/frontend/src/common/components/QueryStateHandler.tsx
@@ -51,6 +51,7 @@ export default function QueryStateHandler({
     } else if (data && (!("contents" in data) || data.contents.length)) {
         return <>{children}</>;
     } else {
+        // eslint-disable-next-line no-console
         console.warn(`${attemptedAction ? attemptedAction + ": " : ""}Ei tuloksia!`);
         return <></>;
     }

--- a/frontend/src/common/components/SimpleErrorMessage.tsx
+++ b/frontend/src/common/components/SimpleErrorMessage.tsx
@@ -1,0 +1,13 @@
+import {IconAlertCircleFill} from "hds-react";
+
+export default function SimpleErrorMessage({errorMessage}: {errorMessage?: string}) {
+    if (errorMessage) {
+        return (
+            <p className="error-text">
+                <IconAlertCircleFill />
+                {errorMessage}
+            </p>
+        );
+    }
+    return null;
+}

--- a/frontend/src/common/components/SimpleErrorMessage.tsx
+++ b/frontend/src/common/components/SimpleErrorMessage.tsx
@@ -1,9 +1,12 @@
 import {IconAlertCircleFill} from "hds-react";
 
-export default function SimpleErrorMessage({errorMessage}: {errorMessage?: string}) {
+export default function SimpleErrorMessage({errorMessage, ...rest}: {errorMessage?: string}) {
     if (errorMessage) {
         return (
-            <p className="error-text">
+            <p
+                className="error-text"
+                {...rest}
+            >
                 <IconAlertCircleFill />
                 {errorMessage}
             </p>

--- a/frontend/src/common/components/form/DateInput.tsx
+++ b/frontend/src/common/components/form/DateInput.tsx
@@ -44,6 +44,7 @@ const DateInput = ({id, name, label, formObject, required, ...rest}: DateInputPr
         try {
             const convertedValue = format(valueAsDate, apiFormat);
             formObject.setValue(formDate.name, convertedValue, true);
+            formObject.clearErrors(name);
         } catch {
             formObject.setValue(formDate.name, newValue, true);
         }
@@ -62,7 +63,7 @@ const DateInput = ({id, name, label, formObject, required, ...rest}: DateInputPr
                 name={formDate.name}
                 label={label || ""}
                 onChange={handleOnChange}
-                onBlur={formDate.handleBlur}
+                onBlur={undefined} // formObject.onBlur will break date formatting
                 ref={formDate.ref}
                 value={getValue() ?? ""}
                 errorText={!!fieldError && fieldError.message}

--- a/frontend/src/common/components/index.ts
+++ b/frontend/src/common/components/index.ts
@@ -20,15 +20,17 @@ import QueryStateHandler from "./QueryStateHandler";
 import RemoveButton from "./RemoveButton";
 import SaveButton from "./SaveButton";
 import SaveDialogModal from "./SaveDialogModal";
+import SimpleErrorMessage from "./SimpleErrorMessage";
 
 export {
+    CloseButton,
     ConfirmDialogModal,
     DetailField,
     Divider,
     EditButton,
     FilterCheckboxField,
-    FilterSelectField,
     FilterIntegerField,
+    FilterSelectField,
     FilterTextInputField,
     FormInputField,
     Heading,
@@ -43,5 +45,5 @@ export {
     RemoveButton,
     SaveButton,
     SaveDialogModal,
-    CloseButton,
+    SimpleErrorMessage,
 };

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -414,7 +414,7 @@ const ApartmentConfirmedMaximumPriceSchema = object({
     created_at: string(),
     maximum_price: number(),
     valid: object({is_valid: boolean(), valid_until: string()}),
-}).nullable();
+});
 
 const ApartmentPricesSchema = object({
     first_sale_purchase_price: number().nullable(), // Read only
@@ -437,7 +437,7 @@ const ApartmentPricesSchema = object({
     }),
     maximum_prices: object({
         // Read only
-        confirmed: ApartmentConfirmedMaximumPriceSchema,
+        confirmed: ApartmentConfirmedMaximumPriceSchema.nullable(),
         unconfirmed: object({
             onwards_2011: ApartmentUnconfirmedMaximumPriceIndicesSchema,
             pre_2011: ApartmentUnconfirmedMaximumPriceIndicesSchema,

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -1,7 +1,13 @@
 import toast, {ToastOptions} from "react-hot-toast";
 
 import {Config} from "../app/services";
-import {IAddress, IApartmentAddress, IOwner} from "./schemas";
+import {
+    IAddress,
+    IApartmentAddress,
+    IApartmentDetails,
+    IApartmentUnconfirmedMaximumPriceIndices,
+    IOwner,
+} from "./schemas";
 
 export function dotted(obj: object, path: string | string[], value?: number | string | null | object) {
     /*
@@ -189,4 +195,12 @@ export const getLogOutUrl = (): string => {
     const baseUrl = new URL(window.location.href).origin;
     const callBackUrl = baseUrl + `/logout`;
     return Config.api_auth_url + "/logout?next=" + callBackUrl;
+};
+
+export const getApartmentUnconfirmedPrices = (
+    apartment: IApartmentDetails
+): IApartmentUnconfirmedMaximumPriceIndices => {
+    const isPre2011 = apartment.prices.maximum_prices.unconfirmed.pre_2011 !== null;
+    if (isPre2011) return apartment.prices.maximum_prices.unconfirmed.pre_2011;
+    else return apartment.prices.maximum_prices.unconfirmed.onwards_2011;
 };

--- a/frontend/src/features/apartment/ApartmentCreatePage.tsx
+++ b/frontend/src/features/apartment/ApartmentCreatePage.tsx
@@ -331,6 +331,7 @@ const LoadedApartmentCreatePage = ({
             {apartment ? <ApartmentHeader /> : <Heading>Uusi asunto</Heading>}
             <form
                 ref={formRef}
+                // eslint-disable-next-line no-console
                 onSubmit={formObject.handleSubmit(onSubmit, (errors) => console.warn(formObject, errors))}
             >
                 <div className="field-sets">

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -412,7 +412,11 @@ const ApartmentMaximumPricesCard = ({
                     <Button
                         theme="black"
                         size="small"
-                        disabled={!apartment.completion_date || housingCompany.regulation_status !== "regulated"}
+                        disabled={
+                            !apartment.completion_date ||
+                            housingCompany.regulation_status !== "regulated" ||
+                            !apartment.prices.first_purchase_date
+                        }
                     >
                         Vahvista
                     </Button>

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -25,7 +25,14 @@ import {
     IOwner,
     IOwnership,
 } from "../../common/schemas";
-import {formatAddress, formatDate, formatMoney, hdsToast, today} from "../../common/utils";
+import {
+    formatAddress,
+    formatDate,
+    formatMoney,
+    getApartmentUnconfirmedPrices,
+    hdsToast,
+    today,
+} from "../../common/utils";
 import ApartmentHeader from "./components/ApartmentHeader";
 import ConditionsOfSaleStatus from "./components/ConditionsOfSaleStatus";
 
@@ -343,10 +350,7 @@ const ApartmentMaximumPricesCard = ({
     apartment: IApartmentDetails;
     housingCompany: IHousingCompanyDetails;
 }) => {
-    const isPre2011 = apartment.prices.maximum_prices.unconfirmed.pre_2011 !== null;
-    const unconfirmedPrices = isPre2011
-        ? apartment.prices.maximum_prices.unconfirmed.pre_2011
-        : apartment.prices.maximum_prices.unconfirmed.onwards_2011;
+    const unconfirmedPrices = getApartmentUnconfirmedPrices(apartment);
     const [isUnconfirmedMaximumPriceModalVisible, setIsUnconfirmedMaximumPriceModalVisible] = useState(false);
     const [isMaximumPriceModalVisible, setIsMaximumPriceModalVisible] = useState(false);
 

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -170,7 +170,7 @@ const UnconfirmedPriceRow = ({label, unconfirmedPrice}: UnconfirmedPriceRowProps
     );
 };
 
-const ConfirmedPriceDetails = ({confirmed}: {confirmed: IApartmentConfirmedMaximumPrice}) => {
+const ConfirmedPriceDetails = ({confirmed}: {confirmed: IApartmentConfirmedMaximumPrice | null}) => {
     if (confirmed === null) return <p className="confirmed-price">-</p>;
     return (
         <>

--- a/frontend/src/features/apartment/ApartmentNewSalePage/ApartmentCatalogPrices.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/ApartmentCatalogPrices.tsx
@@ -38,12 +38,7 @@ const ApartmentCatalogPrices = ({
                     </div>
                 </div>
 
-                {errorMessage ? (
-                    <p className="error-text">
-                        <IconAlertCircleFill />
-                        {errorMessage}
-                    </p>
-                ) : null}
+                <SimpleErrorMessage errorMessage={errorMessage} />
             </div>
         </Fieldset>
     );

--- a/frontend/src/features/apartment/ApartmentNewSalePage/ApartmentCatalogPrices.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/ApartmentCatalogPrices.tsx
@@ -1,14 +1,14 @@
-import {Fieldset, IconAlertCircleFill} from "hds-react";
-import {IApartmentDetails} from "../../../common/schemas";
+import {Fieldset} from "hds-react";
+import {useContext} from "react";
+import SimpleErrorMessage from "../../../common/components/SimpleErrorMessage";
 import {formatMoney} from "../../../common/utils";
+import {ApartmentSaleContext} from "./index";
 
-const ApartmentCatalogPrices = ({
-    apartment,
-    formExtraFieldErrorMessages,
-}: {
-    apartment: IApartmentDetails;
-    formExtraFieldErrorMessages: undefined | {catalog_acquisition_price?: string[]};
-}) => {
+const ApartmentCatalogPrices = () => {
+    const {apartment, formExtraFieldErrorMessages} = useContext(ApartmentSaleContext);
+
+    if (!apartment) return null;
+
     const maximumPrices = {
         maximumPrice: apartment.prices.catalog_purchase_price ?? 0,
         debtFreePurchasePrice: apartment.prices.catalog_acquisition_price ?? 0,

--- a/frontend/src/features/apartment/ApartmentNewSalePage/ApartmentCatalogPrices.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/ApartmentCatalogPrices.tsx
@@ -1,13 +1,24 @@
 import {Fieldset, IconAlertCircleFill} from "hds-react";
+import {IApartmentDetails} from "../../../common/schemas";
 import {formatMoney} from "../../../common/utils";
 
-const ApartmentCatalogPrices = ({apartment, errorMessage}) => {
+const ApartmentCatalogPrices = ({
+    apartment,
+    formExtraFieldErrorMessages,
+}: {
+    apartment: IApartmentDetails;
+    formExtraFieldErrorMessages: undefined | {catalog_acquisition_price?: string[]};
+}) => {
     const maximumPrices = {
         maximumPrice: apartment.prices.catalog_purchase_price ?? 0,
         debtFreePurchasePrice: apartment.prices.catalog_acquisition_price ?? 0,
         apartmentShareOfHousingCompanyLoans: apartment.prices.catalog_share_of_housing_company_loans ?? 0,
         index: "",
     };
+
+    const errorMessage =
+        formExtraFieldErrorMessages?.catalog_acquisition_price &&
+        formExtraFieldErrorMessages.catalog_acquisition_price[0];
 
     return (
         <Fieldset heading="Myyntihintaluettelon hinnat">

--- a/frontend/src/features/apartment/ApartmentNewSalePage/LoadedApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/LoadedApartmentSalesPage.tsx
@@ -293,13 +293,14 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
                                 />
                             </div>
                         </div>
-                        <Checkbox
-                            name="exclude_from_statistics"
-                            label="Ei tilastoihin (esim. sukulaiskauppa)"
-                            formObject={saleForm}
-                            triggerField="purchase_price"
-                            disabled={isMaximumPriceCalculationMissing}
-                        />
+                        {!isApartmentFirstSale ? (
+                            <Checkbox
+                                name="exclude_from_statistics"
+                                label="Ei tilastoihin (esim. sukulaiskauppa)"
+                                formObject={saleForm}
+                                triggerField="purchase_price"
+                            />
+                        ) : null}
                     </form>
                 </Fieldset>
 

--- a/frontend/src/features/apartment/ApartmentNewSalePage/LoadedApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/LoadedApartmentSalesPage.tsx
@@ -1,7 +1,7 @@
 import {zodResolver} from "@hookform/resolvers/zod/dist/zod";
 import {Fieldset} from "hds-react";
 import {useRef, useState} from "react";
-import {useForm} from "react-hook-form";
+import {FormProvider, useForm} from "react-hook-form";
 import {useNavigate} from "react-router-dom";
 import {v4 as uuidv4} from "uuid";
 import {z, ZodSchema} from "zod";
@@ -19,6 +19,7 @@ import {
 } from "../../../common/schemas";
 import {getApartmentUnconfirmedPrices, hdsToast, today} from "../../../common/utils";
 import ApartmentCatalogPrices from "./ApartmentCatalogPrices";
+import {ApartmentSaleContext} from "./index";
 import MaximumPriceCalculationFieldSet from "./MaximumPriceCalculationFieldSet";
 import OwnershipsListFieldSet from "./OwnershipsListFieldSet";
 
@@ -272,69 +273,65 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
     return (
         <div className="view--apartment-conditions-of-sale">
             <div className="fieldsets">
-                <Fieldset heading="Kaupan tiedot *">
-                    <form
-                        ref={formRef}
-                        onSubmit={saleForm.handleSubmit(onSaleFormSubmitValid, onSaleFormSubmitInvalid)}
-                    >
-                        <div className="row">
-                            <DateInput
-                                name="notification_date"
-                                label="Ilmoituspäivämäärä"
-                                formObject={saleForm}
-                                maxDate={new Date()}
-                                required
-                            />
-                            <DateInput
-                                name="purchase_date"
-                                label="Kauppakirjan päivämäärä"
-                                formObject={saleForm}
-                                maxDate={new Date()}
-                                required
-                            />
-                        </div>
-                        <div className="row">
-                            <NumberInput
-                                name="purchase_price"
-                                label="Kauppahinta"
-                                formObject={saleForm}
-                                unit="€"
-                                fractionDigits={2}
-                                required
-                            />
-                            <NumberInput
-                                name="apartment_share_of_housing_company_loans"
-                                label="Osuus yhtiön lainoista"
-                                formObject={saleForm}
-                                unit="€"
-                                required
-                            />
-                        </div>
-                        {!isApartmentFirstSale ? (
-                            <Checkbox
-                                name="exclude_from_statistics"
-                                label="Ei tilastoihin (esim. sukulaiskauppa)"
-                                formObject={saleForm}
-                                triggerField="purchase_price"
-                            />
-                        ) : null}
-                    </form>
-                </Fieldset>
+                <ApartmentSaleContext.Provider value={{apartment, formExtraFieldErrorMessages}}>
+                    <FormProvider {...saleForm}>
+                        <Fieldset heading="Kaupan tiedot *">
+                            <form
+                                ref={formRef}
+                                onSubmit={saleForm.handleSubmit(onSaleFormSubmitValid, onSaleFormSubmitInvalid)}
+                            >
+                                <div className="row">
+                                    <DateInput
+                                        name="notification_date"
+                                        label="Ilmoituspäivämäärä"
+                                        formObject={saleForm}
+                                        maxDate={new Date()}
+                                        required
+                                    />
+                                    <DateInput
+                                        name="purchase_date"
+                                        label="Kauppakirjan päivämäärä"
+                                        formObject={saleForm}
+                                        maxDate={new Date()}
+                                        required
+                                    />
+                                </div>
+                                <div className="row">
+                                    <NumberInput
+                                        name="purchase_price"
+                                        label="Kauppahinta"
+                                        formObject={saleForm}
+                                        unit="€"
+                                        fractionDigits={2}
+                                        required
+                                    />
+                                    <NumberInput
+                                        name="apartment_share_of_housing_company_loans"
+                                        label="Osuus yhtiön lainoista"
+                                        formObject={saleForm}
+                                        unit="€"
+                                        required
+                                    />
+                                </div>
+                                {!isApartmentFirstSale ? (
+                                    <Checkbox
+                                        name="exclude_from_statistics"
+                                        label="Ei tilastoihin (esim. sukulaiskauppa)"
+                                        formObject={saleForm}
+                                        triggerField="purchase_price"
+                                    />
+                                ) : null}
+                            </form>
+                        </Fieldset>
 
-                {isApartmentFirstSale ? (
-                    <ApartmentCatalogPrices
-                        apartment={apartment}
-                        formExtraFieldErrorMessages={formExtraFieldErrorMessages}
-                    />
-                ) : (
-                    <MaximumPriceCalculationFieldSet
-                        apartment={apartment}
-                        setMaximumPrices={setMaximumPrices}
-                        saleForm={saleForm}
-                        formExtraFieldErrorMessages={formExtraFieldErrorMessages}
-                    />
-                )}
-                <OwnershipsListFieldSet formObject={saleForm} />
+                        {isApartmentFirstSale ? (
+                            <ApartmentCatalogPrices />
+                        ) : (
+                            <MaximumPriceCalculationFieldSet setMaximumPrices={setMaximumPrices} />
+                        )}
+                        <OwnershipsListFieldSet />
+                    </FormProvider>
+                </ApartmentSaleContext.Provider>
             </div>
 
             <div className="row row--buttons">

--- a/frontend/src/features/apartment/ApartmentNewSalePage/LoadedApartmentSalesPage.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/LoadedApartmentSalesPage.tsx
@@ -224,6 +224,10 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
             hdsToast.error(errors.ownerships.message);
             return;
         }
+        if (errors.apartment_share_of_housing_company_loans) {
+            // hdsToast.error(errors.apartment_share_of_housing_company_loans.message);
+            return;
+        }
 
         // Handle Soft errors
         // If errors only include ones that can be ignored, show a warning modal and continue creation process
@@ -240,6 +244,7 @@ const LoadedApartmentSalesPage = ({apartment}: {apartment: IApartmentDetails}) =
             setWarningMessage(errors.catalog_acquisition_price.message);
         } else {
             hdsToast.error(`Virhe luodessa asunnon kauppaa!`);
+            setIsWarningModalVisible(false);
             // eslint-disable-next-line no-console
             console.error(errors);
         }

--- a/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationFieldSet.tsx
@@ -2,17 +2,31 @@ import {Dialog, Fieldset} from "hds-react";
 import {useEffect, useState} from "react";
 import {useGetApartmentMaximumPriceQuery, useSaveApartmentMaximumPriceMutation} from "../../../app/services";
 import {QueryStateHandler} from "../../../common/components";
-import {ApartmentSaleFormSchema, IApartmentMaximumPrice} from "../../../common/schemas";
+import {
+    ApartmentSaleFormSchema,
+    IApartmentConfirmedMaximumPrice,
+    IApartmentDetails,
+    IApartmentMaximumPrice,
+} from "../../../common/schemas";
 import {formatDate, hdsToast} from "../../../common/utils";
 import MaximumPriceModalContent from "../components/ApartmentMaximumPriceBreakdownModal";
+import {ISalesPageMaximumPrices} from "./LoadedApartmentSalesPage";
 import MaximumPriceCalculationExists from "./MaximumPriceCalculationExists";
 import MaximumPriceCalculationMissing from "./MaximumPriceCalculationMissing";
 import MaximumPriceModalError from "./MaximumPriceModalError";
 
-const MaximumPriceCalculationFieldSet = ({apartment, setMaximumPrices, saleForm}) => {
+const MaximumPriceCalculationFieldSet = ({
+    apartment,
+    setMaximumPrices,
+    saleForm,
+}: {
+    apartment: IApartmentDetails;
+    setMaximumPrices: (maximumPrices: ISalesPageMaximumPrices) => void;
+    saleForm;
+}) => {
     const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
 
-    const apartmentHasValidCalculation = apartment.prices.maximum_prices.confirmed?.valid.is_valid;
+    const hasApartmentConfirmedCalculation = apartment.prices.maximum_prices.confirmed?.valid.is_valid;
 
     const {
         data: maximumPriceCalculationData,
@@ -102,12 +116,14 @@ const MaximumPriceCalculationFieldSet = ({apartment, setMaximumPrices, saleForm}
     return (
         <Fieldset
             heading={`Enimmäishintalaskelma${
-                apartmentHasValidCalculation
-                    ? ` (vahvistettu ${formatDate(apartment.prices.maximum_prices.confirmed.confirmed_at)})`
+                hasApartmentConfirmedCalculation
+                    ? ` (vahvistettu ${formatDate(
+                          (apartment.prices.maximum_prices.confirmed as IApartmentConfirmedMaximumPrice).confirmed_at
+                      )})`
                     : ""
             } *`}
         >
-            {apartmentHasValidCalculation ? (
+            {hasApartmentConfirmedCalculation ? (
                 <QueryStateHandler
                     data={maximumPriceCalculationData}
                     error={maximumPriceError}

--- a/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationFieldSet.tsx
@@ -1,4 +1,4 @@
-import {Dialog, Fieldset} from "hds-react";
+import {Dialog, Fieldset, IconAlertCircleFill} from "hds-react";
 import {useState} from "react";
 import {useSaveApartmentMaximumPriceMutation} from "../../../app/services";
 import {QueryStateHandler} from "../../../common/components";
@@ -19,10 +19,12 @@ const MaximumPriceCalculationFieldSet = ({
     apartment,
     setMaximumPrices,
     saleForm,
+    formExtraFieldErrorMessages,
 }: {
     apartment: IApartmentDetails;
     setMaximumPrices: (maximumPrices: ISalesPageMaximumPrices) => void;
     saleForm;
+    formExtraFieldErrorMessages: undefined | {maximum_price_calculation?: string[]};
 }) => {
     const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
 
@@ -69,6 +71,10 @@ const MaximumPriceCalculationFieldSet = ({
         apartment_share_of_housing_company_loans: saleForm.getValues("apartment_share_of_housing_company_loans"),
     }).success;
 
+    const errorMessage =
+        formExtraFieldErrorMessages?.maximum_price_calculation &&
+        formExtraFieldErrorMessages.maximum_price_calculation[0];
+
     return (
         <Fieldset
             heading={`Enimmäishintalaskelma${
@@ -79,6 +85,12 @@ const MaximumPriceCalculationFieldSet = ({
                     : ""
             } *`}
         >
+            {errorMessage ? (
+                <p className="error-text">
+                    <IconAlertCircleFill />
+                    {errorMessage}
+                </p>
+            ) : null}
             {hasApartmentConfirmedCalculation ? (
                 <MaximumPriceCalculationExists
                     apartment={apartment}
@@ -89,6 +101,7 @@ const MaximumPriceCalculationFieldSet = ({
                 />
             ) : (
                 <MaximumPriceCalculationMissing
+                    apartment={apartment}
                     handleCalculateButton={handleCreateNewCalculationButton}
                     isCalculationFormValid={isCalculationFormValid}
                 />

--- a/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationFieldSet.tsx
@@ -85,12 +85,7 @@ const MaximumPriceCalculationFieldSet = ({
                     : ""
             } *`}
         >
-            {errorMessage ? (
-                <p className="error-text">
-                    <IconAlertCircleFill />
-                    {errorMessage}
-                </p>
-            ) : null}
+            <SimpleErrorMessage errorMessage={errorMessage} />
             {hasApartmentConfirmedCalculation ? (
                 <MaximumPriceCalculationExists
                     apartment={apartment}

--- a/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationFieldSet.tsx
@@ -111,7 +111,7 @@ const MaximumPriceCalculationFieldSet = ({
                 theme="black"
                 variant={hasLoanValueChanged ? "primary" : "secondary"}
                 onClick={handleCreateNewCalculationButton}
-                disabled={!isCalculationFormValid}
+                disabled={!isCalculationFormValid || !apartment.surface_area}
             >
                 Luo uusi enimmäishintalaskelma
             </Button>

--- a/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationFieldSet.tsx
@@ -40,14 +40,27 @@ const MaximumPriceCalculationFieldSet = ({
     const hasApartmentConfirmedCalculation =
         apartment.prices.maximum_prices.confirmed && apartment.prices.maximum_prices.confirmed.valid.is_valid;
 
+    const apartmentShareOfLoans = saleForm.getValues("apartment_share_of_housing_company_loans");
+    const hasLoanValueChanged =
+        formExtraFieldErrorMessages?.apartment_share_of_housing_company_loans && apartmentShareOfLoans !== null;
+
+    const maximumPriceCalculationErrorMessage =
+        formExtraFieldErrorMessages?.maximum_price_calculation &&
+        formExtraFieldErrorMessages.maximum_price_calculation[0];
+
+    const isCalculationFormValid = ApartmentSaleFormSchema.partial().safeParse({
+        purchase_date: saleForm.getValues("purchase_date"),
+        apartment_share_of_housing_company_loans: saleForm.getValues("apartment_share_of_housing_company_loans"),
+    }).success;
+
     const handleCreateNewCalculationButton = () => {
         if (isCalculationFormValid) {
             const date = saleForm.getValues("purchase_date") ?? null;
-            const loanShare = saleForm.getValues("apartment_share_of_housing_company_loans") ?? 0;
+
             saveMaximumPriceCalculation({
                 data: {
                     calculation_date: date,
-                    apartment_share_of_housing_company_loans: loanShare,
+                    apartment_share_of_housing_company_loans: apartmentShareOfLoans ?? 0,
                     apartment_share_of_housing_company_loans_date: date,
                     additional_info: "",
                 },
@@ -65,16 +78,6 @@ const MaximumPriceCalculationFieldSet = ({
             );
         }
     };
-
-    const hasLoanValueChanged = formExtraFieldErrorMessages?.apartment_share_of_housing_company_loans;
-    const maximumPriceCalculationErrorMessage =
-        formExtraFieldErrorMessages?.maximum_price_calculation &&
-        formExtraFieldErrorMessages.maximum_price_calculation[0];
-
-    const isCalculationFormValid = ApartmentSaleFormSchema.partial().safeParse({
-        purchase_date: saleForm.getValues("purchase_date"),
-        apartment_share_of_housing_company_loans: saleForm.getValues("apartment_share_of_housing_company_loans"),
-    }).success;
 
     return (
         <Fieldset

--- a/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationMissing.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationMissing.tsx
@@ -1,17 +1,12 @@
-import {Button} from "hds-react";
-import {IApartmentDetails} from "../../../common/schemas";
+import {useContext} from "react";
 import {formatMoney, getApartmentUnconfirmedPrices} from "../../../common/utils";
+import {ApartmentSaleContext} from "./index";
 
 // Element to display when there is no valid maximum price calculation for the apartment
-const MaximumPriceCalculationMissing = ({
-    apartment,
-    handleCalculateButton,
-    isCalculationFormValid,
-}: {
-    apartment: IApartmentDetails;
-    handleCalculateButton: () => void;
-    isCalculationFormValid: boolean;
-}) => {
+const MaximumPriceCalculationMissing = () => {
+    const {apartment} = useContext(ApartmentSaleContext);
+    if (!apartment) return null;
+
     const unconfirmedPrices = getApartmentUnconfirmedPrices(apartment);
 
     return (
@@ -23,14 +18,6 @@ const MaximumPriceCalculationMissing = ({
                 Mikäli asunnon velaton kauppahinta ylittää rajaneliöhinta-arvion, tulee asunnolle luoda vahvistettu
                 enimmäishintalaskelma.
             </p>
-
-            <Button
-                theme="black"
-                onClick={handleCalculateButton}
-                disabled={!isCalculationFormValid}
-            >
-                Luo enimmäishintalaskelma
-            </Button>
         </div>
     );
 };

--- a/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationMissing.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationMissing.tsx
@@ -1,14 +1,29 @@
 import {Button} from "hds-react";
+import {IApartmentDetails} from "../../../common/schemas";
+import {formatMoney, getApartmentUnconfirmedPrices} from "../../../common/utils";
 
 // Element to display when there is no valid maximum price calculation for the apartment
-const MaximumPriceCalculationMissing = ({handleCalculateButton, isCalculationFormValid}) => {
+const MaximumPriceCalculationMissing = ({
+    apartment,
+    handleCalculateButton,
+    isCalculationFormValid,
+}: {
+    apartment: IApartmentDetails;
+    handleCalculateButton: () => void;
+    isCalculationFormValid: boolean;
+}) => {
+    const unconfirmedPrices = getApartmentUnconfirmedPrices(apartment);
+
     return (
         <div className="row row--prompt">
             <p>
-                Asunnosta ei ole vahvistettua enimmäishintalaskelmaa, tai se ei ole enää voimassa. Syötä{" "}
-                <span>kauppakirjan päivämäärä</span> sekä <span>yhtiön lainaosuus</span>, ja tee sitten uusi
-                enimmäishintalaskelma saadaksesi asunnon enimmäishinnat kauppaa varten.
+                Asunnosta ei ole vahvistettua enimmäishintalaskelmaa. Enimmäishintana käytetään asunnon
+                rajaneliöhinta-arviota <b>{formatMoney(unconfirmedPrices.surface_area_price_ceiling.value)}.</b>
+                <br />
+                Mikäli asunnon velaton kauppahinta ylittää rajaneliöhinta-arvion, tulee asunnolle luoda vahvistettu
+                enimmäishintalaskelma.
             </p>
+
             <Button
                 theme="black"
                 onClick={handleCalculateButton}

--- a/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationMissing.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/MaximumPriceCalculationMissing.tsx
@@ -12,11 +12,18 @@ const MaximumPriceCalculationMissing = () => {
     return (
         <div className="row row--prompt">
             <p>
-                Asunnosta ei ole vahvistettua enimmäishintalaskelmaa. Enimmäishintana käytetään asunnon
-                rajaneliöhinta-arviota <b>{formatMoney(unconfirmedPrices.surface_area_price_ceiling.value)}.</b>
-                <br />
-                Mikäli asunnon velaton kauppahinta ylittää rajaneliöhinta-arvion, tulee asunnolle luoda vahvistettu
-                enimmäishintalaskelma.
+                Asunnosta ei ole vahvistettua enimmäishintalaskelmaa.
+                {unconfirmedPrices.surface_area_price_ceiling.value ? (
+                    <>
+                        Enimmäishintana käytetään asunnon rajaneliöhinta-arviota
+                        <b> {formatMoney(unconfirmedPrices.surface_area_price_ceiling.value)}.</b>
+                        <br />
+                        Mikäli asunnon velaton kauppahinta ylittää rajaneliöhinta-arvion, tulee asunnolle luoda
+                        vahvistettu enimmäishintalaskelma.
+                    </>
+                ) : (
+                    <b> Asunnon rajaneliöhinta-arviota ei voitu laskea.</b>
+                )}
             </p>
         </div>
     );

--- a/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
@@ -116,7 +116,7 @@ const OwnerMutateForm = ({formObject, formObjectFieldPath, cancelButtonAction, c
     );
 };
 
-const OwnershipsListFieldSet = ({formObject, disabled}) => {
+const OwnershipsListFieldSet = ({formObject}) => {
     const {fields, append, remove} = useFieldArray({
         name: "ownerships",
         control: formObject.control,
@@ -159,7 +159,6 @@ const OwnershipsListFieldSet = ({formObject, disabled}) => {
                                         formObject={formObject}
                                         formObjectFieldPath={`ownerships.${index}.owner`}
                                         formatFormObjectValue={(obj) => (obj.id ? formatOwner(obj) : "")}
-                                        disabled={disabled}
                                         RelatedModelMutateComponent={OwnerMutateForm}
                                     />
                                 </div>
@@ -169,14 +168,13 @@ const OwnershipsListFieldSet = ({formObject, disabled}) => {
                                         fractionDigits={2}
                                         formObject={formObject}
                                         required
-                                        disabled={disabled}
                                     />
                                     <span>%</span>
                                 </div>
-                                <div className={`icon--remove${disabled ? " disabled" : ""}`}>
+                                <div className="icon--remove">
                                     <IconCrossCircle
                                         size="m"
-                                        onClick={() => (disabled ? null : remove(index))}
+                                        onClick={() => remove(index)}
                                     />
                                 </div>
                             </li>
@@ -211,7 +209,6 @@ const OwnershipsListFieldSet = ({formObject, disabled}) => {
                     variant={ownerships.length > 0 ? "secondary" : "primary"}
                     theme="black"
                     onClick={() => append(emptyOwnership)}
-                    disabled={disabled}
                 >
                     Lisää uusi omistajuus rivi
                 </Button>

--- a/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
@@ -1,5 +1,5 @@
 import {Button, Dialog, Fieldset, IconAlertCircleFill, IconArrowLeft, IconCrossCircle, IconPlus} from "hds-react";
-import {useFieldArray, useForm} from "react-hook-form";
+import {useFieldArray, useForm, useFormContext} from "react-hook-form";
 import {v4 as uuidv4} from "uuid";
 
 import {zodResolver} from "@hookform/resolvers/zod/dist/zod";
@@ -116,7 +116,9 @@ const OwnerMutateForm = ({formObject, formObjectFieldPath, cancelButtonAction, c
     );
 };
 
-const OwnershipsListFieldSet = ({formObject}) => {
+const OwnershipsListFieldSet = () => {
+    const formObject = useFormContext();
+
     const {fields, append, remove} = useFieldArray({
         name: "ownerships",
         control: formObject.control,

--- a/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
@@ -1,4 +1,4 @@
-import {Button, Dialog, Fieldset, IconAlertCircleFill, IconArrowLeft, IconCrossCircle, IconPlus} from "hds-react";
+import {Button, Dialog, Fieldset, IconArrowLeft, IconCrossCircle, IconPlus} from "hds-react";
 import {useFieldArray, useForm, useFormContext} from "react-hook-form";
 import {v4 as uuidv4} from "uuid";
 
@@ -9,6 +9,7 @@ import {useGetOwnersQuery, useSaveOwnerMutation} from "../../../app/services";
 import {NumberInput, RelatedModelInput} from "../../../common/components/form";
 import TextInput from "../../../common/components/form/TextInput";
 import SaveButton from "../../../common/components/SaveButton";
+import SimpleErrorMessage from "../../../common/components/SimpleErrorMessage";
 import {IOwner, OwnerSchema, OwnershipsListSchema} from "../../../common/schemas";
 import {formatOwner, hdsToast, validateSocialSecurityNumber} from "../../../common/utils";
 
@@ -129,86 +130,74 @@ const OwnershipsListFieldSet = () => {
     // Blank Ownership. This is appended to the list when user clicks "New ownership"
     const emptyOwnership = {key: uuidv4(), owner: {id: ""} as IOwner, percentage: 100};
 
-    const ownerships = formObject.getValues("ownerships");
     const formErrors = OwnershipsListSchema.safeParse(formObject.getValues("ownerships"));
-    const isFormInvalid = !formErrors.success;
 
     return (
         <Fieldset
-            className={`ownerships-fieldset ${isFormInvalid ? "error" : ""}`}
+            className={`ownerships-fieldset ${formErrors.success ? "" : "error"}`}
             heading="Omistajuudet *"
         >
             <ul className="ownerships-list">
-                {ownerships.length ? (
-                    <>
-                        <li>
-                            <legend className="ownership-headings">
-                                <span>Omistaja *</span>
-                                <span>Osuus *</span>
-                            </legend>
-                        </li>
-                        {fields.map((field, index) => (
-                            <li
-                                className="ownership-item"
-                                key={field.id}
-                            >
-                                <div className="owner">
-                                    <RelatedModelInput
-                                        label="Omistaja"
-                                        required
-                                        queryFunction={useGetOwnersQuery}
-                                        relatedModelSearchField="name"
-                                        formObject={formObject}
-                                        formObjectFieldPath={`ownerships.${index}.owner`}
-                                        formatFormObjectValue={(obj) => (obj.id ? formatOwner(obj) : "")}
-                                        RelatedModelMutateComponent={OwnerMutateForm}
-                                    />
-                                </div>
-                                <div className="percentage">
-                                    <NumberInput
-                                        name={`ownerships.${index}.percentage`}
-                                        fractionDigits={2}
-                                        formObject={formObject}
-                                        required
-                                    />
-                                    <span>%</span>
-                                </div>
-                                <div className="icon--remove">
-                                    <IconCrossCircle
-                                        size="m"
-                                        onClick={() => remove(index)}
-                                    />
-                                </div>
-                            </li>
-                        ))}
-                    </>
-                ) : (
-                    <div
-                        className={isFormInvalid ? "error-text" : ""}
-                        style={{textAlign: "center"}}
-                    >
-                        <IconAlertCircleFill />
-                        Asunnolla ei ole omistajuuksia
-                        <IconAlertCircleFill />
-                    </div>
-                )}
-            </ul>
-            {!formErrors.success && formErrors.error ? (
                 <>
-                    {formErrors.error.issues.map((e) => (
-                        <span
-                            key={`${e.code}-${e.message}`}
-                            className="error-text"
+                    <li>
+                        <legend className="ownership-headings">
+                            <span>Omistaja *</span>
+                            <span>Osuus *</span>
+                        </legend>
+                    </li>
+
+                    {fields.map((field, index) => (
+                        <li
+                            className="ownership-item"
+                            key={field.id}
                         >
-                            {e.message}
-                        </span>
+                            <div className="owner">
+                                <RelatedModelInput
+                                    label="Omistaja"
+                                    required
+                                    queryFunction={useGetOwnersQuery}
+                                    relatedModelSearchField="name"
+                                    formObject={formObject}
+                                    formObjectFieldPath={`ownerships.${index}.owner`}
+                                    formatFormObjectValue={(obj) => (obj.id ? formatOwner(obj) : "")}
+                                    RelatedModelMutateComponent={OwnerMutateForm}
+                                />
+                            </div>
+                            <div className="percentage">
+                                <NumberInput
+                                    name={`ownerships.${index}.percentage`}
+                                    fractionDigits={2}
+                                    formObject={formObject}
+                                    required
+                                />
+                                <span>%</span>
+                            </div>
+                            <div className="icon--remove">
+                                <IconCrossCircle
+                                    size="m"
+                                    onClick={() => remove(index)}
+                                />
+                            </div>
+                        </li>
                     ))}
                 </>
-            ) : null}
+            </ul>
+
+            <>
+                {!formErrors.success &&
+                    formErrors.error &&
+                    formErrors.error.issues.map((e) => (
+                        <SimpleErrorMessage
+                            key={`${e.code}-${e.message}`}
+                            errorMessage={e.message}
+                        />
+                    ))}
+            </>
+
             <div className="row row--buttons">
                 <Button
                     iconLeft={<IconPlus />}
-                    variant={ownerships.length > 0 ? "secondary" : "primary"}
+                    variant={formObject.watch("ownerships").length > 0 ? "secondary" : "primary"}
                     theme="black"
                     onClick={() => append(emptyOwnership)}
                 >

--- a/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
@@ -196,7 +196,12 @@ const OwnershipsListFieldSet = ({formObject, disabled}) => {
             {!formErrors.success && formErrors.error ? (
                 <>
                     {formErrors.error.issues.map((e) => (
-                        <span key={`${e.code}-${e.message}`}>{e.message}</span>
+                        <span
+                            key={`${e.code}-${e.message}`}
+                            className="error-text"
+                        >
+                            {e.message}
+                        </span>
                     ))}
                 </>
             ) : null}

--- a/frontend/src/features/apartment/ApartmentNewSalePage/index.ts
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/index.ts
@@ -1,3 +1,11 @@
+import {createContext} from "react";
+import {IApartmentDetails} from "../../../common/schemas";
 import ApartmentNewSalePage from "./ApartmentNewSalePage";
 
 export default ApartmentNewSalePage;
+
+export const ApartmentSaleContext = createContext<{
+    apartment?: IApartmentDetails;
+    saleForm?;
+    formExtraFieldErrorMessages?;
+}>({});

--- a/frontend/src/features/functions/ThirtyYearRegulation.tsx
+++ b/frontend/src/features/functions/ThirtyYearRegulation.tsx
@@ -152,6 +152,7 @@ const ThirtyYearRegulation = () => {
                     hdsToast.success("Vertailu suoritettu onnistuneesti!");
                 })
                 .catch((error) => {
+                    // eslint-disable-next-line no-console
                     console.warn("Error:", error);
                     setIsErrorModalOpen(true);
                 });

--- a/frontend/src/features/functions/components/ExternalSalesDataImport.tsx
+++ b/frontend/src/features/functions/components/ExternalSalesDataImport.tsx
@@ -27,6 +27,7 @@ export default function ExternalSalesDataImport({formDate}) {
             .unwrap()
             .then((data) => {
                 if ("error" in (data as object)) {
+                    // eslint-disable-next-line no-console
                     console.warn("Uncaught error:", data.error);
                     setIsModalOpen(true);
                 } else {
@@ -36,6 +37,7 @@ export default function ExternalSalesDataImport({formDate}) {
                 }
             })
             .catch((error) => {
+                // eslint-disable-next-line no-console
                 console.warn("Caught error:", error);
                 setIsModalOpen(true);
             });

--- a/frontend/src/styles/base/_general.sass
+++ b/frontend/src/styles/base/_general.sass
@@ -98,6 +98,9 @@ ul, ol
 
 .error-text
   color: var(--color-error) !important
+  svg
+    vertical-align: bottom
+    margin-right: $spacing-2-xs
 
 [class*="checkbox_hds-checkbox"]
   --background-unselected: white

--- a/frontend/src/styles/components/_ApartmentNewSalePage.sass
+++ b/frontend/src/styles/components/_ApartmentNewSalePage.sass
@@ -24,7 +24,7 @@
       grid-column: 1
 
       .row
-        gap: 2em
+        gap: 1em
         &--prompt
           @include flex-flow(column nowrap)
         > div

--- a/frontend/src/styles/components/_ApartmentNewSalePage.sass
+++ b/frontend/src/styles/components/_ApartmentNewSalePage.sass
@@ -50,10 +50,6 @@
           span
             font-weight: bold
             font-size: $fontsize-body-xl
-        .error-text
-          svg
-            vertical-align: bottom
-            margin-right: $spacing-2-xs
 
         &.expired .fieldset--max-prices__value span
           color: $color-black-40 !important

--- a/frontend/src/styles/components/_Forms.sass
+++ b/frontend/src/styles/components/_Forms.sass
@@ -6,8 +6,12 @@
   &--invalid
     [class*="text-input_hds-text-input"]
       border-color: $color-error !important
+  label
+    font-size: var(--fontsize-body-m)
+    span
+      line-height: var(--fontsize-body-m)
   &--required label
-    font-weight: 700
+      font-weight: 700
 
 input, input + label::before
   --focus-outline-color: var(--color-black-50)


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Automatically use unconfirmed Surface Area Price Ceiling when no confirmed maximum price calculation exists for an apartment in apartment sales page
- Refactoring stuffs
- Improved error messaging and validation

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- Test creating an apartment sale:
  - With a confirmed max price calculation
  - Without a confirmed max price calculation
  - First sale with catalog prices
  - First sale without catalog prices

## Tickets

This pull request resolves all or part of the following ticket(s): HT-424
