### PR TITLE
Remove "Helsingin kaupunki" from max price estimate

### DIFF
--- a/backend/hitas/templates/unconfirmed_maximum_price.jinja
+++ b/backend/hitas/templates/unconfirmed_maximum_price.jinja
@@ -10,8 +10,6 @@
 {% endif %}
 
 {% block content %}
-    {% set address = "" %}
-    <h3>Helsingin kaupunki</h3>
     <h3>
         {{ apartment.address.street_address }} {{ apartment.address.stair }} {{ apartment.address.apartment_number }}
         <br>{{ apartment.address.postal_code }} {{ apartment.address.city|upper }}

--- a/backend/hitas/tests/apis/apartment_max_price/test_api_unconfirmed_max_price_pdf.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_unconfirmed_max_price_pdf.py
@@ -84,7 +84,6 @@ def test__api__unconfirmed_max_price_pdf(api_client: HitasAPIClient, freezer):
         00580 Helsinki
         Url http://www.hel.fi/hitas
         00099 HELSINGIN KAUPUNKI
-        Helsingin kaupunki
         {apartment.address}
         {apartment.postal_code.value} HELSINKI
         HITAS-HUONEISTON ENIMMÄISHINTA
@@ -298,7 +297,6 @@ def test__api__unconfirmed_max_price_pdf__past_date(api_client: HitasAPIClient, 
         00580 Helsinki
         Url http://www.hel.fi/hitas
         00099 HELSINGIN KAUPUNKI
-        Helsingin kaupunki
         {apartment.address}
         {apartment.postal_code.value} HELSINKI
         HITAS-HUONEISTON ENIMMÄISHINTA


### PR DESCRIPTION
# Hitas Pull Request

# Description

Don't include the title "Helsingin kaupunki" in max price estimates. In the old system, it was the receiver's name, but in the new system, the pdf should be generic for apartment owners and property managers, etc.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [x] Check the max price estimate pdf 

## Tickets

This pull request resolves all or part of the following ticket(s): HT-622
