### PR TITLE
Releasing by plot department & 30y fixes

### DIFF
--- a/backend/hitas/services/thirty_year_regulation.py
+++ b/backend/hitas/services/thirty_year_regulation.py
@@ -936,7 +936,7 @@ def convert_thirty_year_regulation_results_to_comparison_data(
                         postal_code=row.housing_company.property_manager.postal_code,
                         city=row.housing_company.property_manager.city,
                     ),
-                    last_modified=row.last_modified.date(),
+                    last_modified=row.last_modified.date() if row.last_modified else None,
                 ),
                 letter_fetched=row.letter_fetched,
                 current_regulation_status=row.housing_company.regulation_status.value,

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -956,7 +956,7 @@ const PageInfoSchema = object({
 });
 
 const ErrorResponseSchema = object({
-    error: string().email(),
+    error: string(),
     status: number(),
     reason: string(),
     message: string(),
@@ -966,6 +966,15 @@ const ErrorResponseSchema = object({
     })
         .array()
         .optional(),
+    data: object({
+        status: number(),
+        data: object({
+            error: string(),
+            message: string(),
+            reason: string(),
+            status: number(),
+        }),
+    }).optional(),
 });
 
 // List responses

--- a/frontend/src/features/functions/ThirtyYearRegulation.tsx
+++ b/frontend/src/features/functions/ThirtyYearRegulation.tsx
@@ -125,6 +125,8 @@ const ThirtyYearRegulation = () => {
     const regulationData: object | undefined = getRegulationData ?? makeRegulationData;
     const isRegulationLoading = isGetRegulationLoading ?? isMakeRegulationLoading;
     const regulationError = getRegulationError ?? makeRegulationError;
+    const hasRegulationResults = (!getRegulationError && !!getRegulationData) || !!regulationData;
+    const hasExternalSalesData = !isExternalSalesDataLoading && !externalSalesDataLoadError && !!externalSalesData;
 
     // ******************
     // * Event handlers *
@@ -157,9 +159,6 @@ const ThirtyYearRegulation = () => {
                     setIsErrorModalOpen(true);
                 });
     };
