### PR TITLE
Add PDF templates for regulation letters

### DIFF
--- a/backend/hitas/models/pdf_body.py
+++ b/backend/hitas/models/pdf_body.py
@@ -8,10 +8,14 @@ from hitas.models._base import HitasModel
 class PDFBodyName(Enum):
     CONFIRMED_MAX_PRICE_CALCULATION = "confirmed_max_price_calculation"
     UNCONFIRMED_MAX_PRICE_CALCULATION = "unconfirmed_max_price_calculation"
+    STAYS_REGULATED = "stays_regulated"
+    RELEASED_FROM_REGULATION = "released_from_regulation"
 
     class Labels:
         CONFIRMED_MAX_PRICE_CALCULATION = "Enimmäishintalaskelma"
         UNCONFIRMED_MAX_PRICE_CALCULATION = "Hinta-arvio"
+        STAYS_REGULATED = "Jää sääntelyn piiriin"
+        RELEASED_FROM_REGULATION = "Vapautuu sääntelystä"
 
 
 class PDFBody(HitasModel):

--- a/backend/hitas/templates/regulation_letter.jinja
+++ b/backend/hitas/templates/regulation_letter.jinja
@@ -135,16 +135,9 @@
       <td class="first-column"><b>Hintasääntelystä vapautuminen</b></td>
       <td>
         {% if regulated %}
-          Yhtiönne voi hakea Hitas-sääntelystä vapautumista
+          {{ regulated_body_parts.0|linebreaks }}
         {% elif released %}
-          Kun yhtiö on kaupunginvaltuuston 3.6.2009 (136 §) päätöksen perusteella
-          vapautunut hintojen sääntelystä, kaupungin puolesta ei ole estettä sille, että
-          yhtiöjärjestykseen otetut kaupungin lunastusoikeutta koskevat pykälät poistetaan
-          yhtiöjärjestyksestä.
-          <br>
-          <br>
-          Tämän ilmoituksen jälkeen yhtiön asuntojen enimmäishintoja ei enää vahvisteta, eikä
-          tietoja tapahtuneista kaupoista ilmoiteta.
+          {{ released_body_parts.0|linebreaks }}
         {% endif %}
       </td>
     </tr>
@@ -152,17 +145,13 @@
     <tr>
       <td class="first-column"><b>Tontin maanvuokra</b></td>
       <td>
-        Tontin maanvuokraa tarkistetaan hintasääntelystä vapautumisen yhteydessä 0 - 30
-        prosentilla kiinteistölautakunnan erikseen päättämien ohjeiden mukaisesti. Lisätietoja
-        saa kaupunkiympäristön tontit-yksiköstä.
+          {{ regulated_body_parts.1|linebreaks }}
       </td>
     </tr>
     <tr>
       <td class="first-column"><b>Hintasääntelyn jatkuminen</b></td>
       <td>
-          Mikäli yhtiönne ei hae Hitas-sääntelystä vapautumista, hintavertailu tehdään neljä
-          kertaa vuodessa ja yhtiönne tilanne ilmoitetaan hintasääntelyn osalta seuraavan
-          neljännesvuosivertailun jälkeen.
+          {{ regulated_body_parts.2|linebreaks }}
       </td>
     {% endif %}
     </tr>

--- a/backend/hitas/tests/apis/test_api_pdf_body.py
+++ b/backend/hitas/tests/apis/test_api_pdf_body.py
@@ -43,10 +43,61 @@ def test__api__pdf_body__list(api_client: HitasAPIClient):
 
 
 @pytest.mark.django_db
