### PR TITLE
Don't count deleted apartments for housing company completion date

### DIFF
--- a/backend/hitas/tests/test_utils.py
+++ b/backend/hitas/tests/test_utils.py
@@ -1,0 +1,150 @@
+import datetime
+from typing import Optional
+
+import pytest
+
+from hitas.models import Apartment, HousingCompany
+from hitas.tests.apis.helpers import count_queries
+from hitas.tests.factories import ApartmentFactory, BuildingFactory, HousingCompanyFactory
+from hitas.utils import max_date_if_all_not_null
+
+
+@pytest.mark.django_db
+def test__max_date_if_all_not_null__all_completed():
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=datetime.date(2020, 1, 1),
+    )
+    apartment_2: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=datetime.date(2020, 3, 1),
+    )
+    ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=datetime.date(2020, 2, 1),
+    )
+
+    with count_queries(1):
+        housing_company: Optional[HousingCompany] = (
+            HousingCompany.objects.filter(uuid=housing_company.uuid)
+            .annotate(
+                _completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"),
+            )
+            .first()
+        )
+
+    assert housing_company.completion_date == apartment_2.completion_date
+
+
+@pytest.mark.django_db
+def test__max_date_if_all_not_null__one_not_completed():
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=datetime.date(2020, 1, 1),
+    )
+    ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=datetime.date(2020, 3, 1),
+    )
+    ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=None,
+    )
+
+    with count_queries(1):
+        housing_company: Optional[HousingCompany] = (
+            HousingCompany.objects.filter(uuid=housing_company.uuid)
+            .annotate(
+                _completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"),
+            )
+            .first()
+        )
+
+    assert housing_company.completion_date is None
+
+
+@pytest.mark.django_db
+def test__max_date_if_all_not_null__one_building_empty():
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=datetime.date(2020, 1, 1),
+    )
+    apartment_2: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=datetime.date(2020, 3, 1),
+    )
+    BuildingFactory.create(
+        real_estate__housing_company=housing_company,
+    )
+
+    with count_queries(1):
+        housing_company: Optional[HousingCompany] = (
+            HousingCompany.objects.filter(uuid=housing_company.uuid)
+            .annotate(
+                _completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"),
+            )
+            .first()
+        )
+
+    assert housing_company.completion_date == apartment_2.completion_date
+
+
+@pytest.mark.django_db
+def test__max_date_if_all_not_null__one_apartment_deleted__not_completed():
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=datetime.date(2020, 1, 1),
+    )
+    apartment_2: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=datetime.date(2020, 3, 1),
+    )
+    apartment_3: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=None,
+    )
+    apartment_3.delete()
+
+    with count_queries(1):
+        housing_company: Optional[HousingCompany] = (
+            HousingCompany.objects.filter(uuid=housing_company.uuid)
+            .annotate(
+                _completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"),
+            )
+            .first()
+        )
+
+    assert housing_company.completion_date == apartment_2.completion_date
+
+
+@pytest.mark.django_db
+def test__max_date_if_all_not_null__one_apartment_deleted__deleted_completed_last():
+    housing_company: HousingCompany = HousingCompanyFactory.create()
+    ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=datetime.date(2020, 1, 1),
+    )
+    apartment_2: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=datetime.date(2020, 3, 1),
+    )
+    apartment_3: Apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+        completion_date=datetime.date(2020, 4, 1),
+    )
+    apartment_3.delete()
+
+    with count_queries(1):
+        housing_company: Optional[HousingCompany] = (
+            HousingCompany.objects.filter(uuid=housing_company.uuid)
+            .annotate(
+                _completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"),
+            )
+            .first()
+        )
+
+    assert housing_company.completion_date == apartment_2.completion_date

--- a/backend/hitas/utils.py
+++ b/backend/hitas/utils.py
@@ -72,6 +72,9 @@ def max_if_all_not_null(ref: str, max: Any, min: Any) -> NullIf:
     the array). If the 'min' values would be the largest value (e.g. there are only empty relations), replace
     the 'min' value with nulls instead.
 
+    Also, any soft-deleted relations will be replaced with the supplied 'min' value, resulting in the same effect
+    as described above.
+
     :param ref: Reference to an array of items to aggregate.
     :param max: Highest possible value, which will replace nulls, e.g., 'datetime.max'.
     :param min: Lowest possible value, used when there are empty relations, e.g. 'datetime.min'.
@@ -81,6 +84,10 @@ def max_if_all_not_null(ref: str, max: Any, min: Any) -> NullIf:
         NullIf(
             Max(
                 Case(
+                    When(
+                        condition=~Q(**{f"{parent_ref}__deleted": None}),
+                        then=min,
+                    ),
                     When(
                         condition=Q(**{f"{parent_ref}__isnull": True}),
                         then=min,


### PR DESCRIPTION
# Hitas Pull Request

# Description

Fix issue where housing company completion date would be null if one apartment in the housing company is deleted and not completed.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [ ] Automated tests

## Tickets

This pull request resolves all or part of the following ticket(s): HT-645
