### PR TITLE
Frontend: Adds environment banner on local, dev, test & stage envs

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -25,6 +25,26 @@ const App = (): JSX.Element => {
     const [userTitle, setUserTitle] = useState<string | number>(0);
     const dispatch = useAppDispatch();
 
+    // Get the current environment from the url
+    const getEnvironment = () => {
+        const url = window.location.href;
+        const domain = url.split("/")[2];
+        const environment = domain.split(":")[0] === "localhost" ? "local" : domain.split(".")[1];
+        let name = environment;
+        switch (name) {
+            case "stage":
+                name = "staging";
+                break;
+            case "dev":
+                name = "development";
+                break;
+        }
+        const hasDevelopmentBanner =
+            name === "local" || name === "development" || name === "test" || name === "staging";
+        return {name: name, hasDevelopmentBanner: hasDevelopmentBanner};
+    };
+    const environment = getEnvironment();
+
     // Check the authentication and get the username
     useEffect(() => {
         // UserInfo endpoint should not be called when using token authentication in development
@@ -52,6 +72,7 @@ const App = (): JSX.Element => {
     // Layout
     return (
         <div className="App">
+            {environment.hasDevelopmentBanner && <div className="development-banner">{environment.name}</div>}
             <Navigation
                 title="Asuntopalvelut"
                 menuToggleAriaLabel=""

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -6,6 +6,16 @@
   @include align-items(center)
   min-height: 100vh
 
+  .development-banner
+    @include flexbox()
+    @include flex-flow(column nowrap)
+    @include align-items(center)
+    width: 100%
+    padding: $spacing-xs
+    background: $color-success
+    color: white
+    text-transform: uppercase
+
 .main-content
   @include flexbox()
   @include flex-flow(column nowrap)


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds green environment banner on local, development, test and staging environments.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Run the app and check that the green banner shows up with the correct environment name. 

## Tickets

This pull request resolves all or part of the following ticket(s): HT-620