-def test__api__pdf_body__create(api_client: HitasAPIClient):
+def test__api__pdf_body__create__unconfirmed_max_price(api_client: HitasAPIClient):
     data = {
         "name": PDFBodyName.UNCONFIRMED_MAX_PRICE_CALCULATION.value,
         "texts": ["text 1", "text 2", "text 3"],
+    }
+
+    url = reverse("hitas:pdf-body-list")
+    response = api_client.post(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED, response.json()
+    assert response.json() == {
+        "name": data["name"],
+        "texts": data["texts"],
+    }
+
+
+@pytest.mark.django_db
+def test__api__pdf_body__create__confirmed_max_price(api_client: HitasAPIClient):
+    data = {
+        "name": PDFBodyName.CONFIRMED_MAX_PRICE_CALCULATION.value,
+        "texts": ["text 1"],
+    }
+
+    url = reverse("hitas:pdf-body-list")
+    response = api_client.post(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED, response.json()
+    assert response.json() == {
+        "name": data["name"],
+        "texts": data["texts"],
+    }
+
+
+@pytest.mark.django_db
+def test__api__pdf_body__create__regulation_letter__stays_regulated(api_client: HitasAPIClient):
+    data = {
+        "name": PDFBodyName.STAYS_REGULATED.value,
+        "texts": ["text 1", "text 2", "text 3"],
+    }
+
+    url = reverse("hitas:pdf-body-list")
+    response = api_client.post(url, data=data, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED, response.json()
+    assert response.json() == {
+        "name": data["name"],
+        "texts": data["texts"],
+    }
+
+
+@pytest.mark.django_db
+def test__api__pdf_body__create__regulation_letter__released_from_regulation(api_client: HitasAPIClient):
+    data = {
+        "name": PDFBodyName.RELEASED_FROM_REGULATION.value,
+        "texts": ["text 1"],
     }
 
     url = reverse("hitas:pdf-body-list")
@@ -121,6 +172,14 @@ def test__api__pdf_body__create__invalid_name(api_client: HitasAPIClient):
         [
             PDFBodyName.CONFIRMED_MAX_PRICE_CALCULATION,
             "Confirmed max price calculation must have exactly 1 body text.",
+        ],
+        [
+            PDFBodyName.STAYS_REGULATED,
+            "Regulation continuation letter must have exactly 3 body texts.",
+        ],
+        [
+            PDFBodyName.RELEASED_FROM_REGULATION,
+            "Regulation release letter must have exactly 1 body text.",
         ],
     ],
 )

--- a/backend/hitas/tests/apis/test_api_thirty_year_regulation_report.py
+++ b/backend/hitas/tests/apis/test_api_thirty_year_regulation_report.py
@@ -15,13 +15,14 @@ from rest_framework.reverse import reverse
 
 from hitas.models import ApartmentSale
 from hitas.models.housing_company import HitasType, RegulationStatus
+from hitas.models.pdf_body import PDFBodyName
 from hitas.models.thirty_year_regulation import (
     RegulationResult,
     ThirtyYearRegulationResults,
     ThirtyYearRegulationResultsRow,
 )
 from hitas.tests.apis.helpers import HitasAPIClient
-from hitas.tests.factories import ApartmentSaleFactory
+from hitas.tests.factories import ApartmentSaleFactory, PDFBodyFactory
 from users.models import User
 
 # Regulation letters
@@ -73,6 +74,8 @@ def test__api__regulation_letter__continuation_letter(api_client: HitasAPIClient
         regulation_result=RegulationResult.STAYS_REGULATED,
         letter_fetched=False,
     )
+
+    body = PDFBodyFactory.create(name=PDFBodyName.STAYS_REGULATED, texts=["||foo||", "||bar||", "||baz||"])
 
     url = (
         reverse("hitas:thirty-year-regulation-letter")
@@ -140,16 +143,12 @@ def test__api__regulation_letter__continuation_letter(api_client: HitasAPIClient
         keskineliöhinnan.
         Hintasääntelystä
         vapautuminen
-        Yhtiönne voi hakea Hitas-sääntelystä vapautumista
+        {body.texts[0]}
         Tontin maanvuokra
-        Tontin maanvuokraa tarkistetaan hintasääntelystä vapautumisen yhteydessä 0 - 30
-        prosentilla kiinteistölautakunnan erikseen päättämien ohjeiden mukaisesti. Lisätietoja saa
-        kaupunkiympäristön tontit-yksiköstä.
+        {body.texts[1]}
         Hintasääntelyn
         jatkuminen
-        Mikäli yhtiönne ei hae Hitas-sääntelystä vapautumista, hintavertailu tehdään neljä kertaa
-        vuodessa ja yhtiönne tilanne ilmoitetaan hintasääntelyn osalta seuraavan
-        neljännesvuosivertailun jälkeen.
+        {body.texts[2]}
         Hintasääntelyilmoitus on tulostettu Hitas-rekisteristä.
         Lisätiedot: {api_user.first_name} {api_user.last_name}, {api_user.title}, puhelin {api_user.phone}
         LIITE
@@ -277,6 +276,8 @@ def test__api__regulation_letter__release_letter(api_client: HitasAPIClient, fre
         regulation_result=RegulationResult.RELEASED_FROM_REGULATION,
     )
 
+    body = PDFBodyFactory.create(name=PDFBodyName.RELEASED_FROM_REGULATION, texts=["||foo||"])
+
     url = (
         reverse("hitas:thirty-year-regulation-letter")
         + f"?housing_company_id={sale.apartment.housing_company.uuid.hex}"
@@ -343,11 +344,7 @@ def test__api__regulation_letter__release_letter(api_client: HitasAPIClient, fre
         keskineliöhinnan.
         Hintasääntelystä
         vapautuminen
-        Kun yhtiö on kaupunginvaltuuston 3.6.2009 (136 §) päätöksen perusteella vapautunut
-        hintojen sääntelystä, kaupungin puolesta ei ole estettä sille, että yhtiöjärjestykseen otetut
-        kaupungin lunastusoikeutta koskevat pykälät poistetaan yhtiöjärjestyksestä.
-        Tämän ilmoituksen jälkeen yhtiön asuntojen enimmäishintoja ei enää vahvisteta, eikä tietoja
-        tapahtuneista kaupoista ilmoiteta.
+        {body.texts[0]}
         Hintasääntelyilmoitus on tulostettu Hitas-rekisteristä.
         Lisätiedot: {api_user.first_name} {api_user.last_name}, {api_user.title}, puhelin {api_user.phone}
         LIITE
@@ -502,6 +499,8 @@ def test__api__regulation_letter__previous_letter(api_client: HitasAPIClient, fr
         regulation_result=RegulationResult.STAYS_REGULATED,
     )
 
+    body = PDFBodyFactory.create(name=PDFBodyName.STAYS_REGULATED, texts=["||foo||", "||bar||", "||baz||"])
+
     url = (
         reverse("hitas:thirty-year-regulation-letter")
         + f"?housing_company_id={sale.apartment.housing_company.uuid.hex}"
@@ -565,16 +564,12 @@ def test__api__regulation_letter__previous_letter(api_client: HitasAPIClient, fr
         keskineliöhinnan.
         Hintasääntelystä
         vapautuminen
-        Yhtiönne voi hakea Hitas-sääntelystä vapautumista
+        {body.texts[0]}
         Tontin maanvuokra
-        Tontin maanvuokraa tarkistetaan hintasääntelystä vapautumisen yhteydessä 0 - 30
-        prosentilla kiinteistölautakunnan erikseen päättämien ohjeiden mukaisesti. Lisätietoja saa
-        kaupunkiympäristön tontit-yksiköstä.
+        {body.texts[1]}
         Hintasääntelyn
         jatkuminen
-        Mikäli yhtiönne ei hae Hitas-sääntelystä vapautumista, hintavertailu tehdään neljä kertaa
-        vuodessa ja yhtiönne tilanne ilmoitetaan hintasääntelyn osalta seuraavan
-        neljännesvuosivertailun jälkeen.
+        {body.texts[2]}
         Hintasääntelyilmoitus on tulostettu Hitas-rekisteristä.
         Lisätiedot: {api_user.first_name} {api_user.last_name}, {api_user.title}, puhelin {api_user.phone}
         LIITE

--- a/backend/hitas/views/pdf_body.py
+++ b/backend/hitas/views/pdf_body.py
@@ -29,6 +29,10 @@ class PDFBodySerializer(EnumSupportSerializerMixin, ModelSerializer):
             validated_data["name"] == PDFBodyName.CONFIRMED_MAX_PRICE_CALCULATION and len(validated_data["texts"]) != 1
         ):
             raise ValidationError({"texts": "Confirmed max price calculation must have exactly 1 body text."})
+        elif validated_data["name"] == PDFBodyName.STAYS_REGULATED and len(validated_data["texts"]) != 3:
+            raise ValidationError({"texts": "Regulation continuation letter must have exactly 3 body texts."})
+        elif validated_data["name"] == PDFBodyName.RELEASED_FROM_REGULATION and len(validated_data["texts"]) != 1:
+            raise ValidationError({"texts": "Regulation release letter must have exactly 1 body text."})
 
     class Meta:
         model = PDFBody

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -8494,11 +8494,15 @@ components:
         Can have the following values:
           - "confirmed_max_price_calculation"
           - "unconfirmed_max_price_calculation"
+          - "stays_regulated"
+          - "released_from_regulation"
       type: string
       example: "confirmed_max_price_calculation"
       x-extensible-enum:
         - "confirmed_max_price_calculation"
         - "unconfirmed_max_price_calculation"
+        - "stays_regulated"
+        - "released_from_regulation"
 
     # Errors
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

Add PDF body templates to regulation letters.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests

## Tickets

This pull request resolves all or part of the following ticket(s): HT-646
