### PR TITLE
Front release batch

### DIFF
--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -579,7 +579,7 @@ const mutationApi = hitasApi.injectEndpoints({
                 headers: mutationApiJsonHeaders(),
                 body: arg.data,
             }),
-            invalidatesTags: (result, error) => (!error && result ? [{type: "Apartment", id: "LIST"}] : []),
+            invalidatesTags: (result, error) => (!error && result ? [{type: "Apartment"}] : []),
         }),
     }),
 });

--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -572,6 +572,15 @@ const mutationApi = hitasApi.injectEndpoints({
             invalidatesTags: (result, error, arg) =>
                 !error ? [{type: "HousingCompany", id: arg.housingCompanyId}, {type: "Apartment"}] : [],
         }),
+        batchCompleteApartments: builder.mutation({
+            query: (arg) => ({
+                url: `housing-companies/${arg.housing_company_id}/batch-complete-apartments`,
+                method: "PATCH",
+                headers: mutationApiJsonHeaders(),
+                body: arg.data,
+            }),
+            invalidatesTags: (result, error) => (!error && result ? [{type: "Apartment", id: "LIST"}] : []),
+        }),
     }),
 });
 
@@ -618,4 +627,5 @@ export const {
     useSaveExternalSalesDataMutation,
     useValidateSalesCatalogMutation,
     useCreateFromSalesCatalogMutation,
+    useBatchCompleteApartmentsMutation,
 } = mutationApi;

