### PR TITLE
Allow malformed identifier & fix toast position

### DIFF
--- a/backend/hitas/views/owner.py
+++ b/backend/hitas/views/owner.py
@@ -21,6 +21,9 @@ class OwnerSerializer(HitasModelSerializer):
         valid_identifier = check_social_security_number(value) or check_business_id(value)
         if self.instance is not None:  # update
             if value != self.instance.identifier:
+                if self.instance.valid_identifier and not valid_identifier:
+                    raise ValidationError("Previous identifier was valid. Cannot update to an invalid one.")
+
                 if valid_identifier and Owner.objects.filter(identifier=value).exists():
                     raise ValidationError("An owner with this identifier already exists.")
 

--- a/backend/hitas/views/owner.py
+++ b/backend/hitas/views/owner.py
@@ -21,9 +21,6 @@ class OwnerSerializer(HitasModelSerializer):
         valid_identifier = check_social_security_number(value) or check_business_id(value)
         if self.instance is not None:  # update
             if value != self.instance.identifier:
-                if self.instance.valid_identifier and not valid_identifier:
-                    raise ValidationError("Previous identifier was valid. Cannot update to an invalid one.")
-
                 if valid_identifier and Owner.objects.filter(identifier=value).exists():
                     raise ValidationError("An owner with this identifier already exists.")
 

--- a/frontend/src/common/components/ModifyPersonInfoModal.tsx
+++ b/frontend/src/common/components/ModifyPersonInfoModal.tsx
@@ -4,10 +4,10 @@ import {Dispatch, SetStateAction, useState} from "react";
 import {useForm} from "react-hook-form";
 import {z} from "zod";
 import {useSaveOwnerMutation} from "../../app/services";
