### PR TITLE
Use housing company completion date in max price calculations

### DIFF
--- a/backend/hitas/calculations/max_prices/rules.py
+++ b/backend/hitas/calculations/max_prices/rules.py
@@ -21,6 +21,7 @@ class CalculatorRules:
         apartment_improvements: List,
         housing_company_improvements: List,
         calculation_date: datetime.date,
+        housing_company_completion_date: datetime.date,
     ) -> IndexCalculation:
         raise NotImplementedError()
 
@@ -33,6 +34,7 @@ class CalculatorRules:
         apartment_improvements: List,
         housing_company_improvements: List,
         calculation_date: datetime.date,
+        housing_company_completion_date: datetime.date,
     ) -> IndexCalculation:
         raise NotImplementedError()
 

--- a/backend/hitas/calculations/max_prices/rules_2011_onwards.py
+++ b/backend/hitas/calculations/max_prices/rules_2011_onwards.py
@@ -34,6 +34,7 @@ class Rules2011Onwards(CalculatorRules):
         apartment_improvements: List,
         housing_company_improvements: List,
         calculation_date: datetime.date,
+        housing_company_completion_date: datetime.date,
     ) -> IndexCalculation:
         return self._calculate_max_price(
             apartment,
@@ -44,6 +45,7 @@ class Rules2011Onwards(CalculatorRules):
             apartment_share_of_housing_company_loans_date,
             housing_company_improvements,
             calculation_date,
+            housing_company_completion_date,
             "cpi2005eq100",
         )
 
@@ -56,6 +58,7 @@ class Rules2011Onwards(CalculatorRules):
         apartment_improvements: List,
         housing_company_improvements: List,
         calculation_date: datetime.date,
+        housing_company_completion_date: datetime.date,
     ) -> IndexCalculation:
         return self._calculate_max_price(
             apartment,
@@ -66,6 +69,7 @@ class Rules2011Onwards(CalculatorRules):
             apartment_share_of_housing_company_loans_date,
             housing_company_improvements,
             calculation_date,
+            housing_company_completion_date,
             "mpi2005eq100",
         )
 
@@ -79,6 +83,7 @@ class Rules2011Onwards(CalculatorRules):
         apartment_share_of_housing_company_loans_date: datetime.date,
         housing_company_improvements: List,
         calculation_date: datetime.date,
+        housing_company_completion_date: datetime.date,
         index_name: str,
     ) -> IndexCalculation:
         # Start calculations
@@ -129,7 +134,7 @@ class Rules2011Onwards(CalculatorRules):
                 debt_free_price_m2=debt_free_shares_price / apartment.surface_area,
                 apartment_share_of_housing_company_loans=apartment_share_of_housing_company_loans,
                 apartment_share_of_housing_company_loans_date=apartment_share_of_housing_company_loans_date,
-                completion_date=apartment.completion_date,
+                completion_date=housing_company_completion_date,
                 completion_date_index=completion_date_index,
                 calculation_date=calculation_date,
                 calculation_date_index=calculation_date_index,

--- a/backend/hitas/calculations/max_prices/rules_pre_2011.py
+++ b/backend/hitas/calculations/max_prices/rules_pre_2011.py
@@ -43,6 +43,7 @@ class RulesPre2011(CalculatorRules):
         apartment_improvements: List,
         housing_company_improvements: List,
         calculation_date: datetime.date,
+        housing_company_completion_date: datetime.date,
     ) -> IndexCalculation:
         if not apartment.realized_housing_company_acquisition_price:
             raise InvalidCalculationResultException(error_code="missing_realized_housing_company_acquisition_price")
@@ -146,7 +147,7 @@ class RulesPre2011(CalculatorRules):
                 debt_free_price_m2=debt_free_shares_price / apartment.surface_area,
                 apartment_share_of_housing_company_loans=apartment_share_of_housing_company_loans,
                 apartment_share_of_housing_company_loans_date=apartment_share_of_housing_company_loans_date,
