### PR TITLE
Add non disclosure to owner front

### DIFF
--- a/backend/hitas/models/utils.py
+++ b/backend/hitas/models/utils.py
@@ -182,7 +182,10 @@ def deobfuscate(
     obfuscated_data: dict[str, Any] = {}
     for field in fields:
         obfuscated_data[field] = getattr(instance, field)
-        setattr(instance, field, instance._unobfuscated_data[field])
+        # Restore the obfuscated value if the value for the field is still the obfuscated value.
+        # This allows the model to be saved with new values for the obfuscated fields.
+        if obfuscated_data[field] == instance.obfuscation_rules[field]:
+            setattr(instance, field, instance._unobfuscated_data[field])
 
     # Log the access to de-obfuscated fields
     if log_access:

--- a/frontend/src/common/components/ModifyOwnerModal.tsx
+++ b/frontend/src/common/components/ModifyOwnerModal.tsx
@@ -55,8 +55,7 @@ const OwnerMutateForm = ({owner, closeModalAction}: IOwnerMutateForm) => {
     const identifierValue = ownerFormObject.watch("identifier");
 
     // helper booleans for special saving controls with invalid data
-    const hasFormChanged =
-        ownerFormObject.formState.isDirty && JSON.stringify(owner) !== JSON.stringify(ownerFormObject.getValues());
+    const hasFormChanged = Object.entries(owner).toString() !== Object.entries(ownerFormObject.getValues()).toString();
     const isMalformedIdentifier = ownerFormObject.formState.errors.identifier?.type === "custom";
     const isIdentifierEmpty = identifierValue === "";
     const isBackendErrorInIdentifier = ownerFormObject.formState.errors.identifier?.type === "backend";
@@ -156,7 +155,7 @@ interface IModifyPersonInfoModalProps {
     setIsVisible: Dispatch<SetStateAction<boolean>>;
 }
 
-export default function ModifyPersonInfoModal({owner, isVisible, setIsVisible}: IModifyPersonInfoModalProps) {
+export default function ModifyOwnerModal({owner, isVisible, setIsVisible}: IModifyPersonInfoModalProps) {
     return (
         <Dialog
             id="modify-person-info-modal"

--- a/frontend/src/common/components/ModifyPersonInfoModal.tsx
+++ b/frontend/src/common/components/ModifyPersonInfoModal.tsx
@@ -6,7 +6,7 @@ import {z} from "zod";
 import {useSaveOwnerMutation} from "../../app/services";
 import {IOwner, OwnerSchema} from "../schemas";
 import {hdsToast, validateBusinessId, validateSocialSecurityNumber} from "../utils";
-import TextInput from "./form/TextInput";
+import {Checkbox, TextInput} from "./form";
 import SaveButton from "./SaveButton";
 
 interface IOwnerMutateForm {
@@ -112,6 +112,11 @@ const OwnerMutateForm = ({owner, closeModalAction}: IOwnerMutateForm) => {
                 <TextInput
                     name="email"
                     label="Sähköpostiosoite"
+                    formObject={ownerFormObject}
+                />
+                <Checkbox
+                    label="Turvakielto"
+                    name="non_disclosure"
                     formObject={ownerFormObject}
                 />
                 {

--- a/frontend/src/common/components/NewOwnerForm.tsx
+++ b/frontend/src/common/components/NewOwnerForm.tsx
@@ -6,7 +6,7 @@ import {SubmitHandler, useForm} from "react-hook-form";
 
 import {IOwner, OwnerSchema} from "../schemas";
 import {validateSocialSecurityNumber} from "../utils";
-import {TextInput} from "./form";
+import {Checkbox, TextInput} from "./form";
 import {SaveButton} from "./index";
 
 type NewOwnerFormProps = {
@@ -22,6 +22,7 @@ const NewOwnerForm = ({confirmAction, cancelAction, isInvalidSSNAllowed, isLoadi
         name: "",
         identifier: "",
         email: "",
+        non_disclosure: false,
     };
 
     const formObject = useForm<IOwner>({
@@ -58,6 +59,11 @@ const NewOwnerForm = ({confirmAction, cancelAction, isInvalidSSNAllowed, isLoadi
             <TextInput
                 name="email"
                 label="Sähköpostiosoite"
+                formObject={formObject}
+            />
+            <Checkbox
+                name="non_disclosure"
+                label="Turvakielto"
                 formObject={formObject}
             />
             {

--- a/frontend/src/common/components/form/RelatedModelInput.tsx
+++ b/frontend/src/common/components/form/RelatedModelInput.tsx
@@ -176,7 +176,6 @@ const RelatedModelModal = ({
                             {RelatedModelMutateComponent ? (
                                 <Button
                                     theme="black"
-                                    size="small"
                                     iconLeft={<IconPlus />}
                                     onClick={() => setIsRelatedModelMutateVisible(true)}
                                 >

--- a/frontend/src/common/components/formInputField/FormOwnershipInputField.tsx
+++ b/frontend/src/common/components/formInputField/FormOwnershipInputField.tsx
@@ -118,7 +118,7 @@ export default function FormOwnershipInputField({
         (internalFilterValue.length >= MIN_LENGTH && {[relatedModelSearchField]: internalFilterValue}) || {},
         {skip: !isModalVisible}
     );
-    const [formData, setFormData] = useImmer<IOwner>({name: "", identifier: "", email: ""});
+    const [formData, setFormData] = useImmer<IOwner>({name: "", identifier: "", email: "", non_disclosure: false});
     const [createOwner, {data: createData, error: createError, isLoading: isCreating}] = useSaveOwnerMutation();
 
     const openModal = () => setIsModalVisible(true);
@@ -169,7 +169,7 @@ export default function FormOwnershipInputField({
 
     useEffect(() => {
         if (!isCreating && !createError && createData && doesAContainB(createData, formData)) {
-            setFormData({name: "", identifier: "", email: ""});
+            setFormData({name: "", identifier: "", email: "", non_disclosure: false});
             hitasToast("Omistaja lisätty onnistuneesti!");
             setDisplayedValue(`${createData.name} (${createData.identifier})`);
             setFieldValue(createData.id);

--- a/frontend/src/common/components/index.ts
+++ b/frontend/src/common/components/index.ts
@@ -11,7 +11,7 @@ import FormInputField from "./formInputField/FormInputField";
 import Heading from "./Heading";
 import ImprovementsTable from "./ImprovementsTable";
 import ListPageNumbers from "./ListPageNumbers";
-import ModifyPersonInfoModal from "./ModifyPersonInfoModal";
+import ModifyOwnerModal from "./ModifyOwnerModal";
 import NavigateBackButton from "./NavigateBackButton";
 import NewOwnerForm from "./NewOwnerForm";
 import Notifications from "./Notifications";
@@ -36,7 +36,7 @@ export {
     Heading,
     ImprovementsTable,
     ListPageNumbers,
-    ModifyPersonInfoModal,
+    ModifyOwnerModal,
     NavigateBackButton,
     NewOwnerForm,
     Notifications,

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -580,7 +580,7 @@ const OwnershipsListSchema = object({
         if (elements.filter((e) => !e.owner.id).length) {
             ctx.addIssue({
                 code: z.ZodIssueCode.custom,
-                message: "Tyhjä omistaja kenttä",
+                message: `"Omistaja"-kenttä ei voi olla tyhjä`,
             });
             return;
         }

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -8,13 +8,7 @@ import {
     useGetApartmentDetailQuery,
     useGetHousingCompanyDetailQuery,
 } from "../../app/services";
-import {
-    DetailField,
-    Divider,
-    ImprovementsTable,
-    ModifyPersonInfoModal,
-    QueryStateHandler,
-} from "../../common/components";
+import {DetailField, Divider, ImprovementsTable, ModifyOwnerModal, QueryStateHandler} from "../../common/components";
 import {DateInput, TextAreaInput} from "../../common/components/form";
 import {
     IApartmentConditionOfSale,
@@ -631,7 +625,7 @@ const LoadedApartmentDetails = ({
                         </Tabs.TabPanel>
                     </Tabs>
                 </div>
-                <ModifyPersonInfoModal
+                <ModifyOwnerModal
                     owner={owner as IOwner}
                     isVisible={isModifyPersonInfoModalVisible}
                     setIsVisible={setIsModifyPersonInfoModalVisible}

--- a/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
@@ -110,7 +110,6 @@ const OwnerMutateForm = ({formObject, formObjectFieldPath, cancelButtonAction, c
                 <SaveButton
                     onClick={handleSaveButtonClick}
                     isLoading={isSaveOwnerLoading}
-                    size="small"
                 />
             </Dialog.ActionButtons>
         </>
@@ -178,21 +177,18 @@ const OwnershipsListFieldSet = () => {
                                     onClick={() => remove(index)}
                                 />
                             </div>
+                            {!formErrors.success &&
+                                formErrors.error &&
+                                formErrors.error.issues.map((e) => (
+                                    <SimpleErrorMessage
+                                        key={`${e.code}-${e.message}`}
+                                        errorMessage={e.message}
+                                    />
+                                ))}
                         </li>
                     ))}
                 </>
             </ul>
-
-            <>
-                {!formErrors.success &&
-                    formErrors.error &&
-                    formErrors.error.issues.map((e) => (
-                        <SimpleErrorMessage
-                            key={`${e.code}-${e.message}`}
-                            errorMessage={e.message}
-                        />
-                    ))}
-            </>
 
             <div className="row row--buttons">
                 <Button
@@ -201,7 +197,7 @@ const OwnershipsListFieldSet = () => {
                     theme="black"
                     onClick={() => append(emptyOwnership)}
                 >
-                    Lisää uusi omistajuus rivi
+                    Lisää uusi omistajuusrivi
                 </Button>
             </div>
         </Fieldset>

--- a/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
@@ -6,7 +6,7 @@ import {zodResolver} from "@hookform/resolvers/zod/dist/zod";
 import {useRef, useState} from "react";
 import {z} from "zod";
 import {useGetOwnersQuery, useSaveOwnerMutation} from "../../../app/services";
-import {NumberInput, RelatedModelInput} from "../../../common/components/form";
+import {Checkbox, NumberInput, RelatedModelInput} from "../../../common/components/form";
 import TextInput from "../../../common/components/form/TextInput";
 import SaveButton from "../../../common/components/SaveButton";
 import SimpleErrorMessage from "../../../common/components/SimpleErrorMessage";
@@ -96,12 +96,16 @@ const OwnerMutateForm = ({formObject, formObjectFieldPath, cancelButtonAction, c
                     label="Sähköpostiosoite"
                     formObject={ownerFormObject}
                 />
+                <Checkbox
+                    name="non_disclosure"
+                    label="Turvakielto"
+                    formObject={ownerFormObject}
+                />
             </form>
 
             <Dialog.ActionButtons>
                 <Button
                     theme="black"
-                    size="small"
                     iconLeft={<IconArrowLeft />}
                     onClick={cancelButtonAction}
                 >

--- a/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
+++ b/frontend/src/features/apartment/ApartmentNewSalePage/OwnershipsListFieldSet.tsx
@@ -6,7 +6,7 @@ import {zodResolver} from "@hookform/resolvers/zod/dist/zod";
 import {useRef, useState} from "react";
 import {z} from "zod";
 import {useGetOwnersQuery, useSaveOwnerMutation} from "../../../app/services";
-import {Checkbox, NumberInput, RelatedModelInput} from "../../../common/components/form";
+import {NumberInput, RelatedModelInput} from "../../../common/components/form";
 import TextInput from "../../../common/components/form/TextInput";
 import SaveButton from "../../../common/components/SaveButton";
 import SimpleErrorMessage from "../../../common/components/SimpleErrorMessage";
@@ -96,16 +96,12 @@ const OwnerMutateForm = ({formObject, formObjectFieldPath, cancelButtonAction, c
                     label="Sähköpostiosoite"
                     formObject={ownerFormObject}
                 />
-                <Checkbox
-                    name="non_disclosure"
-                    label="Turvakielto"
-                    formObject={ownerFormObject}
-                />
             </form>
 
             <Dialog.ActionButtons>
                 <Button
                     theme="black"
+                    size="small"
                     iconLeft={<IconArrowLeft />}
                     onClick={cancelButtonAction}
                 >
@@ -181,18 +177,21 @@ const OwnershipsListFieldSet = () => {
                                     onClick={() => remove(index)}
                                 />
                             </div>
-                            {!formErrors.success &&
-                                formErrors.error &&
-                                formErrors.error.issues.map((e) => (
-                                    <SimpleErrorMessage
-                                        key={`${e.code}-${e.message}`}
-                                        errorMessage={e.message}
-                                    />
-                                ))}
                         </li>
                     ))}
                 </>
             </ul>
+
+            <>
+                {!formErrors.success &&
+                    formErrors.error &&
+                    formErrors.error.issues.map((e) => (
+                        <SimpleErrorMessage
+                            key={`${e.code}-${e.message}`}
+                            errorMessage={e.message}
+                        />
+                    ))}
+            </>
 
             <div className="row row--buttons">
                 <Button

--- a/frontend/src/styles/components/_ApartmentNewSalePage.sass
+++ b/frontend/src/styles/components/_ApartmentNewSalePage.sass
@@ -73,6 +73,7 @@
         @include flexbox()
         @include justify-content(space-between)
         margin-bottom: 0.25em
+        padding-right: calc(32px + var(--spacing-xs))
     .ownership-item
       @include flexbox()
       position: relative


### PR DESCRIPTION
# Hitas Pull Request

# Description

There is a checkbox for the non disclosure option in the create/edit owner views, which obfuscates the owner. However the different listings with the obfuscated owners don't work yet.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [ ] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Edit an owner and choose to have "Turvakielto" on. After saving, the user's info shouldn't be listed anywhere (== looks like "()", as the user listings aren't equipped to show an obfuscated user yet.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-479