### PR TITLE
Show dynamic price ceilings

### DIFF
--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -22,6 +22,8 @@ import {
     IHousingCompanyListResponse,
     IHousingCompanyWritable,
     IIndex,
+    IIndexListQuery,
+    IIndexListResponse,
     IIndexQuery,
     IIndexResponse,
     IOwner,
@@ -243,8 +245,8 @@ const listApi = hitasApi.injectEndpoints({
                 params: params,
             }),
         }),
-        getIndices: builder.query<IIndexResponse, IIndexQuery>({
-            query: (params: IIndexQuery) => ({
+        getIndices: builder.query<IIndexListResponse, IIndexListQuery>({
+            query: (params: IIndexListQuery) => ({
                 url: `indices/${params.indexType}`,
                 params: params.params,
             }),
@@ -317,6 +319,11 @@ const detailApi = hitasApi.injectEndpoints({
                 },
             }),
             providesTags: (result, error, arg) => [{type: "ThirtyYearRegulation", id: arg.calculationDate}],
+        }),
+        getIndex: builder.query<IIndexResponse, IIndexQuery>({
+            query: (params: IIndexQuery) => ({
+                url: `indices/${params.indexType}/${params.month}`,
+            }),
         }),
     }),
 });
@@ -570,6 +577,7 @@ export const {
     useGetApartmentMaximumPriceQuery,
     useGetExternalSalesDataQuery,
     useGetThirtyYearRegulationQuery,
+    useGetIndexQuery,
 } = detailApi;
 
 export const {

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -903,6 +903,8 @@ const ApartmentMaximumPriceWritableSchema = object({
 
 const IndexSchema = object({indexType: string(), month: string(), value: number().nullable()});
 
+const IndexResponseSchema = object({indexType: string(), value: number(), valid_until: string()});
+
 const ThirtyYearRegulationCompanySchema = object({
     id: string(),
     display_name: string(),
@@ -1009,7 +1011,7 @@ const PostalCodeResponseSchema = object({
     contents: PostalCodeSchema.array(),
 });
 
-const IndexResponseSchema = object({
+const IndexListResponseSchema = object({
     page: PageInfoSchema,
     contents: IndexSchema.array(),
 });
@@ -1033,13 +1035,18 @@ const ApartmentQuerySchema = object({
     apartmentId: string(),
 });
 
-const IndexQuerySchema = object({
+const IndexListQuerySchema = object({
     indexType: string(),
     params: object({
         page: number(),
         limit: number(),
         year: string(),
     }),
+});
+
+const IndexQuerySchema = object({
+    indexType: string(),
+    month: string(),
 });
 
 const ThirtyYearRegulationQuerySchema = object({
@@ -1088,10 +1095,10 @@ export {
     CodeResponseSchema,
     OwnersResponseSchema,
     PostalCodeResponseSchema,
-    IndexResponseSchema,
+    IndexListResponseSchema,
     HousingCompanyApartmentQuerySchema,
     ApartmentQuerySchema,
-    IndexQuerySchema,
+    IndexListQuerySchema,
     FilterOwnersQuerySchema,
     ApartmentSaleFormSchema,
     OwnerSchema,
@@ -1161,10 +1168,12 @@ export type IApartmentListResponse = z.infer<typeof ApartmentListResponseSchema>
 export type ICodeResponse = z.infer<typeof CodeResponseSchema>;
 export type IOwnersResponse = z.infer<typeof OwnersResponseSchema>;
 export type IPostalCodeResponse = z.infer<typeof PostalCodeResponseSchema>;
-export type IIndexResponse = z.infer<typeof IndexResponseSchema>;
+export type IIndexListResponse = z.infer<typeof IndexListResponseSchema>;
 export type IHousingCompanyApartmentQuery = z.infer<typeof HousingCompanyApartmentQuerySchema>;
 export type IApartmentQuery = z.infer<typeof ApartmentQuerySchema>;
+export type IIndexListQuery = z.infer<typeof IndexListQuerySchema>;
 export type IIndexQuery = z.infer<typeof IndexQuerySchema>;
+export type IIndexResponse = z.infer<typeof IndexResponseSchema>;
 export type IFilterOwnersQuery = z.infer<typeof FilterOwnersQuerySchema>;
 
 export type IExternalSalesDataResponse = z.infer<typeof ExternalSalesDataResponseSchema>;

--- a/frontend/src/features/functions/ThirtyYearRegulation.tsx
+++ b/frontend/src/features/functions/ThirtyYearRegulation.tsx
@@ -187,6 +187,7 @@ const ThirtyYearRegulation = () => {
                                     formObject={formObject}
                                     defaultValue={years[0]}
                                     setDirectValue={true}
+                                    disabled={hasSkippedCompanies}
                                     required
                                 />
                                 <Select
@@ -196,6 +197,7 @@ const ThirtyYearRegulation = () => {
                                     formObject={formObject}
                                     defaultValue={hitasQuarterOptions[hitasQuarterOptions.length - 1]}
                                     value={formTimePeriod}
+                                    disabled={hasSkippedCompanies}
                                     required
                                 />
                             </div>

--- a/frontend/src/features/functions/components/ThirtyYearLoadedResults.tsx
+++ b/frontend/src/features/functions/components/ThirtyYearLoadedResults.tsx
@@ -45,6 +45,7 @@ const ThirtyYearLoadedResults = ({data, calculationDate, reCalculateFn}): JSX.El
                             variant="secondary"
                             size="small"
                             onClick={() => setIsModalOpen((prev) => !prev)}
+                            className="obfuscated-owners-button"
                         >
                             Obfuskoidut omistajat
                         </Button>
@@ -66,7 +67,7 @@ const ThirtyYearLoadedResults = ({data, calculationDate, reCalculateFn}): JSX.El
                             </ul>
                         </>
                     ) : (
-                        <p>Vertailussa ei automaattisesti vapautunut yhtiöitä.</p>
+                        <p>Vertailussa ei vapautunut yhtiöitä.</p>
                     )}
                     {hasManuallyReleasedCompanies && (
                         <>

--- a/frontend/src/features/functions/components/ThirtyYearResults.tsx
+++ b/frontend/src/features/functions/components/ThirtyYearResults.tsx
@@ -10,7 +10,7 @@ export default function ThirtyYearResults({
     error,
     isLoading,
     date,
-    priceCeiling,
+    priceCeilingValue,
     compareFn,
 }) {
     // Because the compareFn doesn't play ball with isLoading, we need to keep track of whether the button has been
@@ -50,7 +50,7 @@ export default function ThirtyYearResults({
                         theme="black"
                         onClick={handleCompareButton}
                         type="submit"
-                        disabled={!priceCeiling || !hasExternalSalesData || isButtonClicked} // Disable button if no price ceiling or no external sales data, or it has been clicked
+                        disabled={!priceCeilingValue || !hasExternalSalesData || isButtonClicked} // Disable button if no price ceiling or no external sales data, or it has been clicked
                         isLoading={isButtonClicked} // show loading spinner while the comparison is running
                     >
                         Aloita vertailu

--- a/frontend/src/features/functions/components/ThirtyYearResults.tsx
+++ b/frontend/src/features/functions/components/ThirtyYearResults.tsx
@@ -33,7 +33,7 @@ export default function ThirtyYearResults({
                 (hasExternalSalesData && hasResults && (
                     <QueryStateHandler
                         data={data}
-                        error={data ? undefined : error}
+                        error={error}
                         isLoading={isLoading}
                         attemptedAction="hae suoritetun vertailun tulokset"
                     >

--- a/frontend/src/styles/components/_Functions.sass
+++ b/frontend/src/styles/components/_Functions.sass
@@ -181,6 +181,9 @@
     .companies
       margin-top: $spacing-m
       background-color: $color-engel-medium-light
+      .obfuscated-owners-button
+        position: relative
+        top: -0.5rem
       p
         background-color: white
         padding: $spacing-m


### PR DESCRIPTION
# Hitas Pull Request

# Description

The 30 year comparison view now shows the real price ceiling value, instead of a dummy-value.
This PR fixes also the weirdness when changing between 30y results.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [X] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Change between 30y results, notice the distinct lack of weirdness.

## Tickets

This pull request resolves all or part of the following ticket(s):