### PR TITLE
Fix owner bulk create for obfuscated users

### DIFF
--- a/backend/hitas/models/owner.py
+++ b/backend/hitas/models/owner.py
@@ -72,7 +72,11 @@ class Owner(ExternalSafeDeleteHitasModel):
         return values
 
     @classmethod
-    def post_fetch_values_list_flat_hook(cls, value: Any, field: str) -> Any:
+    def post_fetch_values_list_flat_hook(cls, value: Any, field: str) -> None:
+        # Primary keys must be allowed so that 'bulk_create' works
+        if field == "pk":
+            return value
+
         raise RuntimeError(
             "Due to owner obfuscation, 'non_disclosure' field should always be included "
             "when fetching owners. When using .values_list(..., flat=True), this cannot be done."

--- a/backend/hitas/tests/test_owner_obfuscation.py
+++ b/backend/hitas/tests/test_owner_obfuscation.py
@@ -172,3 +172,26 @@ def test_owner_obfuscation__values_list_flat():
 
     with pytest.raises(RuntimeError, match=re.escape(msg)):
         Owner.objects.values_list("name", flat=True).first()
+
+
+@pytest.mark.django_db
+def test_owner_obfuscation__values_list_flat__pk():
+    owner: Owner = OwnerFactory.create(
+        name="Testi Testinen",
+        identifier="123456-789A",
+        email=None,
+        non_disclosure=True,
+    )
+
+    # Primary keys can be fetched, since they are required for 'bulk_create' to work
+    pk = Owner.objects.values_list("pk", flat=True).first()
+    assert owner.pk == pk
+
+    # Check that bulk create works
+    Owner.objects.bulk_create(
+        [
+            Owner(name="Testi Testinen", identifier="123456-789A", email=None, non_disclosure=True),
+        ]
+    )
+
+    assert len(Owner.objects.all()) == 2


### PR DESCRIPTION
# Hitas Pull Request

# Description

Owner.objects.bulk_create fetched owner primary keys with values_list("pk", flat=True). This should be allowed in the owner post fetch hook. Needed for oracle migration.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests

## Tickets

This pull request resolves all or part of the following ticket(s): -