### PR TITLE
Change update_or_create or get_or_create on regulation result saving

### DIFF
--- a/backend/hitas/services/thirty_year_regulation.py
+++ b/backend/hitas/services/thirty_year_regulation.py
@@ -606,7 +606,7 @@ def _save_regulation_results(  # NOSONAR
     """
     Save regulation results for reporting.
     """
-    thirty_year_regulation_results, created = ThirtyYearRegulationResults.objects.update_or_create(
+    thirty_year_regulation_results, created = ThirtyYearRegulationResults.objects.get_or_create(
         calculation_month=calculation_month,
         defaults={
             "regulation_month": regulation_month,


### PR DESCRIPTION
# Hitas Pull Request

# Description

Regulation should not be updated after they are created. There is already a check before this for previous regulation results, but this should be corrected nontheless.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [ ] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

-

## Tickets

This pull request resolves all or part of the following ticket(s): -