-                completion_date=apartment.completion_date,
+                completion_date=housing_company_completion_date,
                 completion_date_index=apartment.completion_date_cpi,
                 calculation_date=calculation_date,
                 calculation_date_index=apartment.calculation_date_cpi,
@@ -162,6 +163,7 @@ class RulesPre2011(CalculatorRules):
         apartment_improvements: List,
         housing_company_improvements: List,
         calculation_date: datetime.date,
+        housing_company_completion_date: datetime.date,
     ) -> IndexCalculation:
         # Start calculations
 
@@ -244,7 +246,7 @@ class RulesPre2011(CalculatorRules):
                 debt_free_price_m2=debt_free_shares_price / apartment.surface_area,
                 apartment_share_of_housing_company_loans=apartment_share_of_housing_company_loans,
                 apartment_share_of_housing_company_loans_date=apartment_share_of_housing_company_loans_date,
-                completion_date=apartment.completion_date,
+                completion_date=housing_company_completion_date,
                 completion_date_index=apartment.completion_date_mpi,
                 calculation_date=calculation_date,
                 calculation_date_index=apartment.calculation_date_mpi,

--- a/backend/hitas/services/housing_company.py
+++ b/backend/hitas/services/housing_company.py
@@ -66,8 +66,8 @@ def get_completed_housing_companies(
                 output_field=HitasModelDecimalField(),
             ),
             surface_area=Round(Sum("real_estates__buildings__apartments__surface_area")),
-            completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"),
-            completion_month=TruncMonth("completion_date"),
+            _completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"),
+            completion_month=TruncMonth("_completion_date"),
             avg_price_per_square_meter=(
                 F("realized_acquisition_price")
                 # Prevent zero-division errors
@@ -80,7 +80,7 @@ def get_completed_housing_companies(
             ),
         )
         .filter(
-            completion_date__lte=completion_month,
+            _completion_date__lte=completion_month,
             regulation_status=RegulationStatus.REGULATED,
         )
     )
