### PR TITLE
backend: Fix calculating housing company value

### DIFF
--- a/backend/hitas/calculations/max_prices/max_price.py
+++ b/backend/hitas/calculations/max_prices/max_price.py
@@ -420,7 +420,8 @@ def fetch_apartment(
                         queryset=(
                             Apartment.objects.filter(
                                 building__real_estate__housing_company__uuid=housing_company_uuid,
-                            ).annotate(
+                            )
+                            .annotate(
                                 _price=Case(
                                     When(
                                         condition=Q(sales__isnull=True),
@@ -430,6 +431,7 @@ def fetch_apartment(
                                     output_field=HitasModelDecimalField(),
                                 ),
                             )
+                            .distinct()
                         ),
                         sum_field="_price",
                     ),
@@ -444,7 +446,8 @@ def fetch_apartment(
                             Apartment.objects.filter(
                                 building__real_estate__housing_company__uuid=housing_company_uuid,
                                 completion_date=OuterRef("completion_date"),
-                            ).annotate(
+                            )
+                            .annotate(
                                 _price=Case(
                                     When(
                                         condition=Q(sales__isnull=True),
@@ -454,6 +457,7 @@ def fetch_apartment(
                                     output_field=HitasModelDecimalField(),
                                 ),
                             )
+                            .distinct()
                         ),
                         sum_field="_price",
                     ),

--- a/backend/hitas/calculations/max_prices/max_price.py
+++ b/backend/hitas/calculations/max_prices/max_price.py
@@ -205,10 +205,10 @@ def calculate_max_price(
             "shares": {
                 "start": apartment.share_number_start,
                 "end": apartment.share_number_end,
-                "total": apartment.share_number_end - apartment.share_number_start + 1,
+                "total": apartment.shares_count,
             },
             "rooms": apartment.rooms,
-            "type": apartment.apartment_type.value,
+            "type": safe_attrgetter(apartment, "apartment_type.value", default=None),
             "surface_area": apartment.surface_area,
             "address": {
                 "street_address": apartment.street_address,


### PR DESCRIPTION
# Hitas Pull Request

# Description

- In some cases joining sales to apartments caused duplicate apartments in the queryset which skewed the result

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [ ] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- Automatic tests

## Tickets

This pull request resolves all or part of the following ticket(s): Bug report