### PR TITLE
Disable poetry parallel install to avoid OOM errors in Azure Pipelines

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -34,7 +34,10 @@ FROM base AS builder
 ENV POETRY_VERSION=1.3.1
 ENV POETRY_HOME=/usr/pypoetry
 ENV PATH=$POETRY_HOME/bin:$PATH
+# Set so that poetry uses venv created in '/hitas/venv'.
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
+# Disable parallel installer to avoid out-of-memory errors in Azure Pipelines.
+ENV POETRY_INSTALLER_PARALLEL=false
 
 # Install build dependencies
 RUN apt-get install -y --no-install-recommends \


### PR DESCRIPTION
# Hitas Pull Request

# Description

Fixes CI in Azure pipelines bu disabling parallel installs with poetry.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [ ] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- Tested in CI, no further testing required

## Tickets

This pull request resolves all or part of the following ticket(s): -