@@ -306,7 +306,7 @@ def find_regulated_housing_companies_for_reporting() -> list[HousingCompanyWithR
             _acquisition_price=get_first_sale_acquisition_price("real_estates__buildings__apartments__id"),
         )
         .annotate(
-            completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"),
+            _completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"),
             surface_area=Round(Sum("real_estates__buildings__apartments__surface_area")),
             realized_acquisition_price=Sum("_acquisition_price"),
             avg_price_per_square_meter=RoundWithPrecision(
@@ -317,7 +317,7 @@ def find_regulated_housing_companies_for_reporting() -> list[HousingCompanyWithR
         )
         .order_by(
             "postal_code__value",
-            "completion_date",
+            "_completion_date",
         )
     )
 
@@ -328,18 +328,18 @@ def find_unregulated_housing_companies_for_reporting() -> list[HousingCompanyWit
         .prefetch_related("real_estates__buildings__apartments")
         .exclude(regulation_status=RegulationStatus.REGULATED)
         .annotate(
-            completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"),
+            _completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"),
             apartment_count=Count("real_estates__buildings__apartments"),
             _release_date=get_regulation_release_date("id"),
         )
-        .order_by("-completion_date")
+        .order_by("-_completion_date")
     )
 
 
 def find_housing_companies_for_state_reporting() -> list[HousingCompanyWithStateReportAnnotations]:
     return list(
         HousingCompany.objects.annotate(
-            completion_date=max_date_if_all_not_null(ref="real_estates__buildings__apartments__completion_date"),
+            _completion_date=max_date_if_all_not_null(ref="real_estates__buildings__apartments__completion_date"),
             apartment_count=Count("real_estates__buildings__apartments"),
         )
     )

--- a/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
@@ -47,15 +47,23 @@ def test__api__apartment_max_price__construction_price_index__2011_onwards(api_c
         building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     # Create another apartment with rest of the surface area
-    ApartmentFactory.create(building__real_estate__housing_company=a.housing_company, surface_area=4302)
+    ApartmentFactory.create(
+        building__real_estate__housing_company=a.housing_company,
+        completion_date=datetime.date(2019, 11, 27),
+        surface_area=4302,
+    )
 
     cpi_improvement: HousingCompanyConstructionPriceImprovement = (
         HousingCompanyConstructionPriceImprovementFactory.create(
-            housing_company=a.housing_company, value=150000, completion_date=datetime.date(2020, 5, 21)
+            housing_company=a.housing_company,
+            value=150000,
+            completion_date=datetime.date(2020, 5, 21),
         )
     )
     mpi_improvement: HousingCompanyMarketPriceImprovement = HousingCompanyMarketPriceImprovementFactory.create(
-        housing_company=a.housing_company, value=150000, completion_date=datetime.date(2020, 5, 21)
+        housing_company=a.housing_company,
+        value=150000,
+        completion_date=datetime.date(2020, 5, 21),
     )
 
     sale: ApartmentSale = ApartmentSaleFactory.create(
@@ -267,7 +275,11 @@ def test__api__apartment_max_price__market_price_index__2011_onwards(api_client:
         building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     # Create another apartment with rest of the surface area
-    ApartmentFactory.create(building__real_estate__housing_company=a.housing_company, surface_area=2655)
+    ApartmentFactory.create(
+        completion_date=datetime.date(2014, 8, 27),
+        building__real_estate__housing_company=a.housing_company,
+        surface_area=2655,
+    )
 
     cpi_improvement: HousingCompanyConstructionPriceImprovement = (
         HousingCompanyConstructionPriceImprovementFactory.create(
@@ -464,6 +476,7 @@ def test__api__apartment_max_price__market_price_index__pre_2011(api_client: Hit
     )
     # Create another apartment with rest of the surface area
     ApartmentFactory.create(
+        completion_date=datetime.date(2003, 5, 9),
         building__real_estate__housing_company=a.housing_company,
         surface_area=3336,
         share_number_start=3,
@@ -763,10 +776,13 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
         sales__purchase_price=16551639.5,
         sales__apartment_share_of_housing_company_loans=0.5,
     )
-    # Create another apartment with different completion date and rest of the acquisition price
+    # Create another apartment with a later completion date and rest of the acquisition price.
+    # Now the completion date used in the calculation should be this apartments completion date, since
+    # it becomes the latest apartment in the housing company, and thus its completion date is used for the
+    # housing company's completion date.
     ApartmentFactory.create(
         building__real_estate__housing_company=a.housing_company,
-        completion_date=datetime.date(2011, 12, 30),
+        completion_date=datetime.date(2012, 7, 28),
         surface_area=0.0,
         sales__purchase_price=20545029.0,
         sales__apartment_share_of_housing_company_loans=1.0,
@@ -792,9 +808,9 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
     )
     o1: Ownership = OwnershipFactory.create(percentage=100.0, sale=sale)
 
-    # Create necessary apartment's completion date indices
-    ConstructionPriceIndexFactory.create(month=datetime.date(2012, 6, 1), value=296.10)
-    MarketPriceIndexFactory.create(month=datetime.date(2012, 6, 1), value=263.60)
+    # Create necessary housing company's completion date indices
+    ConstructionPriceIndexFactory.create(month=datetime.date(2012, 7, 1), value=296.10)
+    MarketPriceIndexFactory.create(month=datetime.date(2012, 7, 1), value=263.60)
 
     # Create necessary calculation date indices
     ConstructionPriceIndexFactory.create(month=datetime.date(2022, 11, 1), value=364.60)
@@ -914,7 +930,7 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
             "debt_free_price_m2": 5228.62,
             "apartment_share_of_housing_company_loans": 3000,
             "apartment_share_of_housing_company_loans_date": "2022-11-20",
-            "completion_date": "2012-06-28",
+            "completion_date": "2012-07-28",
             "completion_date_index": 296.10,
             "calculation_date": "2022-11-21",
             "calculation_date_index": 364.6,
@@ -966,7 +982,7 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
             "debt_free_price_m2": 8564.47,
             "apartment_share_of_housing_company_loans": 3000,
             "apartment_share_of_housing_company_loans_date": "2022-11-20",
-            "completion_date": "2012-06-28",
+            "completion_date": "2012-07-28",
             "completion_date_index": 263.6,
             "calculation_date": "2022-11-21",
             "calculation_date_index": 567.1,
@@ -1137,7 +1153,11 @@ def test__api__apartment_max_price__surface_area_price_ceiling(api_client: Hitas
         building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     # Create another apartment with rest of the surface area
-    ApartmentFactory.create(building__real_estate__housing_company=a.housing_company, surface_area=2655)
+    ApartmentFactory.create(
+        completion_date=datetime.date(2012, 1, 13),
+        building__real_estate__housing_company=a.housing_company,
+        surface_area=2655,
+    )
 
     sale: ApartmentSale = ApartmentSaleFactory.create(
         apartment=a,
@@ -1490,7 +1510,11 @@ def test__api__apartment_max_price__missing_property_manager(api_client: HitasAP
         building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
     # Create another apartment with rest of the surface area
-    ApartmentFactory.create(building__real_estate__housing_company=a.housing_company, surface_area=4302)
+    ApartmentFactory.create(
+        completion_date=datetime.date(2019, 11, 27),
+        building__real_estate__housing_company=a.housing_company,
+        surface_area=4302,
+    )
 
     HousingCompanyConstructionPriceImprovementFactory.create(
         housing_company=a.housing_company, value=150000, completion_date=datetime.date(2020, 5, 21)

--- a/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_confirm.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_confirm.py
@@ -34,9 +34,8 @@ def test__api__apartment_max_price__confirm(api_client: HitasAPIClient):
     )
     unconfirmed_mpc_other_apartment: ApartmentMaximumPriceCalculation = ApartmentMaximumPriceCalculationFactory.create(
         confirmed_at=None,
-        apartment=ApartmentFactory.create(
-            building__real_estate__housing_company=a.housing_company,
-        ),
+        apartment__completion_date=datetime.date(2019, 11, 27),
+        apartment__building__real_estate__housing_company=a.housing_company,
     )
     unconfirmed_mpc_other_hc: ApartmentMaximumPriceCalculation = ApartmentMaximumPriceCalculationFactory.create(
         confirmed_at=None

--- a/backend/hitas/tests/factories/apartment.py
+++ b/backend/hitas/tests/factories/apartment.py
@@ -105,11 +105,18 @@ def create_apartment_max_price_calculation(create_indices=True, **kwargs) -> Apa
 
     # Create max price calculation
     mpc: ApartmentMaximumPriceCalculation = ApartmentMaximumPriceCalculationFactory.create(**kwargs)
+    housing_company_completion_date = mpc.apartment.housing_company.completion_date
     mpc.json = calculate_max_price(
-        apartment=fetch_apartment(mpc.apartment.housing_company.uuid, mpc.apartment.uuid, mpc.calculation_date),
+        apartment=fetch_apartment(
+            housing_company_uuid=mpc.apartment.housing_company.uuid,
+            apartment_uuid=mpc.apartment.uuid,
+            calculation_month=monthify(mpc.calculation_date),
+            housing_company_completion_month=monthify(housing_company_completion_date),
+        ),
         apartment_share_of_housing_company_loans=fuzzy.FuzzyInteger(0, 5000).fuzz(),
         apartment_share_of_housing_company_loans_date=fuzzy.FuzzyDate(date(2020, 1, 1)).fuzz(),
         calculation_date=mpc.calculation_date,
+        housing_company_completion_date=housing_company_completion_date,
     )
     mpc.save()
     # Refresh to make sure the JSON is encoded


### PR DESCRIPTION
# Hitas Pull Request

# Description

Use housing company completion date in max price calculations. Max price calculation results remain backwards compatible, since housing company completion date is used where apartment completion date was used.

`completion_date` has been added to housing company as a property, which required some refactoring but makes code easier to use.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests 

## Tickets

This pull request resolves all or part of the following ticket(s): HT-642
