### PR TITLE
Add batch complete apartments endpoint

### DIFF
--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -1,7 +1,7 @@
 import datetime
 from datetime import date
 from decimal import Decimal
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 from django.urls import reverse
@@ -1407,3 +1407,475 @@ def test__api__regulation_status(api_client: HitasAPIClient):
         {"label": "Released by Hitas", "value": "released_by_hitas"},
         {"label": "Released by Plot Department", "value": "released_by_plot_department"},
     ]
+
+
+# Batch complete apartments tests
+
+
+@pytest.mark.django_db
+def test__api__batch_complete_apartments__improper_range(api_client: HitasAPIClient):
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+
+    url = reverse(
+        "hitas:housing-company-batch-complete-apartments",
+        kwargs={
+            "uuid": housing_company.uuid.hex,
+        },
+    )
+
+    data = {
+        "completion_date": "2020-01-01",
+        "apartment_number_start": 2,
+        "apartment_number_end": 1,
+    }
+
+    response = api_client.patch(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.json() == {
+        "error": "bad_request",
+        "fields": [
+            {
+                "field": "non_field_errors",
+                "message": "Starting apartment number must be less than or equal to the ending apartment number.",
+            },
+        ],
+        "message": "Bad request",
+        "reason": "Bad Request",
+        "status": 400,
+    }
+
+
+@pytest.mark.django_db
+def test__api__batch_complete_apartments__no_apartments(api_client: HitasAPIClient):
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+
+    url = reverse(
+        "hitas:housing-company-batch-complete-apartments",
+        kwargs={
+            "uuid": housing_company.uuid.hex,
+        },
+    )
+
+    data = {
+        "completion_date": "2020-01-01",
+        "apartment_number_start": 1,
+        "apartment_number_end": 100,
+    }
+
+    response = api_client.patch(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {
+        "completed_apartment_count": 0,
+    }
+
+
+@pytest.mark.django_db
+def test__api__batch_complete_apartments__single__in_range(api_client: HitasAPIClient):
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=1,
+        completion_date=None,
+    )
+
+    url = reverse(
+        "hitas:housing-company-batch-complete-apartments",
+        kwargs={
+            "uuid": housing_company.uuid.hex,
+        },
+    )
+
+    data = {
+        "completion_date": "2020-01-01",
+        "apartment_number_start": 1,
+        "apartment_number_end": 1,
+    }
+
+    response = api_client.patch(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {
+        "completed_apartment_count": 1,
+    }
+
+    apartment.refresh_from_db()
+    assert apartment.completion_date == date(2020, 1, 1)
+
+
+@pytest.mark.django_db
+def test__api__batch_complete_apartments__single__not_in_range(api_client: HitasAPIClient):
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=1,
+        completion_date=None,
+    )
+
+    url = reverse(
+        "hitas:housing-company-batch-complete-apartments",
+        kwargs={
+            "uuid": housing_company.uuid.hex,
+        },
+    )
+
+    data = {
+        "completion_date": "2020-01-01",
+        "apartment_number_start": 2,
+        "apartment_number_end": 100,
+    }
+
+    response = api_client.patch(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {
+        "completed_apartment_count": 0,
+    }
+
+    apartment.refresh_from_db()
+    assert apartment.completion_date is None
+
+
+@pytest.mark.django_db
+def test__api__batch_complete_apartments__single__all(api_client: HitasAPIClient):
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=1,
+        completion_date=None,
+    )
+
+    url = reverse(
+        "hitas:housing-company-batch-complete-apartments",
+        kwargs={
+            "uuid": housing_company.uuid.hex,
+        },
+    )
+
+    data = {
+        "completion_date": "2020-01-01",
+        "apartment_number_start": None,
+        "apartment_number_end": None,
+    }
+
+    response = api_client.patch(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {
+        "completed_apartment_count": 1,
+    }
+
+    apartment.refresh_from_db()
+    assert apartment.completion_date == date(2020, 1, 1)
+
+
+@pytest.mark.django_db
+def test__api__batch_complete_apartments__single__set_not_completed(api_client: HitasAPIClient):
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    apartment: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=1,
+        completion_date=datetime.date(2020, 1, 1),
+    )
+
+    url = reverse(
+        "hitas:housing-company-batch-complete-apartments",
+        kwargs={
+            "uuid": housing_company.uuid.hex,
+        },
+    )
+
+    data = {
+        "completion_date": None,
+        "apartment_number_start": 1,
+        "apartment_number_end": 1,
+    }
+
+    response = api_client.patch(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {
+        "completed_apartment_count": 1,
+    }
+
+    apartment.refresh_from_db()
+    assert apartment.completion_date is None
+
+
+@pytest.mark.django_db
+def test__api__batch_complete_apartments__multiple__in_range(api_client: HitasAPIClient):
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    apartment_1: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=1,
+        completion_date=None,
+    )
+    apartment_2: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=2,
+        completion_date=None,
+    )
+
+    url = reverse(
+        "hitas:housing-company-batch-complete-apartments",
+        kwargs={
+            "uuid": housing_company.uuid.hex,
+        },
+    )
+
+    data = {
+        "completion_date": "2020-01-01",
+        "apartment_number_start": 1,
+        "apartment_number_end": 2,
+    }
+
+    response = api_client.patch(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {
+        "completed_apartment_count": 2,
+    }
+
+    apartment_1.refresh_from_db()
+    assert apartment_1.completion_date == date(2020, 1, 1)
+
+    apartment_2.refresh_from_db()
+    assert apartment_2.completion_date == date(2020, 1, 1)
+
+
+@pytest.mark.django_db
+def test__api__batch_complete_apartments__multiple__some_in_range(api_client: HitasAPIClient):
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    apartment_1: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=1,
+        completion_date=None,
+    )
+    apartment_2: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=2,
+        completion_date=None,
+    )
+
+    url = reverse(
+        "hitas:housing-company-batch-complete-apartments",
+        kwargs={
+            "uuid": housing_company.uuid.hex,
+        },
+    )
+
+    data = {
+        "completion_date": "2020-01-01",
+        "apartment_number_start": 1,
+        "apartment_number_end": 1,
+    }
+
+    response = api_client.patch(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {
+        "completed_apartment_count": 1,
+    }
+
+    apartment_1.refresh_from_db()
+    assert apartment_1.completion_date == date(2020, 1, 1)
+
+    apartment_2.refresh_from_db()
+    assert apartment_2.completion_date is None
+
+
+@pytest.mark.django_db
+def test__api__batch_complete_apartments__multiple__different_stair(api_client: HitasAPIClient):
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    apartment_1: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=1,
+        completion_date=None,
+    )
+    apartment_2: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="B",
+        apartment_number=1,
+        completion_date=None,
+    )
+
+    url = reverse(
+        "hitas:housing-company-batch-complete-apartments",
+        kwargs={
+            "uuid": housing_company.uuid.hex,
+        },
+    )
+
+    data = {
+        "completion_date": "2020-01-01",
+        "apartment_number_start": 1,
+        "apartment_number_end": 1,
+    }
+
+    response = api_client.patch(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+
+    # Both apartments are completed, even though they are in different stairs
+    # This was agreed as the current accepted behaviour, as the most common use cases
+    # for this feature are covered by just selecting an apartment number range.
+    assert response.json() == {
+        "completed_apartment_count": 2,
+    }
+
+    apartment_1.refresh_from_db()
+    assert apartment_1.completion_date == date(2020, 1, 1)
+
+    apartment_2.refresh_from_db()
+    assert apartment_2.completion_date == date(2020, 1, 1)
+
+
+@pytest.mark.django_db
+def test__api__batch_complete_apartments__multiple__all(api_client: HitasAPIClient):
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    apartment_1: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=1,
+        completion_date=None,
+    )
+    apartment_2: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=2,
+        completion_date=None,
+    )
+
+    url = reverse(
+        "hitas:housing-company-batch-complete-apartments",
+        kwargs={
+            "uuid": housing_company.uuid.hex,
+        },
+    )
+
+    data = {
+        "completion_date": "2020-01-01",
+        "apartment_number_start": None,
+        "apartment_number_end": None,
+    }
+
+    response = api_client.patch(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {
+        "completed_apartment_count": 2,
+    }
+
+    apartment_1.refresh_from_db()
+    assert apartment_1.completion_date == date(2020, 1, 1)
+
+    apartment_2.refresh_from_db()
+    assert apartment_2.completion_date == date(2020, 1, 1)
+
+
+@pytest.mark.django_db
+def test__api__batch_complete_apartments__multiple__one_already_completed(api_client: HitasAPIClient):
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    apartment_1: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=1,
+        completion_date=None,
+    )
+    apartment_2: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=2,
+        completion_date=date(2022, 1, 1),
+    )
+
+    url = reverse(
+        "hitas:housing-company-batch-complete-apartments",
+        kwargs={
+            "uuid": housing_company.uuid.hex,
+        },
+    )
+
+    data = {
+        "completion_date": "2020-01-01",
+        "apartment_number_start": 1,
+        "apartment_number_end": 2,
+    }
+
+    response = api_client.patch(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {
+        "completed_apartment_count": 2,
+    }
+
+    apartment_1.refresh_from_db()
+    assert apartment_1.completion_date == date(2020, 1, 1)
+
+    # Completion date is changed even if set
+    apartment_2.refresh_from_db()
+    assert apartment_2.completion_date == date(2020, 1, 1)
+
+
+@pytest.mark.parametrize(
+    ["apartment_number_start", "apartment_number_end"],
+    [
+        (1, None),
+        (None, 2),
+    ],
+)
+@pytest.mark.django_db
+def test__api__batch_complete_apartments__multiple__open_range(
+    api_client: HitasAPIClient,
+    apartment_number_start: Optional[int],
+    apartment_number_end: Optional[int],
+):
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    apartment_1: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=1,
+        completion_date=None,
+    )
+    apartment_2: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        stair="A",
+        apartment_number=2,
+        completion_date=None,
+    )
+
+    url = reverse(
+        "hitas:housing-company-batch-complete-apartments",
+        kwargs={
+            "uuid": housing_company.uuid.hex,
+        },
+    )
+
+    data = {
+        "completion_date": "2020-01-01",
+        "apartment_number_start": apartment_number_start,
+        "apartment_number_end": apartment_number_end,
+    }
+
+    response = api_client.patch(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {
+        "completed_apartment_count": 2,
+    }
+
+    apartment_1.refresh_from_db()
+    assert apartment_1.completion_date == date(2020, 1, 1)
+
+    apartment_2.refresh_from_db()
+    assert apartment_2.completion_date == date(2020, 1, 1)

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -7,6 +7,9 @@ info:
   version: 1.0.0
   description: API definitions for Hitas Helsinki project.
 paths:
+
+  # Housing companies
+
   /api/v1/housing-companies:
     get:
       description: Fetch housing companies
@@ -271,6 +274,42 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/v1/housing-companies/{housing_company_id}/batch-complete-apartments:
+    patch:
+      description: Mark multiple apartments in this housing company as completed
+      operationId: partial-update-batch-complete-apartments
+      tags:
+        - Housing companies
+      parameters:
+        - name: housing_company_id
+          required: true
+          in: path
+          description: Housing company ID
+          schema:
+            type: string
+            example: a3181b8fa60b47df8ccba0d554a913bb
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              $ref: '#/components/schemas/BatchCompleteDetails'
+      responses:
+        '200':
+          description: Successfully read a housing company details
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                $ref: '#/components/schemas/BatchCompleteResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -4648,6 +4687,50 @@ components:
                     example: 13359.75
                   completion_date:
                     $ref: '#/components/schemas/YearMonth'
+
+    BatchCompleteDetails:
+      description: Results from housing company apartment batch completion endpoint
+      type: object
+      additionalProperties: false
+      required:
+        - completion_date
+        - apartment_number_start
+        - apartment_number_end
+      properties:
+        completion_date:
+          description: Completion date for all the apartments. If null, mark apartments as not completed.
+          type: string
+          nullable: true
+          format: date
+          example: 2022-01-01
+        apartment_number_start:
+          description: |-
+            Mark apartments as completed starting from this apartment number.
+            If 'apartment_number_end' is null, and this is given, mark all apartments starting from this apartment as completed.
+            If this and 'apartment_number_end' are null, mark all apartments as completed.
+          type: integer
+          nullable: true
+          example: 1
+        apartment_number_end:
+          description: |-
+            Mark apartment as completed ending at this apartment number.
+            If 'apartment_number_start' is null, and this is given, mark all apartments until this apartment as completed.
+            If this and 'apartment_number_start' are null, mark all apartments as completed.
+          type: integer
+          nullable: true
+          example: 10
+
+    BatchCompleteResult:
+      description: Results from housing company apartment batch completion endpoint
+      type: object
+      additionalProperties: false
+      required:
+        - completed_apartment_count
+      properties:
+        completed_apartment_count:
+          description: How many apartments were marked as completed?
+          type: integer
+          example: 12
 
     RealEstate:
       description: Single real estate


### PR DESCRIPTION
# Hitas Pull Request

# Description

Add an endpoint for marking multiple apartments as completed simultaneously.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] Use the endpoint to mark apartments as completed and observe the results.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-466