### PR TITLE
Frontend: Makes the environment banner visible when scrolling down

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -71,50 +71,52 @@ const App = (): JSX.Element => {
 
     // Layout
     return (
-        <div className="App">
+        <div className="app-container">
             {environment.hasDevelopmentBanner && <div className="development-banner">{environment.name}</div>}
-            <Navigation
-                title="Asuntopalvelut"
-                menuToggleAriaLabel=""
-                skipTo=""
-                skipToContentLabel=""
-                titleUrl="/"
-            >
-                {!isUserInfoLoading && !token && (
-                    <Navigation.Actions>
-                        <Navigation.User
-                            authenticated={isAuthenticated && userTitle !== 0}
-                            buttonAriaLabel={`Käyttäjä ${userTitle}`}
-                            label="Kirjaudu sisään"
-                            onSignIn={signIn}
-                            userName={userTitle}
-                        >
-                            <Navigation.Item
-                                onClick={logOut}
-                                variant="supplementary"
-                                label="Kirjaudu ulos"
-                                icon={<IconSignout aria-hidden />}
-                            />
-                        </Navigation.User>
-                    </Navigation.Actions>
-                )}
-                <Navigation.Row ariaLabel="Main navigation">
-                    <Link to="housing-companies">Yhtiöt</Link>
-                    <Link to="apartments">Asunnot</Link>
-                    <Link to="reports">Raportit</Link>
-                    <Link to="documents">Dokumentit</Link>
-                    <Link to="codes">Koodisto</Link>
-                    <Link to="functions">Toiminnot</Link>
-                </Navigation.Row>
-            </Navigation>
+            <div className="App">
+                <Navigation
+                    title="Asuntopalvelut"
+                    menuToggleAriaLabel=""
+                    skipTo=""
+                    skipToContentLabel=""
+                    titleUrl="/"
+                >
+                    {!isUserInfoLoading && !token && (
+                        <Navigation.Actions>
+                            <Navigation.User
+                                authenticated={isAuthenticated && userTitle !== 0}
+                                buttonAriaLabel={`Käyttäjä ${userTitle}`}
+                                label="Kirjaudu sisään"
+                                onSignIn={signIn}
+                                userName={userTitle}
+                            >
+                                <Navigation.Item
+                                    onClick={logOut}
+                                    variant="supplementary"
+                                    label="Kirjaudu ulos"
+                                    icon={<IconSignout aria-hidden />}
+                                />
+                            </Navigation.User>
+                        </Navigation.Actions>
+                    )}
+                    <Navigation.Row ariaLabel="Main navigation">
+                        <Link to="housing-companies">Yhtiöt</Link>
+                        <Link to="apartments">Asunnot</Link>
+                        <Link to="reports">Raportit</Link>
+                        <Link to="documents">Dokumentit</Link>
+                        <Link to="codes">Koodisto</Link>
+                        <Link to="functions">Toiminnot</Link>
+                    </Navigation.Row>
+                </Navigation>
 
-            <Container className="main-content">
-                {isAuthenticating || isUserInfoLoading ? <Spinner /> : <Outlet />}
-            </Container>
+                <Container className="main-content">
+                    {isAuthenticating || isUserInfoLoading ? <Spinner /> : <Outlet />}
+                </Container>
 
-            <Notifications />
+                <Notifications />
 
-            <Footer />
+                <Footer />
+            </div>
         </div>
     );
 };

--- a/frontend/src/styles/layout/_page.sass
+++ b/frontend/src/styles/layout/_page.sass
@@ -1,20 +1,27 @@
 @use '../imports' as *
 
+.app-container
+  @include flexbox()
+  @include flex-flow(column nowrap)
+  height: 100vh
+  overflow: hidden
+
+  .development-banner
+      @include flexbox()
+      @include flex-flow(column nowrap)
+      @include align-items(center)
+      width: 100%
+      padding: $spacing-xs
+      background: $color-success
+      color: white
+      text-transform: uppercase
+
 .App
   @include flexbox()
   @include flex-flow(column nowrap)
   @include align-items(center)
-  min-height: 100vh
-
-  .development-banner
-    @include flexbox()
-    @include flex-flow(column nowrap)
-    @include align-items(center)
-    width: 100%
-    padding: $spacing-xs
-    background: $color-success
-    color: white
-    text-transform: uppercase
+  @include flex-grow(1)
+  overflow: auto
 
 .main-content
   @include flexbox()


### PR DESCRIPTION
# Hitas Pull Request

# Description

Makes the environment banner also visible when scrolling down for local, development, test and staging environments.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Open a page that needs scrolling and ensure that scrolling is enabled and the environment banner shows also when scrolled down.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-620