### PR TITLE
Add report for unregulated housing companies

### DIFF
--- a/backend/hitas/models/housing_company.py
+++ b/backend/hitas/models/housing_company.py
@@ -260,11 +260,20 @@ class HousingCompanyWithAnnotations(HousingCompany):
         abstract = True
 
 
-class HousingCompanyWithReportAnnotations(HousingCompany):
+class HousingCompanyWithRegulatedReportAnnotations(HousingCompany):
     completion_date: datetime.date
     surface_area: Optional[Decimal]
     realized_acquisition_price: Optional[Decimal]
     avg_price_per_square_meter: Optional[Decimal]
+    apartment_count: int
+
+    class Meta:
+        abstract = True
+
+
+class HousingCompanyWithUnregulatedReportAnnotations(HousingCompany):
+    completion_date: datetime.date
+    release_date: Optional[datetime.date]
     apartment_count: int
 
     class Meta:

--- a/backend/hitas/urls.py
+++ b/backend/hitas/urls.py
@@ -60,6 +60,13 @@ router.register(
     basename="regulated-housing-companies-report",
 )
 
+# /api/v1/reports/download-unregulated-housing-companies-report
+router.register(
+    r"reports/download-unregulated-housing-companies-report",
+    views.UnregulatedHousingCompaniesReportView,
+    basename="unregulated-housing-companies-report",
+)
+
 # Codes
 router.register(r"postal-codes", views.HitasPostalCodeViewSet, basename="postal-code")
 router.register(r"building-types", views.BuildingTypeViewSet, basename="building-type")

--- a/backend/hitas/views/__init__.py
+++ b/backend/hitas/views/__init__.py
@@ -20,6 +20,10 @@ from hitas.views.owner import DeObfuscatedOwnerView, OwnerViewSet
 from hitas.views.postal_code import HitasPostalCodeViewSet
 from hitas.views.property_manager import PropertyManagerViewSet
 from hitas.views.real_estate import RealEstateViewSet
-from hitas.views.reports import RegulateHousingCompaniesReportView, SalesReportView
+from hitas.views.reports import (
+    RegulateHousingCompaniesReportView,
+    SalesReportView,
+    UnregulatedHousingCompaniesReportView,
+)
 from hitas.views.sales_catalog import SalesCatalogCreateView, SalesCatalogValidateView
 from hitas.views.thirty_year_regulation import ThirtyYearRegulationPostalCodesView, ThirtyYearRegulationView

--- a/backend/hitas/views/reports.py
+++ b/backend/hitas/views/reports.py
@@ -7,8 +7,15 @@ from rest_framework.request import Request
 from rest_framework.viewsets import ViewSet
 
 from hitas.services.apartment_sale import find_sales_on_interval_for_reporting
-from hitas.services.housing_company import find_regulated_housing_companies_for_reporting
-from hitas.services.reports import build_regulated_housing_companies_report_excel, build_sales_report_excel
+from hitas.services.housing_company import (
+    find_regulated_housing_companies_for_reporting,
+    find_unregulated_housing_companies_for_reporting,
+)
+from hitas.services.reports import (
+    build_regulated_housing_companies_report_excel,
+    build_sales_report_excel,
+    build_unregulated_housing_companies_report_excel,
+)
 from hitas.types import HitasJSONRenderer
 from hitas.views.utils.excel import ExcelRenderer, get_excel_response
 
@@ -46,4 +53,14 @@ class RegulateHousingCompaniesReportView(ViewSet):
         housing_companies = find_regulated_housing_companies_for_reporting()
         workbook = build_regulated_housing_companies_report_excel(housing_companies)
         filename = "Valvonnan piirissä olevat yhtiöt.xlsx"
+        return get_excel_response(filename=filename, excel=workbook)
+
+
+class UnregulatedHousingCompaniesReportView(ViewSet):
+    renderer_classes = [HitasJSONRenderer, ExcelRenderer]
+
+    def list(self, request: Request, *args, **kwargs) -> HttpResponse:
+        housing_companies = find_unregulated_housing_companies_for_reporting()
+        workbook = build_unregulated_housing_companies_report_excel(housing_companies)
+        filename = "Vapautuneet yhtiöt.xlsx"
         return get_excel_response(filename=filename, excel=workbook)

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3862,6 +3862,27 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/v1/reports/download-unregulated-housing-companies-report:
+    get:
+      description: Download an Excel report of housing companies released from regulation
+      operationId: fetch-unregulated-housing-companies-report-excel
+      tags:
+        - Reports
+      responses:
+        '200':
+          description: Successfully downloaded a report of housing companies released from regulation
+          content:
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
 components:
   parameters:
     PagingLimitParameter:


### PR DESCRIPTION
# Hitas Pull Request

# Description

Add the ability to create unregulated housing company report.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] Uncomment the lines below from the top of `backend/openapi.yaml` and open the Swagger interface at `localhost:8090`. Add `http://localhost:8090` to `CORS_ALLOWED_ORIGINS` in `backend/.env`. Add `authentication_classes = []` & `permission_classes = []` to `hitas.views.reports.UnregulatedHousingCompaniesReportView`. Use the new report endpoint from the Swagger interface while the backend is running at `localhost:8000` and observe the downloaded Excel file.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-608