-import TextInput from "../../common/components/form/TextInput";
-import SaveButton from "../../common/components/SaveButton";
-import {IOwner, OwnerSchema} from "../../common/schemas";
-import {hdsToast, validateSocialSecurityNumber} from "../../common/utils";
+import {IOwner, OwnerSchema} from "../schemas";
+import {hdsToast, validateSocialSecurityNumber} from "../utils";
+import TextInput from "./form/TextInput";
+import SaveButton from "./SaveButton";
 
 interface IOwnerMutateForm {
     owner: IOwner;
@@ -107,7 +107,8 @@ interface IModifyPersonInfoModalProps {
     isVisible: boolean;
     setIsVisible: Dispatch<SetStateAction<boolean>>;
 }
-export const ModifyPersonInfoModal = ({owner, isVisible, setIsVisible}: IModifyPersonInfoModalProps) => {
+
+export default function ModifyPersonInfoModal({owner, isVisible, setIsVisible}: IModifyPersonInfoModalProps) {
     return (
         <Dialog
             id="modify-person-info-modal"
@@ -129,4 +130,4 @@ export const ModifyPersonInfoModal = ({owner, isVisible, setIsVisible}: IModifyP
             </Dialog.Content>
         </Dialog>
     );
-};
+}

--- a/frontend/src/common/components/ModifyPersonInfoModal.tsx
+++ b/frontend/src/common/components/ModifyPersonInfoModal.tsx
@@ -52,8 +52,9 @@ const OwnerMutateForm = ({owner, closeModalAction}: IOwnerMutateForm) => {
         resolver: resolver,
     });
 
-    // helper values
     const identifierValue = ownerFormObject.watch("identifier");
+
+    // helper booleans
     const hasFormChanged =
         ownerFormObject.formState.isDirty && JSON.stringify(owner) !== JSON.stringify(ownerFormObject.getValues());
     const isMalformedIdentifier = ownerFormObject.formState.errors.identifier?.type === "custom";

--- a/frontend/src/common/components/ModifyPersonInfoModal.tsx
+++ b/frontend/src/common/components/ModifyPersonInfoModal.tsx
@@ -72,7 +72,7 @@ const OwnerMutateForm = ({owner, closeModalAction}: IOwnerMutateForm) => {
     useEffect(() => {
         // validate the initial form values
         ownerFormObject.trigger();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
+        // eslint-disable-next-line
     }, []);
 
     const onFormSubmitValid = () => {

--- a/frontend/src/common/components/Notifications.tsx
+++ b/frontend/src/common/components/Notifications.tsx
@@ -38,7 +38,7 @@ export default function Notifications(): JSX.Element {
                         key={`toast-message-${toast.id}-${toast.createdAt}`}
                         ref={ref}
                         style={{
-                            position: "absolute",
+                            position: "fixed",
                             top: "var(--spacing-layout-s)",
                             right: "var(--spacing-layout-s)",
                             width: "200px",

--- a/frontend/src/common/components/index.ts
+++ b/frontend/src/common/components/index.ts
@@ -11,6 +11,7 @@ import FormInputField from "./formInputField/FormInputField";
 import Heading from "./Heading";
 import ImprovementsTable from "./ImprovementsTable";
 import ListPageNumbers from "./ListPageNumbers";
+import ModifyPersonInfoModal from "./ModifyPersonInfoModal";
 import NavigateBackButton from "./NavigateBackButton";
 import NewOwnerForm from "./NewOwnerForm";
 import Notifications from "./Notifications";
@@ -33,6 +34,7 @@ export {
     Heading,
     ImprovementsTable,
     ListPageNumbers,
+    ModifyPersonInfoModal,
     NavigateBackButton,
     NewOwnerForm,
     Notifications,

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -335,7 +335,7 @@ const OwnerSchema = object({
     id: APIIdString.optional(),
     name: string({required_error: errorMessages.required}).min(2, errorMessages.stringLength),
     identifier: string({required_error: errorMessages.required}).min(1, errorMessages.stringLength),
-    email: string().email(errorMessages.emailInvalid).optional().or(z.literal("")).optional(),
+    email: string().email(errorMessages.emailInvalid).optional().or(z.literal("")),
     non_disclosure: boolean().optional(),
 });
 

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -334,8 +334,9 @@ const ApartmentLinkedModelsSchema = object({
 const OwnerSchema = object({
     id: APIIdString.optional(),
     name: string({required_error: errorMessages.required}).min(2, errorMessages.stringLength),
-    identifier: string({required_error: errorMessages.required}),
+    identifier: string({required_error: errorMessages.required}).min(1, errorMessages.stringLength),
     email: string().email(errorMessages.emailInvalid).optional().or(z.literal("")).optional(),
+    non_disclosure: boolean().optional(),
 });
 
 const ownershipSchema = object({

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -335,7 +335,7 @@ const OwnerSchema = object({
     id: APIIdString.optional(),
     name: string({required_error: errorMessages.required}).min(2, errorMessages.stringLength),
     identifier: string({required_error: errorMessages.required}),
-    email: string().email(errorMessages.emailInvalid).optional().or(z.literal("")),
+    email: string().email(errorMessages.emailInvalid).optional().or(z.literal("")).optional(),
 });
 
 const ownershipSchema = object({

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -8,9 +8,14 @@ import {
     useGetApartmentDetailQuery,
     useGetHousingCompanyDetailQuery,
 } from "../../app/services";
-import {DetailField, Divider, ImprovementsTable, QueryStateHandler} from "../../common/components";
+import {
+    DetailField,
+    Divider,
+    ImprovementsTable,
+    ModifyPersonInfoModal,
+    QueryStateHandler,
+} from "../../common/components";
 import {DateInput, TextAreaInput} from "../../common/components/form";
-import {ModifyPersonInfoModal} from "../../common/components/ModifyPersonInfoModal";
 import {
     IApartmentConditionOfSale,
     IApartmentConfirmedMaximumPrice,


### PR DESCRIPTION
# Hitas Pull Request

# Description

Allows submitting malformed identifier values with a warning if the value was originally malformed when modifying owner information.
Disables submitting the form when other invalid values are present including backend errors.
Fixes the toast position so that it is visible also when the user has scrolled down the page.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Modify the owner information from the owner link in the apartment details page. 
- Check that you can submit malformed social security or business numbers for owner that originally had invalid one, but when you do you get a warning. 
- Check that you cannot submit empty identifier or name values or malformed email address. 
- Check that you can see the feedback of the submission also when scrolled down the page

## Tickets

This pull request resolves all or part of the following ticket(s): HT-75