-
-    const hasRegulationResults = (!getRegulationError && !!getRegulationData) || !!regulationData;
-    const hasExternalSalesData = !isExternalSalesDataLoading && !externalSalesDataLoadError && !!externalSalesData;
 
     return (
         <div className="view--functions__thirty-year-regulation">

--- a/frontend/src/features/functions/ThirtyYearRegulation.tsx
+++ b/frontend/src/features/functions/ThirtyYearRegulation.tsx
@@ -133,15 +133,15 @@ const ThirtyYearRegulation = () => {
     const onCompareButtonClick = (data) => {
         // format eventual skipped data to match the API format
         const skippedArray: {postalCode: string; replacements: string[]}[] = [];
-        if (data.skipped) {
-            data.skipped.forEach((skipped) => {
+        if (data?.skipped) {
+            data?.skipped.forEach((skipped) => {
                 skippedArray.push({
                     postalCode: skipped.missingCode,
                     replacements: [skipped.postalCode1, skipped.postalCode2],
                 });
             });
         } else
-            makeRegulation({
+            return makeRegulation({
                 data: {
                     calculationDate: formDate,
                     replacementPostalCodes: skippedArray,
@@ -158,8 +158,7 @@ const ThirtyYearRegulation = () => {
                 });
     };
 
-    const hasRegulationResults =
-        (!isGetRegulationLoading && !getRegulationError && !!getRegulationData) || !!regulationData;
+    const hasRegulationResults = (!getRegulationError && !!getRegulationData) || !!regulationData;
     const hasExternalSalesData = !isExternalSalesDataLoading && !externalSalesDataLoadError && !!externalSalesData;
 
     return (
@@ -238,7 +237,7 @@ const ThirtyYearRegulation = () => {
                         </div>
                         <ThirtyYearResults
                             hasResults={hasRegulationResults}
-                            hasData={hasExternalSalesData}
+                            hasExternalSalesData={hasExternalSalesData}
                             data={regulationData}
                             error={regulationError}
                             isLoading={isRegulationLoading}

--- a/frontend/src/features/functions/components/ThirtyYearLoadedResults.tsx
+++ b/frontend/src/features/functions/components/ThirtyYearLoadedResults.tsx
@@ -8,20 +8,28 @@ const ThirtyYearLoadedResults = ({data, calculationDate, reCalculateFn}): JSX.El
     const releasedFromRegulation = data?.released_from_regulation ?? [];
     const releasedCompanies = [...automaticallyReleased, ...releasedFromRegulation];
     const stayingCompanies = data?.stays_regulated ?? [];
+    const manuallyReleasedCompanies = stayingCompanies.filter(
+        (company) => company.current_regulation_status !== "regulated"
+    );
+    const displayedStayingCompanies = stayingCompanies.filter(
+        (company) => company.current_regulation_status === "regulated"
+    );
     const skippedCompanies = data?.skipped ?? [];
     const obfuscatedOwners = data?.obfuscated_owners ?? [];
     const [isModalOpen, setIsModalOpen] = useState(obfuscatedOwners.length > 0);
     const [isNoCompaniesModalOpen, setIsNoCompaniesModalOpen] = useState(true);
 
     const ResultsList = ({category}) => {
-        const companies = category === "freed" ? releasedCompanies : stayingCompanies;
+        const companies = category === "freed" ? releasedCompanies : displayedStayingCompanies;
+        const hasManuallyReleasedCompanies = category === "freed" && manuallyReleasedCompanies.length > 0;
         return (
             <div className={`companies companies--${category}`}>
                 <Heading type="body">
-                    {category === "freed" ? "Valvonnasta vapautuvat " : "Valvonnan piiriin jäävät "}
+                    {category === "freed" ? "Valvonnasta vapautetut " : "Valvonnan piiriin jäävät "}
                     yhtiöt
                 </Heading>
                 <div className="list">
+                    {hasManuallyReleasedCompanies && <h3>Vertailussa vapautuneet yhtiöt</h3>}
                     {companies.length > 0 ? (
                         <div className="list-headers">
                             <div className="list-header name">Nimi ja osoite</div>
@@ -45,6 +53,21 @@ const ThirtyYearLoadedResults = ({data, calculationDate, reCalculateFn}): JSX.El
                             />
                         ))}
                     </ul>
+                    {hasManuallyReleasedCompanies && (
+                        <>
+                            <h3>Tontit-yksikön päätöksellä vapautetut yhtiöt</h3>
+                            <ul className="results-list">
+                                {manuallyReleasedCompanies.map((item, idx) => (
+                                    <ThirtyYearResultListItem
+                                        company={item}
+                                        calculationDate={calculationDate}
+                                        category={category}
+                                        key={idx}
+                                    />
+                                ))}
+                            </ul>
+                        </>
+                    )}
                 </div>
             </div>
         );
@@ -99,7 +122,7 @@ const ThirtyYearLoadedResults = ({data, calculationDate, reCalculateFn}): JSX.El
                     <Dialog.Content>
                         Vertailun yhteydessä obfuskoidut omistajat:
                         <ul>
-                            {obfuscatedOwners.sort().map((owner, idx) => (
+                            {obfuscatedOwners.map((owner, idx) => (
                                 <li key={idx}>{owner.name}</li>
                             ))}
                         </ul>

--- a/frontend/src/features/functions/components/ThirtyYearLoadedResults.tsx
+++ b/frontend/src/features/functions/components/ThirtyYearLoadedResults.tsx
@@ -3,6 +3,18 @@ import {useState} from "react";
 import {CloseButton, Heading} from "../../../common/components";
 import {ThirtyYearResultListItem, ThirtyYearSkippedList} from "./";
 
+const ListHeaders = () => (
+    <div className="list-headers">
+        <div className="list-header name">Nimi ja osoite</div>
+        <div className="list-header date">Valmistumispäivä</div>
+        <div className="list-header property-manager">
+            Isännöitsijätiedot
+            <br />
+            päivitetty viimeksi
+        </div>
+    </div>
+);
+
 const ThirtyYearLoadedResults = ({data, calculationDate, reCalculateFn}): JSX.Element => {
     const automaticallyReleased = data?.automatically_released ?? [];
     const releasedFromRegulation = data?.released_from_regulation ?? [];
@@ -18,18 +30,6 @@ const ThirtyYearLoadedResults = ({data, calculationDate, reCalculateFn}): JSX.El
     const obfuscatedOwners = data?.obfuscated_owners ?? [];
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [isNoCompaniesModalOpen, setIsNoCompaniesModalOpen] = useState(true);
-
-    const ListHeaders = () => (
-        <div className="list-headers">
-            <div className="list-header name">Nimi ja osoite</div>
-            <div className="list-header date">Valmistumispäivä</div>
-            <div className="list-header property-manager">
-                Isännöitsijätiedot
-                <br />
-                päivitetty viimeksi
-            </div>
-        </div>
-    );
 
     const ResultsList = ({category}) => {
         const companies = category === "freed" ? releasedCompanies : displayedStayingCompanies;
@@ -55,12 +55,12 @@ const ThirtyYearLoadedResults = ({data, calculationDate, reCalculateFn}): JSX.El
                     {companies.length > 0 ? (
                         <>
                             <ul className="results-list">
-                                {companies.map((item, idx) => (
+                                {companies.map((item) => (
                                     <ThirtyYearResultListItem
                                         company={item}
                                         calculationDate={calculationDate}
                                         category={category}
-                                        key={idx}
+                                        key={item.id}
                                     />
                                 ))}
                             </ul>
@@ -72,12 +72,12 @@ const ThirtyYearLoadedResults = ({data, calculationDate, reCalculateFn}): JSX.El
                         <>
                             <h3>Tontit-yksikön päätöksellä vapautetut yhtiöt</h3>
                             <ul className="results-list">
-                                {manuallyReleasedCompanies.map((item, idx) => (
+                                {manuallyReleasedCompanies.map((item) => (
                                     <ThirtyYearResultListItem
                                         company={item}
                                         calculationDate={calculationDate}
                                         category={category}
-                                        key={idx}
+                                        key={item.id}
                                     />
                                 ))}
                             </ul>
@@ -137,8 +137,8 @@ const ThirtyYearLoadedResults = ({data, calculationDate, reCalculateFn}): JSX.El
                     <Dialog.Content>
                         Vertailun yhteydessä obfuskoidut omistajat:
                         <ul>
-                            {obfuscatedOwners.map((owner, idx) => (
-                                <li key={idx}>{owner.name}</li>
+                            {obfuscatedOwners.map((owner) => (
+                                <li key={owner.id}>{owner.name}</li>
                             ))}
                         </ul>
                     </Dialog.Content>

--- a/frontend/src/features/functions/components/ThirtyYearLoadedResults.tsx
+++ b/frontend/src/features/functions/components/ThirtyYearLoadedResults.tsx
@@ -99,8 +99,8 @@ const ThirtyYearLoadedResults = ({data, calculationDate, reCalculateFn}): JSX.El
                     <Dialog.Content>
                         Vertailun yhteydessä obfuskoidut omistajat:
                         <ul>
-                            {obfuscatedOwners.map((owner) => (
-                                <li key={owner.id}>{owner.name}</li>
+                            {obfuscatedOwners.sort().map((owner, idx) => (
+                                <li key={idx}>{owner.name}</li>
                             ))}
                         </ul>
                     </Dialog.Content>

--- a/frontend/src/features/functions/components/ThirtyYearLoadedResults.tsx
+++ b/frontend/src/features/functions/components/ThirtyYearLoadedResults.tsx
@@ -1,4 +1,4 @@
-import {Dialog} from "hds-react";
+import {Button, Dialog} from "hds-react";
 import {useState} from "react";
 import {CloseButton, Heading} from "../../../common/components";
 import {ThirtyYearResultListItem, ThirtyYearSkippedList} from "./";
@@ -16,8 +16,20 @@ const ThirtyYearLoadedResults = ({data, calculationDate, reCalculateFn}): JSX.El
     );
     const skippedCompanies = data?.skipped ?? [];
     const obfuscatedOwners = data?.obfuscated_owners ?? [];
-    const [isModalOpen, setIsModalOpen] = useState(obfuscatedOwners.length > 0);
+    const [isModalOpen, setIsModalOpen] = useState(false);
     const [isNoCompaniesModalOpen, setIsNoCompaniesModalOpen] = useState(true);
+
+    const ListHeaders = () => (
+        <div className="list-headers">
+            <div className="list-header name">Nimi ja osoite</div>
+            <div className="list-header date">Valmistumispäivä</div>
+            <div className="list-header property-manager">
+                Isännöitsijätiedot
+                <br />
+                päivitetty viimeksi
+            </div>
+        </div>
+    );
 
     const ResultsList = ({category}) => {
         const companies = category === "freed" ? releasedCompanies : displayedStayingCompanies;
@@ -27,32 +39,35 @@ const ThirtyYearLoadedResults = ({data, calculationDate, reCalculateFn}): JSX.El
                 <Heading type="body">
                     {category === "freed" ? "Valvonnasta vapautetut " : "Valvonnan piiriin jäävät "}
                     yhtiöt
+                    {category === "freed" && obfuscatedOwners.length > 0 && (
+                        <Button
+                            theme="black"
+                            variant="secondary"
+                            size="small"
+                            onClick={() => setIsModalOpen((prev) => !prev)}
+                        >
+                            Obfuskoidut omistajat
+                        </Button>
+                    )}
                 </Heading>
                 <div className="list">
-                    {hasManuallyReleasedCompanies && <h3>Vertailussa vapautuneet yhtiöt</h3>}
+                    <ListHeaders />
                     {companies.length > 0 ? (
-                        <div className="list-headers">
-                            <div className="list-header name">Nimi ja osoite</div>
-                            <div className="list-header date">Valmistumispäivä</div>
-                            <div className="list-header property-manager">
-                                Isännöitsijätiedot
-                                <br />
-                                päivitetty viimeksi
-                            </div>
-                        </div>
+                        <>
+                            <ul className="results-list">
+                                {companies.map((item, idx) => (
+                                    <ThirtyYearResultListItem
+                                        company={item}
+                                        calculationDate={calculationDate}
+                                        category={category}
+                                        key={idx}
+                                    />
+                                ))}
+                            </ul>
+                        </>
                     ) : (
-                        <p>Ei listattavia yhtiöitä.</p>
+                        <p>Vertailussa ei automaattisesti vapautunut yhtiöitä.</p>
                     )}
-                    <ul className="results-list">
-                        {companies.map((item, idx) => (
-                            <ThirtyYearResultListItem
-                                company={item}
-                                calculationDate={calculationDate}
-                                category={category}
-                                key={idx}
-                            />
-                        ))}
-                    </ul>
                     {hasManuallyReleasedCompanies && (
                         <>
                             <h3>Tontit-yksikön päätöksellä vapautetut yhtiöt</h3>

--- a/frontend/src/features/functions/components/ThirtyYearResultListItem.tsx
+++ b/frontend/src/features/functions/components/ThirtyYearResultListItem.tsx
@@ -64,7 +64,7 @@ const ThirtyYearResultListItem = ({company, calculationDate, category}) => {
                         {isHousingCompanyReleased ? "Vapautettu" : "Vapauta"}
                     </Button>
                 )}
-                {!isHousingCompanyReleased && (
+                {company.current_regulation_status !== "released_by_plot_department" && (
                     <Button
                         theme="black"
                         onClick={handleClickDownloadPDFButton}

--- a/frontend/src/features/functions/components/ThirtyYearResults.tsx
+++ b/frontend/src/features/functions/components/ThirtyYearResults.tsx
@@ -1,10 +1,11 @@
 import {Button} from "hds-react";
+import {useState} from "react";
 import {QueryStateHandler} from "../../../common/components";
 import {ThirtyYearLoadedResults} from "./index";
 
 export default function ThirtyYearResults({
     hasResults,
-    hasData,
+    hasExternalSalesData,
     data,
     error,
     isLoading,
@@ -12,29 +13,45 @@ export default function ThirtyYearResults({
     priceCeiling,
     compareFn,
 }) {
+    // Because the compareFn doesn't play ball with isLoading, we need to keep track of whether the button has been
+    // clicked. Clicking it again while the comparison is running results in errors.
+    const [isButtonClicked, setIsButtonClicked] = useState(false);
+    let req;
+    const handleCompareButton = () => {
+        setIsButtonClicked(true);
+        compareFn()
+            .then(() => setIsButtonClicked(false)) // wait until the comparison is done before re-enabling the button
+            .catch((e) => {
+                // eslint-disable-next-line no-console
+                console.warn(e);
+                setIsButtonClicked(false); // in the event of an error, re-enable the button
+            });
+    };
     return (
         <>
-            {hasData && hasResults && (
-                <QueryStateHandler
-                    data={data}
-                    error={data ? undefined : error}
-                    isLoading={isLoading}
-                    attemptedAction="hae suoritetun vertailun tulokset"
-                >
-                    <ThirtyYearLoadedResults
+            {req?.status === "pending" ||
+                (hasExternalSalesData && hasResults && (
+                    <QueryStateHandler
                         data={data}
-                        calculationDate={date}
-                        reCalculateFn={compareFn}
-                    />
-                </QueryStateHandler>
-            )}
+                        error={data ? undefined : error}
+                        isLoading={isLoading}
+                        attemptedAction="hae suoritetun vertailun tulokset"
+                    >
+                        <ThirtyYearLoadedResults
+                            data={data}
+                            calculationDate={date}
+                            reCalculateFn={compareFn}
+                        />
+                    </QueryStateHandler>
+                ))}
             {!hasResults && !(data as unknown as {skipped: object[]})?.skipped && (
-                <div className="row row--buttons">
+                <div className="row row--buttons ">
                     <Button
                         theme="black"
-                        onClick={compareFn}
+                        onClick={handleCompareButton}
                         type="submit"
-                        disabled={!priceCeiling || !hasData}
+                        disabled={!priceCeiling || !hasExternalSalesData || isButtonClicked} // Disable button if no price ceiling or no external sales data, or it has been clicked
+                        isLoading={isButtonClicked} // show loading spinner while the comparison is running
                     >
                         Aloita vertailu
                     </Button>

--- a/frontend/src/styles/components/_Functions.sass
+++ b/frontend/src/styles/components/_Functions.sass
@@ -301,5 +301,7 @@
   ul
     list-style-type: disc
     padding-left: $spacing-s
+    max-height: 600px
+    overflow-y: scroll
   li
     margin-bottom: $spacing-2-xs


### PR DESCRIPTION
# Hitas Pull Request

# Description

Manually released companies are now listed as a separate listing under the "freed companies" heading. There's also a lot of small fixes here and there, including (but not limited to): 
- the obfuscated owners list is hidden behind a button, instead of showing it open by default.
- there is real time feedback after having clicked the "Aloita vertailu" button, and you can't click it again while waiting for the results (as that results in an error)

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [ ] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Make a 30y comparison and manually release a company via the "Vapauta" button from the companies which stay regulated. It should move to the upper listing (freed companies) in a list of its own, titled "Tontit-yksikön päätöksellä vapautetut yhtiöt".
Generally play around with the functionality, as it should now work as intended summa summarum.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-484, HT-549, HT-564