--- a/frontend/src/common/components/SaveDialogModal.tsx
+++ b/frontend/src/common/components/SaveDialogModal.tsx
@@ -30,6 +30,7 @@ interface SaveStateProps {
     isVisible: boolean;
     setIsVisible;
     title?: string;
+    className?: string;
 }
 
 const ActionSuccess = ({linkURL, linkText, baseURL, data}) => {
@@ -109,6 +110,7 @@ export default function SaveDialogModal({
     isVisible,
     setIsVisible,
     title,
+    className,
 }: SaveStateProps): JSX.Element {
     return (
         <Dialog
@@ -117,7 +119,7 @@ export default function SaveDialogModal({
             aria-labelledby="finish-modal"
             isOpen={isVisible}
             close={() => setIsVisible(false)}
-            className={error && "error-modal"}
+            className={error ? className + " error-modal" : className}
             boxShadow
         >
             <Dialog.Header

--- a/frontend/src/common/components/SaveDialogModal.tsx
+++ b/frontend/src/common/components/SaveDialogModal.tsx
@@ -62,13 +62,13 @@ const ActionSuccess = ({linkURL, linkText, baseURL, data}) => {
 };
 
 const ActionFailed = ({error}) => {
-    const errorStatus = error?.data?.status + ":" ?? "";
+    const errorStatus = error?.data?.status ?? "";
     const errorFields = error?.data?.fields ?? [];
     const nonFieldError = ((error as FetchBaseQueryError)?.data as {message?: string})?.message || "";
     return (
         <Dialog.Content>
             <h3>
-                {errorStatus} {nonFieldError}
+                {errorStatus} : {nonFieldError}
             </h3>
             {errorFields.length > 1 ? (
                 <Accordion

--- a/frontend/src/features/housingCompany/BatchCompleteApartmentsModal.tsx
+++ b/frontend/src/features/housingCompany/BatchCompleteApartmentsModal.tsx
@@ -30,10 +30,8 @@ const BatchCompleteApartmentsModal = ({housingCompanyId}) => {
                 completion_date: today(),
             },
         };
-        console.log("To API:", submitData);
         batchComplete(submitData)
             .then((data) => {
-                console.log("API response:", data);
                 hdsToast.success(
                     (data as {data: {completed_apartment_count: number}}).data.completed_apartment_count +
                         " asuntoa merkitty onnistuneesti valmiiksi"
@@ -47,7 +45,6 @@ const BatchCompleteApartmentsModal = ({housingCompanyId}) => {
                 hdsToast.error("Asuntojen merkitseminen valmiiksi epäonnistui");
             });
     };
-    console.log(JSON.stringify(groupCompleteForm.getValues()));
     return (
         <>
             <Button

--- a/frontend/src/features/housingCompany/BatchCompleteApartmentsModal.tsx
+++ b/frontend/src/features/housingCompany/BatchCompleteApartmentsModal.tsx
@@ -1,0 +1,96 @@
+import {Button, Dialog} from "hds-react";
+import {useState} from "react";
+import {useForm} from "react-hook-form";
+import {useBatchCompleteApartmentsMutation} from "../../app/services";
+import {CloseButton} from "../../common/components";
+import {NumberInput} from "../../common/components/form";
+import {hdsToast, today} from "../../common/utils";
+
+const BatchCompleteApartmentsModal = ({housingCompanyId}) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [batchComplete] = useBatchCompleteApartmentsMutation();
+    const groupCompleteForm = useForm({
+        defaultValues: {
+            start: 1,
+            end: null,
+        },
+        mode: "all",
+    });
+    const {handleSubmit, setFocus} = groupCompleteForm;
+    const onSubmit = (data: {start: number | null; end: number | null}) => {
+        const submitData = {
+            housing_company_id: housingCompanyId,
+            data: {
+                apartment_number_start: data.start as number,
+                apartment_number_end: data.end as number,
+                completion_date: today(),
+            },
+        };
+        console.log("To API:", submitData);
+        batchComplete({data: submitData})
+            .then((data) => {
+                console.log("API response:", data);
+                hdsToast.success("Asunnot merkitty valmiiksi");
+            })
+            .catch((e) => {
+                // eslint-disable-next-line no-console
+                console.warn(e);
+                hdsToast.error("Asuntojen merkitseminen valmiiksi epäonnistui");
+            });
+    };
+    return (
+        <>
+            <Button
+                theme="black"
+                size="small"
+                variant="secondary"
+                onClick={() => {
+                    setIsOpen(true);
+                    setFocus("end"); // FIXME: This doesn't work :/
+                }}
+            >
+                Merkitse valmiiksi
+            </Button>
+            <Dialog
+                id="batch-complete-modal"
+                aria-labelledby="batch-complete-modal"
+                isOpen={isOpen}
+            >
+                <Dialog.Header
+                    title="Merkitse sarja valmiiksi"
+                    id="batch-complete-modal__header"
+                />
+                <form onSubmit={handleSubmit(onSubmit)}>
+                    <Dialog.Content>
+                        <div className="apartment-numbers">
+                            <NumberInput
+                                name="start"
+                                label="Asunnosta"
+                                formObject={groupCompleteForm}
+                                required
+                            />
+                            <NumberInput
+                                name="end"
+                                label="Asuntoon"
+                                formObject={groupCompleteForm}
+                                required
+                            />
+                        </div>
+                    </Dialog.Content>
+                    <Dialog.ActionButtons>
+                        <CloseButton onClick={() => setIsOpen(false)} />
+                        <Button
+                            theme="black"
+                            type="submit"
+                            disabled={groupCompleteForm.getValues("end") === null}
+                        >
+                            Merkitse valmiiksi
+                        </Button>
+                    </Dialog.ActionButtons>
+                </form>
+            </Dialog>
+        </>
+    );
+};
+
+export default BatchCompleteApartmentsModal;

--- a/frontend/src/features/housingCompany/BatchCompleteApartmentsModal.tsx
+++ b/frontend/src/features/housingCompany/BatchCompleteApartmentsModal.tsx
@@ -72,8 +72,8 @@ const BatchCompleteApartmentsModal = ({housingCompanyId}) => {
                         <p>Määritä asunnot, jotka haluat merkitä valmiiksi.</p>
                         <>
                             <p>
-                                Jos kumpikin kenttä on tyhjä, valitaan kaikki asunnot. Jos et halua rajata alku tai
-                                loppupäätä, jätä kenttä tyhjäksi.
+                                Jos et halua rajata pelkkää alku- tai loppupäätä jätä kenttä tyhjäksi. Jos kumpikin
+                                kenttä on tyhjä valitaan kaikki yhtiön asunnot. Numerot koskevat kaikkia rappuja.
                             </p>
                             <div className="apartment-numbers">
                                 <div className={formStart ? "toggled" : undefined}>

--- a/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
@@ -17,13 +17,13 @@ import {
     QueryStateHandler,
     SaveButton,
 } from "../../common/components";
-import {FileInput} from "../../common/components/form";
+import {FileInput, NumberInput} from "../../common/components/form";
 import {getHousingCompanyHitasTypeName, getHousingCompanyRegulationStatusName} from "../../common/localisation";
 import {IHousingCompanyDetails, ISalesCatalogApartment} from "../../common/schemas";
 import {formatAddress, formatDate, formatMoney, hdsToast} from "../../common/utils";
 import {HousingCompanyApartmentResultsList} from "../apartment/ApartmentListPage";
 
-const LoadedHousingCompanyDetails = ({housingCompany}: {housingCompany: IHousingCompanyDetails}) => {
+const LoadedHousingCompanyDetails = ({housingCompany}: {housingCompany: IHousingCompanyDetails}): JSX.Element => {
     const [isImportModalOpen, setIsImportModalOpen] = useState(false);
     const params = useParams() as {readonly housingCompanyId: string};
     const salesCatalogForm = useForm({defaultValues: {salesCatalog: null}});
@@ -52,7 +52,7 @@ const LoadedHousingCompanyDetails = ({housingCompany}: {housingCompany: IHousing
             housingCompanyId: params.housingCompanyId,
         })
             .then(() => {
-                hdsToast.success("Asuntojen tuonti onnistui");
+                hdsToast.success("Asuntojen tuonti onnistui.");
                 setIsImportModalOpen(false);
             })
             .catch((e) => {
@@ -72,6 +72,13 @@ const LoadedHousingCompanyDetails = ({housingCompany}: {housingCompany: IHousing
             // eslint-disable-next-line no-console
             .catch((e) => console.warn(e));
     };
+    const groupCompleteForm = useForm({
+        defaultValues: {
+            start: 0,
+            end: 0,
+        },
+        mode: "all",
+    });
     return (
         <>
             <Heading>
@@ -174,11 +181,11 @@ const LoadedHousingCompanyDetails = ({housingCompany}: {housingCompany: IHousing
                                         value={
                                             housingCompany.property_manager &&
                                             `${housingCompany.property_manager.name}
-                                            ${
-                                                housingCompany.property_manager.email
-                                                    ? `(${housingCompany.property_manager.email})`
-                                                    : ""
-                                            }`
+                                        ${
+                                            housingCompany.property_manager.email
+                                                ? `(${housingCompany.property_manager.email})`
+                                                : ""
+                                        }`
                                         }
                                     />
                                     <div>
@@ -291,6 +298,24 @@ const LoadedHousingCompanyDetails = ({housingCompany}: {housingCompany: IHousing
                 <div className="list-wrapper list-wrapper--apartments">
                     <Heading type="list">
                         <span>Asunnot</span>
+                        <form onSubmit={handleSubmit(onSubmit)}>
+                            <NumberInput
+                                name="start"
+                                formObject={groupCompleteForm}
+                            />
+                            <NumberInput
+                                name="end"
+                                formObject={groupCompleteForm}
+                            />
+                            <Button
+                                theme="black"
+                                size="small"
+                                type="submit"
+                                disabled={groupCompleteForm.getValues("end") === 0}
+                            >
+                                Merkitse valmiiksi
+                            </Button>
+                        </form>
                         <Link to="apartments/create">
                             <Button
                                 theme="black"
@@ -340,7 +365,14 @@ const LoadedHousingCompanyDetails = ({housingCompany}: {housingCompany: IHousing
                                             <div>{apartment.apartment_number}</div>
                                             <div>{apartment.floor}</div>
                                             <div>
-                                                {apartment.rooms} {(apartment.apartment_type as {value: string}).value}
+                                                {apartment.rooms}{" "}
+                                                {
+                                                    (
+                                                        apartment.apartment_type as {
+                                                            value: string;
+                                                        }
+                                                    ).value
+                                                }
                                             </div>
                                             <div>{apartment.surface_area}</div>
                                             <div>{`${apartment.share_number_start} - ${apartment.share_number_end}`}</div>

--- a/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
@@ -73,13 +73,6 @@ const LoadedHousingCompanyDetails = ({housingCompany}: {housingCompany: IHousing
             // eslint-disable-next-line no-console
             .catch((e) => console.warn(e));
     };
-    const groupCompleteForm = useForm({
-        defaultValues: {
-            start: 0,
-            end: 0,
-        },
-        mode: "all",
-    });
 
     return (
         <>

--- a/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
@@ -345,14 +345,7 @@ const LoadedHousingCompanyDetails = ({housingCompany}: {housingCompany: IHousing
                                             <div>{apartment.apartment_number}</div>
                                             <div>{apartment.floor}</div>
                                             <div>
-                                                {apartment.rooms}{" "}
-                                                {
-                                                    (
-                                                        apartment.apartment_type as {
-                                                            value: string;
-                                                        }
-                                                    ).value
-                                                }
+                                                {apartment.rooms} {(apartment.apartment_type as {value: string}).value}
                                             </div>
                                             <div>{apartment.surface_area}</div>
                                             <div>{`${apartment.share_number_start} - ${apartment.share_number_end}`}</div>

--- a/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
@@ -17,11 +17,12 @@ import {
     QueryStateHandler,
     SaveButton,
 } from "../../common/components";
-import {FileInput, NumberInput} from "../../common/components/form";
+import {FileInput} from "../../common/components/form";
 import {getHousingCompanyHitasTypeName, getHousingCompanyRegulationStatusName} from "../../common/localisation";
 import {IHousingCompanyDetails, ISalesCatalogApartment} from "../../common/schemas";
 import {formatAddress, formatDate, formatMoney, hdsToast} from "../../common/utils";
 import {HousingCompanyApartmentResultsList} from "../apartment/ApartmentListPage";
+import {BatchCompleteApartmentsModal} from "./";
 
 const LoadedHousingCompanyDetails = ({housingCompany}: {housingCompany: IHousingCompanyDetails}): JSX.Element => {
     const [isImportModalOpen, setIsImportModalOpen] = useState(false);
@@ -79,6 +80,7 @@ const LoadedHousingCompanyDetails = ({housingCompany}: {housingCompany: IHousing
         },
         mode: "all",
     });
+
     return (
         <>
             <Heading>
@@ -298,34 +300,19 @@ const LoadedHousingCompanyDetails = ({housingCompany}: {housingCompany: IHousing
                 <div className="list-wrapper list-wrapper--apartments">
                     <Heading type="list">
                         <span>Asunnot</span>
-                        <form onSubmit={handleSubmit(onSubmit)}>
-                            <NumberInput
-                                name="start"
-                                formObject={groupCompleteForm}
-                            />
-                            <NumberInput
-                                name="end"
-                                formObject={groupCompleteForm}
-                            />
-                            <Button
-                                theme="black"
-                                size="small"
-                                type="submit"
-                                disabled={groupCompleteForm.getValues("end") === 0}
-                            >
-                                Merkitse valmiiksi
-                            </Button>
-                        </form>
-                        <Link to="apartments/create">
-                            <Button
-                                theme="black"
-                                size="small"
-                                iconLeft={<IconPlus />}
-                                disabled={housingCompany.regulation_status !== "regulated"}
-                            >
-                                Lisää asunto
-                            </Button>
-                        </Link>
+                        <div className="buttons">
+                            <BatchCompleteApartmentsModal housingCompanyId={params.housingCompanyId} />
+                            <Link to="apartments/create">
+                                <Button
+                                    theme="black"
+                                    size="small"
+                                    iconLeft={<IconPlus />}
+                                    disabled={housingCompany.regulation_status !== "regulated"}
+                                >
+                                    Lisää asunto
+                                </Button>
+                            </Link>
+                        </div>
                     </Heading>
                     <div className="listing">
                         <HousingCompanyApartmentResultsList housingCompanyId={params.housingCompanyId} />

--- a/frontend/src/features/housingCompany/index.ts
+++ b/frontend/src/features/housingCompany/index.ts
@@ -1,3 +1,4 @@
+import BatchCompleteApartmentsModal from "./BatchCompleteApartmentsModal";
 import HousingCompanyBuildingsPage from "./HousingCompanyBuildingsPage";
 import HousingCompanyCreatePage from "./HousingCompanyCreatePage";
 import HousingCompanyDetailsPage from "./HousingCompanyDetailsPage";
@@ -6,6 +7,7 @@ import HousingCompanyListPage from "./HousingCompanyListPage";
 import HousingCompanyRealEstatesPage from "./HousingCompanyRealEstatesPage";
 
 export {
+    BatchCompleteApartmentsModal,
     HousingCompanyCreatePage,
     HousingCompanyDetailsPage,
     HousingCompanyListPage,

--- a/frontend/src/styles/components/_DialogModule.sass
+++ b/frontend/src/styles/components/_DialogModule.sass
@@ -29,8 +29,19 @@
     align-self: center
 
 #batch-complete-modal
+  .input-field
+    width: 100%
+    height: auto
   .apartment-numbers
     margin-top: $spacing-m
     @include flexbox()
     @include justify-content(space-between)
-    gap: $spacing-layout-2-xl
+    @include flex-flow(row nowrap)
+    gap: $spacing-2-xs
+    > div
+      @include flexbox()
+      @include flex-flow(row)
+      align-items: flex-start
+      label
+        width: 100%
+        flex-grow: 1

--- a/frontend/src/styles/components/_DialogModule.sass
+++ b/frontend/src/styles/components/_DialogModule.sass
@@ -27,3 +27,10 @@
     display: flex
     justify-content: center
     align-self: center
+
+#batch-complete-modal
+  .apartment-numbers
+    margin-top: $spacing-m
+    @include flexbox()
+    @include justify-content(space-between)
+    gap: $spacing-layout-2-xl

--- a/frontend/src/styles/components/_DialogModule.sass
+++ b/frontend/src/styles/components/_DialogModule.sass
@@ -45,3 +45,6 @@
       label
         width: 100%
         flex-grow: 1
+
+.batch-complete-error-modal
+  min-height: 380px

--- a/frontend/src/styles/components/_Forms.sass
+++ b/frontend/src/styles/components/_Forms.sass
@@ -45,3 +45,18 @@ div .disabled
   li
     background-color: $color-engel-light
     width: auto !important
+
+[class^="heading--"] form
+  @include flexbox()
+  @include flex-flow(row nowrap)
+  font-size: $fontsize-body-m
+  .input-field
+    height: 56px
+    margin-bottom: 0
+    width: 90px
+    margin-left: $spacing-s
+  button
+    position: relative
+    top: 7px
+    height: 56px
+    margin-left: $spacing-s

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -40,3 +40,9 @@ footer
 .error-modal
   background: $color-error-light !important
   border-color: $color-error !important
+
+[class^="heading--"]
+  .buttons
+    @include flexbox()
+    @include flex-flow(row nowrap)
+    gap: $spacing-m


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds the possibility to mark a batch of apartments ready, to the housing company view.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [X] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Notice the new button in the housing company apartment listing's header. Click it to open a modal, into which you can enter an apartment-number range and then free them. 
You can leave the ending field empty, to select all apartments onwards from the starting number - and likewise select all apartments up to and including the ending one if you leave the starting field empty.
Leaving both fields empty selects all apartments.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-465