### PR TITLE
front: Owners list in codes tab & fixes to modify owner info modal

### DIFF
--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -16,6 +16,7 @@ import {
     IConditionOfSale,
     ICreateConditionOfSale,
     IExternalSalesDataResponse,
+    IFilterOwnersQuery,
     IHousingCompanyApartmentQuery,
     IHousingCompanyDetails,
     IHousingCompanyListResponse,
@@ -24,6 +25,7 @@ import {
     IIndexQuery,
     IIndexResponse,
     IOwner,
+    IOwnersResponse,
     IPostalCodeResponse,
     IRealEstate,
     IThirtyYearAvailablePostalCodesResponse,
@@ -221,11 +223,12 @@ const listApi = hitasApi.injectEndpoints({
             }),
             providesTags: [{type: "Apartment", id: "LIST"}],
         }),
-        getOwners: builder.query<ICodeResponse, object>({
-            query: (params: object) => ({
+        getOwners: builder.query<IOwnersResponse, IFilterOwnersQuery>({
+            query: (params: IFilterOwnersQuery) => ({
                 url: "owners",
                 params: params,
             }),
+            providesTags: (result, error, arg) => [{type: "Owner"}],
         }),
         getPropertyManagers: builder.query<IApartmentListResponse, object>({
             query: (params: object) => ({

--- a/frontend/src/common/components/ModifyOwnerModal.tsx
+++ b/frontend/src/common/components/ModifyOwnerModal.tsx
@@ -55,8 +55,8 @@ const OwnerMutateForm = ({owner, closeModalAction}: IOwnerMutateForm) => {
     const identifierValue = ownerFormObject.watch("identifier");
 
     // helper booleans for special saving controls with invalid data
-    const hasFormChanged = Object.entries(owner).toString() !== Object.entries(ownerFormObject.getValues()).toString();
-    const isMalformedIdentifier = ownerFormObject.formState.errors.identifier?.type === "custom";
+    const hasFormChanged = ownerFormObject.formState.isDirty;
+    const isMalformedIdentifier = !!ownerFormObject.formState.errors.identifier;
     const isIdentifierEmpty = identifierValue === "";
     const isBackendErrorInIdentifier = ownerFormObject.formState.errors.identifier?.type === "backend";
     const isOtherErrorsThanIdentifier = Object.keys(ownerFormObject.formState.errors).some(
@@ -75,9 +75,12 @@ const OwnerMutateForm = ({owner, closeModalAction}: IOwnerMutateForm) => {
         !hasFormChanged;
 
     useEffect(() => {
-        // validate the initial form values and set the initial identifier validity
+        // validate the initial form values
         ownerFormObject.trigger().then(() => {
+            // set the initial identifier validity
             setIsInitialIdentifierValid(!ownerFormObject.formState.errors.identifier);
+            // set initial focus
+            setTimeout(() => ownerFormObject.setFocus("name"), 5);
         });
         // eslint-disable-next-line
     }, []);

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -54,8 +54,9 @@ export const errorMessages = {
     required: "Pakollinen kenttä",
     postalCodeFormat: "Virheellinen postinumero",
     stringLength: "Liian lyhyt arvo",
-    stringMin: "Liian vähän kirjaimia",
-    stringMax: "Liian monta kirjainta",
+    stringMin: "Liian lyhyt arvo",
+    stringMax: "Liian monta merkkiä",
+    stringMaxIs: "Maksimimerkkimäärä on ",
     numberLength: "Liian lyhyt arvo",
     numberType: "Arvon pitää olla numero",
     numberMin: "Liian pieni arvo",
@@ -332,8 +333,12 @@ const ApartmentLinkedModelsSchema = object({
 
 const OwnerSchema = object({
     id: APIIdString.optional(),
-    name: string({required_error: errorMessages.required}).min(2, errorMessages.stringLength),
-    identifier: string({required_error: errorMessages.required}).min(1, errorMessages.stringLength),
+    name: string({required_error: errorMessages.required})
+        .min(2, errorMessages.stringLength)
+        .max(256, errorMessages.stringMaxIs + "256"),
+    identifier: string({required_error: errorMessages.required})
+        .min(1, errorMessages.stringLength)
+        .max(11, errorMessages.stringMaxIs + "11"),
     email: string().email(errorMessages.emailInvalid).optional().or(z.literal("")),
     non_disclosure: boolean().optional(),
 });
@@ -990,6 +995,11 @@ const IndexResponseSchema = object({
     contents: IndexSchema.array(),
 });
 
+const OwnersResponseSchema = object({
+    page: PageInfoSchema,
+    contents: OwnerSchema.array(),
+});
+
 // Query Parameters
 
 const HousingCompanyApartmentQuerySchema = object({
@@ -1023,6 +1033,14 @@ const ThirtyYearRegulationQuerySchema = object({
         .optional(),
 });
 
+const FilterOwnersQuerySchema = object({
+    name: string().optional(),
+    identifier: string().optional(),
+    email: string().optional(),
+    limit: number().int().optional(),
+    page: number().int().optional(),
+});
+
 // ********************************
 // * Exports
 // ********************************
@@ -1049,11 +1067,13 @@ export {
     HousingCompanyListResponseSchema,
     ApartmentListResponseSchema,
     CodeResponseSchema,
+    OwnersResponseSchema,
     PostalCodeResponseSchema,
     IndexResponseSchema,
     HousingCompanyApartmentQuerySchema,
     ApartmentQuerySchema,
     IndexQuerySchema,
+    FilterOwnersQuerySchema,
     ApartmentSaleFormSchema,
     OwnerSchema,
     OwnershipFormSchema,
@@ -1120,11 +1140,13 @@ export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;
 export type IHousingCompanyListResponse = z.infer<typeof HousingCompanyListResponseSchema>;
 export type IApartmentListResponse = z.infer<typeof ApartmentListResponseSchema>;
 export type ICodeResponse = z.infer<typeof CodeResponseSchema>;
+export type IOwnersResponse = z.infer<typeof OwnersResponseSchema>;
 export type IPostalCodeResponse = z.infer<typeof PostalCodeResponseSchema>;
 export type IIndexResponse = z.infer<typeof IndexResponseSchema>;
 export type IHousingCompanyApartmentQuery = z.infer<typeof HousingCompanyApartmentQuerySchema>;
 export type IApartmentQuery = z.infer<typeof ApartmentQuerySchema>;
 export type IIndexQuery = z.infer<typeof IndexQuerySchema>;
+export type IFilterOwnersQuery = z.infer<typeof FilterOwnersQuerySchema>;
 
 export type IExternalSalesDataResponse = z.infer<typeof ExternalSalesDataResponseSchema>;
 export type IThirtyYearRegulationResponse = z.infer<typeof ThirtyYearRegulationResponseSchema>;

--- a/frontend/src/features/codes/Codes.tsx
+++ b/frontend/src/features/codes/Codes.tsx
@@ -1,6 +1,5 @@
 import {Tabs} from "hds-react";
-
-import IndicesList from "./IndicesList";
+import {IndicesList, OwnersList} from "./";
 
 const Codes = (): JSX.Element => {
     return (
@@ -10,7 +9,7 @@ const Codes = (): JSX.Element => {
                 <Tabs.TabList>
                     <Tabs.Tab>Indeksit</Tabs.Tab>
                     <Tabs.Tab>Postinumerot</Tabs.Tab>
-                    <Tabs.Tab>Laskentasäännöt</Tabs.Tab>
+                    <Tabs.Tab>Omistajat</Tabs.Tab>
                     <Tabs.Tab>Rahoitusmuodot</Tabs.Tab>
                 </Tabs.TabList>
                 <Tabs.TabPanel className="view--codes__tab--indices">
@@ -19,8 +18,8 @@ const Codes = (): JSX.Element => {
                 <Tabs.TabPanel className="view--codes__tab--postalcodes">
                     <h1>Postinumerot</h1>
                 </Tabs.TabPanel>
-                <Tabs.TabPanel className="view--codes__tab--rules">
-                    <h1>Laskentasäännöt</h1>
+                <Tabs.TabPanel className="view--codes__tab--owners">
+                    <OwnersList />
                 </Tabs.TabPanel>
                 <Tabs.TabPanel className="view--codes__tab--financing-methods">
                     <h1>Rahoitusmuodot</h1>

--- a/frontend/src/features/codes/OwnersList.tsx
+++ b/frontend/src/features/codes/OwnersList.tsx
@@ -1,0 +1,113 @@
+import {IconCrossCircle, IconSearch, TextInput} from "hds-react";
+import {useCallback, useRef, useState} from "react";
+import {useGetOwnersQuery} from "../../app/services";
+import {ModifyOwnerModal, QueryStateHandler} from "../../common/components";
+import {IFilterOwnersQuery, IOwner} from "../../common/schemas";
+
+const OwnerResultList: React.FC<{params: IFilterOwnersQuery}> = ({params}) => {
+    const MIN_LENGTH = 2; // Minimum length before applying filter
+    const MAX_ROWS = 12; // Maximum rows to show
+    if (params.name?.length && params.name?.length < MIN_LENGTH) {
+        delete params.name;
+    }
+    if (params.identifier?.length && params.identifier?.length < MIN_LENGTH) {
+        delete params.identifier;
+    }
+    // get the data
+    const {data, error, isLoading} = useGetOwnersQuery({...params, limit: MAX_ROWS});
+
+    // state for the modal
+    const [isModifyOwnerModalOpen, setIsModifyOwnerModalOpen] = useState(false);
+    const [owner, setOwner] = useState<IOwner | undefined>(undefined);
+
+    // action for the row click
+    const editFn = (ownerEdited: IOwner) => {
+        setIsModifyOwnerModalOpen(true);
+        setOwner(ownerEdited);
+    };
+    return (
+        <QueryStateHandler
+            data={data}
+            error={error}
+            isLoading={isLoading}
+        >
+            <div className="list-headers">
+                <div>Nimi</div>
+                <div>Henkilö- tai Y-tunnus</div>
+            </div>
+            <ul className="results-list">
+                {data?.contents.map((owner: IOwner) => (
+                    <div
+                        key={owner.id}
+                        className="results-list__item"
+                        onClick={(e) => {
+                            e.preventDefault();
+                            editFn(owner);
+                        }}
+                    >
+                        <span>{owner.name}</span>
+                        <span>{owner.identifier}</span>
+                    </div>
+                ))}
+            </ul>
+            <span className="list-footer">
+                Näytetään {data?.page.size}/{data?.page.total_items} hakutulosta
+            </span>
+            <ModifyOwnerModal
+                owner={owner as IOwner}
+                isVisible={isModifyOwnerModalOpen}
+                setIsVisible={setIsModifyOwnerModalOpen}
+            />
+        </QueryStateHandler>
+    );
+};
+
+export default function OwnersList() {
+    // search strings
+    const [filterParams, setFilterParams] = useState<IFilterOwnersQuery>({name: "", identifier: ""});
+
+    // focus the field when clicking its cross circle icon
+    const nameSearchRef = useRef<HTMLInputElement>(null);
+    const identifierSearchRef = useRef<HTMLInputElement>(null);
+    const focus = useCallback(
+        (field: string) => {
+            if (field === "name") {
+                nameSearchRef.current?.focus();
+            } else if (field === "identifier") {
+                identifierSearchRef.current?.focus();
+            }
+        },
+        [nameSearchRef, identifierSearchRef]
+    );
+    const clearAndFocus = (field: string) => {
+        setFilterParams((prev) => ({...prev, [field]: ""}));
+        focus(field);
+    };
+
+    return (
+        <div className="listing">
+            <div className="filters">
+                <TextInput
+                    id="filter__name"
+                    ref={nameSearchRef}
+                    label="Nimi"
+                    value={filterParams.name}
+                    onChange={(e) => setFilterParams((prev) => ({...prev, name: e.target.value}))}
+                    onButtonClick={() => clearAndFocus("name")}
+                    autoFocus
+                    buttonIcon={filterParams.name ? <IconCrossCircle /> : <IconSearch />}
+                />
+                <TextInput
+                    id="filter__identifier"
+                    ref={identifierSearchRef}
+                    label="Henkilö- tai Y-tunnus"
+                    value={filterParams.identifier}
+                    onChange={(e) => setFilterParams((prev) => ({...prev, identifier: e.target.value}))}
+                    onButtonClick={() => clearAndFocus("identifier")}
+                    buttonIcon={filterParams.identifier ? <IconCrossCircle /> : <IconSearch />}
+                />
+            </div>
+            <OwnerResultList params={filterParams} />
+        </div>
+    );
+}

--- a/frontend/src/features/codes/index.ts
+++ b/frontend/src/features/codes/index.ts
@@ -1,4 +1,5 @@
 import Codes from "./Codes";
 import IndicesList from "./IndicesList";
+import OwnersList from "./OwnersList";
 
-export {Codes, IndicesList};
+export {Codes, IndicesList, OwnersList};

--- a/frontend/src/styles/components/_Codes.sass
+++ b/frontend/src/styles/components/_Codes.sass
@@ -40,7 +40,6 @@
 
 
   .results
-    height: 510px
 
     &-list
       border: 1px solid #888
@@ -101,3 +100,8 @@
     @include flexbox()
     @include justify-content(center)
     padding-top: $spacing-layout-m
+
+  .list-footer
+      margin-left: auto
+      margin-right: auto
+      margin-top: 1em


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Added owners search to the owners tab in codes. Clicking the row in the search results opens the owner info modification modal.
- Fixed validation issue, completed validation rules to align with the backend validation rules and set the initial focus for the modify owner info modal.
- Ensured the owners list updates after modifying the owner info.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Open the owner search from the owners tab in codes. Ensure you can search owners with part of the name and/or identifier. Click a row in the search results list and check that the initial focus and validations work as expected in the owner modification modal. Modify and save the owner information and check that the data in the search results list updated correspondingly.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-588
