### PR TITLE
Price ceiling front

### DIFF
--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -40,7 +40,7 @@ import {
     IThirtyYearRegulationResponse,
     IUserInfoResponse,
 } from "../common/schemas";
-import {hitasToast} from "../common/utils";
+import {hdsToast} from "../common/utils";
 
 // /////////
 // Config //
@@ -86,7 +86,7 @@ const handleDownloadPDF = (response) => {
         .then((blob) => {
             const filename = response.headers.get("Content-Disposition")?.split("=")[1];
             if (filename === undefined) {
-                hitasToast("Virhe tiedostoa ladattaessa.", "error");
+                hdsToast.error("Virhe ladattaessa tiedostoa.");
                 return;
             }
 
@@ -128,7 +128,7 @@ export const downloadApartmentUnconfirmedMaximumPricePDF = (
 
 export const downloadApartmentMaximumPricePDF = (apartment: IApartmentDetails, requestDate?: string) => {
     if (!apartment.prices.maximum_prices.confirmed) {
-        hitasToast("Enimmäishintalaskelmaa ei ole olemassa", "error");
+        hdsToast.error("Enimmäishintalaskelmaa ei ole olemassa.");
         return;
     }
     const url = `${Config.api_v1_url}/housing-companies/${apartment.links.housing_company.id}/apartments/${apartment.id}/reports/download-latest-confirmed-prices`;

--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -347,6 +347,11 @@ const detailApi = hitasApi.injectEndpoints({
                 url: `indices/${params.indexType}/${params.month}`,
             }),
         }),
+        getPriceCeilingCalculationData: builder.query<{calculationMonth: string}, object>({
+            query: (params: {calculationMonth: string}) => ({
+                url: `indices/surface-area-price-ceiling-calculation-data/${params.calculationMonth}-01`,
+            }),
+        }),
     }),
 });
 
@@ -659,6 +664,7 @@ export const {
     useGetExternalSalesDataQuery,
     useGetThirtyYearRegulationQuery,
     useGetIndexQuery,
+    useGetPriceCeilingCalculationDataQuery,
 } = detailApi;
 
 export const {

--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -624,6 +624,15 @@ const mutationApi = hitasApi.injectEndpoints({
             }),
             invalidatesTags: (result, error) => (!error && result ? [{type: "Apartment"}] : []),
         }),
+        calculatePriceCeiling: builder.mutation({
+            query: ({data}) => ({
+                url: "indices/surface-area-price-ceiling",
+                method: "POST",
+                headers: mutationApiJsonHeaders(),
+                body: data,
+            }),
+            invalidatesTags: (result, error) => (!error && result ? [{type: "Index", id: "LIST"}] : []),
+        }),
     }),
 });
 
@@ -673,4 +682,5 @@ export const {
     useValidateSalesCatalogMutation,
     useCreateFromSalesCatalogMutation,
     useBatchCompleteApartmentsMutation,
+    useCalculatePriceCeilingMutation,
 } = mutationApi;

--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -149,6 +149,19 @@ export const downloadRegulationResults = (calculationDate?: string) => {
         .catch((error) => console.error(error));
 };
 
+export const downloadSurfaceAreaPriceCeilingResults = (calculationDate?: string) => {
+    const params = `calculation_date=${calculationDate}`;
+    const url = `${Config.api_v1_url}/indices/surface-area-price-ceiling/reports/download-surface-area-price-ceiling-results?${params}`;
+    const init = {
+        ...getFetchInit(),
+        method: "GET",
+    };
+    fetch(url, init)
+        .then(handleDownloadPDF)
+        // eslint-disable-next-line no-console
+        .catch((error) => console.error(error));
+};
+
 // ///////////
 // Auth API //
 // ///////////

--- a/frontend/src/common/components/DownloadButton.tsx
+++ b/frontend/src/common/components/DownloadButton.tsx
@@ -1,0 +1,16 @@
+import {Button, IconDownload} from "hds-react";
+
+const DownloadButton = ({downloadFn, buttonText, ...buttonProps}) => {
+    return (
+        <Button
+            onClick={downloadFn}
+            theme="black"
+            iconLeft={<IconDownload />}
+            {...buttonProps}
+        >
+            {buttonText}
+        </Button>
+    );
+};
+
+export default DownloadButton;

--- a/frontend/src/common/components/FilterTextInputField.tsx
+++ b/frontend/src/common/components/FilterTextInputField.tsx
@@ -9,6 +9,8 @@ interface FilterTextInputFieldProps {
     setFilterParams: (object) => void;
     minLength?: number;
     maxLength?: number;
+    defaultValue?: string;
+    required?: boolean;
 }
 
 export default function FilterTextInputField({
@@ -18,6 +20,7 @@ export default function FilterTextInputField({
     setFilterParams,
     minLength = 3,
     maxLength,
+    ...rest
 }: FilterTextInputFieldProps): JSX.Element {
     const [isInvalid, setIsInvalid] = useState(false);
 
@@ -51,6 +54,7 @@ export default function FilterTextInputField({
             onFocus={() => setIsInvalid(false)}
             invalid={isInvalid}
             maxLength={maxLength}
+            {...rest}
         />
     );
 }

--- a/frontend/src/common/components/Heading.tsx
+++ b/frontend/src/common/components/Heading.tsx
@@ -1,7 +1,7 @@
 interface HeadingProps {
     children;
     className?: string;
-    type?: "main" | "list" | "body";
+    type?: "main" | "list" | "body" | "sub";
 }
 
 const Heading = ({children, className = "", type = "main"}: HeadingProps) => {
@@ -12,6 +12,8 @@ const Heading = ({children, className = "", type = "main"}: HeadingProps) => {
             return <h2 className={`heading--${type} ${className}`}>{children}</h2>;
         case "body":
             return <h3 className={`heading--${type} ${className}`}>{children}</h3>;
+        case "sub":
+            return <h4 className={`heading--${type} ${className}`}>{children}</h4>;
     }
 };
 

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -205,3 +205,28 @@ export const getApartmentUnconfirmedPrices = (
     if (isPre2011) return apartment.prices.maximum_prices.unconfirmed.pre_2011;
     else return apartment.prices.maximum_prices.unconfirmed.onwards_2011;
 };
+
+// Takes a date and returns the hitasQuarter it belongs to. Returns current quarter if no date is given.
+export const getHitasQuarter = (date?) => {
+    const time = date ? Number(date.slice("-")[1]) : new Date().getMonth() + 1;
+    let defaultQuarter = {label: "1.2. - 30.4.", value: "02-01"};
+    // FIXME: The +2 is a hack to get the next quarter as a return value for testing. Remove before commit!
+    switch (time + 2) {
+        case 0:
+        case 10:
+        case 11:
+            defaultQuarter = {label: "1.11. - 31.1.", value: "11-01"};
+            break;
+        case 4:
+        case 5:
+        case 6:
+            defaultQuarter = {label: "1.5. - 31.7.", value: "05-01"};
+            break;
+        case 7:
+        case 8:
+        case 9:
+            defaultQuarter = {label: "1.8. - 31.10.", value: "08-01"};
+            break;
+    }
+    return defaultQuarter;
+};

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -154,6 +154,7 @@ export function hitasToast(
     toast(message, {...opts, className: type});
 }
 
+// Toast hook with easier Notification typing
 export const hdsToast = {
     success: (message: string | JSX.Element, opts?: ToastOptions) => toast(message, {...opts, className: "success"}),
     info: (message: string | JSX.Element, opts?: ToastOptions) => toast(message, {...opts, className: "info"}),
@@ -177,6 +178,7 @@ export function doesAContainB(A: object, B: object): boolean {
     return true;
 }
 
+// Returns true if obj is empty, false otherwise. Returns true if obj is undefined or null.
 export function isEmpty(obj: object | undefined | null): boolean {
     if (obj === undefined || obj === null) return true;
     return Object.keys(obj).length === 0;
@@ -199,6 +201,7 @@ export const getLogOutUrl = (): string => {
     return Config.api_auth_url + "/logout?next=" + callBackUrl;
 };
 
+// Returns apartment's maximum unconfirmed prices, whether they are pre-2011 or onwards-2011
 export const getApartmentUnconfirmedPrices = (
     apartment: IApartmentDetails
 ): IApartmentUnconfirmedMaximumPriceIndices => {
@@ -212,11 +215,11 @@ export const getApartmentUnconfirmedPrices = (
 export const getHitasQuarter = (date?) => {
     // Extract month from date, or use current month if there's no date (getMonth returns a 0-indexed value, so add 1)
     const month = date ? Number(date.split("-")[1]) : new Date().getMonth() + 1;
-    const quarter = {number: NaN};
+    const quarter: Record<"number", number> = {number: 0};
     switch (month) {
-        case 1:
         case 11:
         case 12:
+        case 1:
             quarter.number = 3;
             break;
         case 2:

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -208,23 +208,22 @@ export const getApartmentUnconfirmedPrices = (
 
 // Takes a date and returns the hitasQuarter it belongs to. Returns current quarter if no date is given.
 export const getHitasQuarter = (date?) => {
-    const time = date ? Number(date.slice("-")[1]) : new Date().getMonth() + 1;
-    let defaultQuarter = {label: "1.2. - 30.4.", value: "02-01"};
-    // FIXME: The +2 is a hack to get the next quarter as a return value for testing. Remove before commit!
-    switch (time + 2) {
-        case 0:
-        case 10:
-        case 11:
-            defaultQuarter = {label: "1.11. - 31.1.", value: "11-01"};
-            break;
+    const time = date ? Number(date.split("-")[1]) : new Date().getMonth() + 1;
+    let defaultQuarter = {label: "1.11. - 31.1.", value: "11-01"};
+    switch (time) {
+        case 2:
+        case 3:
         case 4:
+            defaultQuarter = {label: "1.2. - 30.4.", value: "02-01"};
+            break;
         case 5:
         case 6:
+        case 7:
             defaultQuarter = {label: "1.5. - 31.7.", value: "05-01"};
             break;
-        case 7:
         case 8:
         case 9:
+        case 10:
             defaultQuarter = {label: "1.8. - 31.10.", value: "08-01"};
             break;
     }

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -2,6 +2,7 @@ import toast, {ToastOptions} from "react-hot-toast";
 
 import {Config} from "../app/services";
 import {
+    hitasQuarters,
     IAddress,
     IApartmentAddress,
     IApartmentDetails,
@@ -206,26 +207,35 @@ export const getApartmentUnconfirmedPrices = (
     else return apartment.prices.maximum_prices.unconfirmed.onwards_2011;
 };
 
-// Takes a date and returns the hitasQuarter it belongs to. Returns current quarter if no date is given.
+// Takes a date in YYYY-MM-DD format (with the day being optional), and returns the hitas-quarter the date belongs to.
+// Returns the current hitas-quarter if no date is supplied.
 export const getHitasQuarter = (date?) => {
-    const time = date ? Number(date.split("-")[1]) : new Date().getMonth() + 1;
-    let defaultQuarter = {label: "1.11. - 31.1.", value: "11-01"};
-    switch (time) {
+    // Extract month from date, or use current month if there's no date (getMonth returns a 0-indexed value, so add 1)
+    const month = date ? Number(date.split("-")[1]) : new Date().getMonth() + 1;
+    const quarter = {number: NaN};
+    switch (month) {
+        case 1:
+        case 11:
+        case 12:
+            quarter.number = 3;
+            break;
         case 2:
         case 3:
         case 4:
-            defaultQuarter = {label: "1.2. - 30.4.", value: "02-01"};
+            quarter.number = 0;
             break;
         case 5:
         case 6:
         case 7:
-            defaultQuarter = {label: "1.5. - 31.7.", value: "05-01"};
+            quarter.number = 1;
             break;
         case 8:
         case 9:
         case 10:
-            defaultQuarter = {label: "1.8. - 31.10.", value: "08-01"};
+            quarter.number = 2;
             break;
+        default:
+            return {label: "Virheellinen kuukausi!", value: "---"};
     }
-    return defaultQuarter;
+    return hitasQuarters[quarter.number];
 };

--- a/frontend/src/features/functions/PriceCeilingPerSquare.tsx
+++ b/frontend/src/features/functions/PriceCeilingPerSquare.tsx
@@ -7,6 +7,7 @@ import {
     useGetIndicesQuery,
 } from "../../app/services";
 import {FilterTextInputField, Heading, QueryStateHandler} from "../../common/components";
+import DownloadButton from "../../common/components/DownloadButton";
 import {getHitasQuarter, hdsToast, today} from "../../common/utils";
 
 export const years = Array.from({length: 34}, (_, index) => {
@@ -78,11 +79,11 @@ const PriceCeilingCalculationSection = ({data, currentMonth}) => {
         calculatePriceCeiling({
             data: {calculation_month: currentMonth},
         })
-            .then((data) => {
-                console.log(data);
+            .then(() => {
                 hdsToast.success("Rajahinnan laskenta onnistui");
             })
             .catch((e) => {
+                // eslint-disable-next-line no-console
                 console.warn(e);
                 hdsToast.error("Rajahinnan laskenta epäonnistui");
             });
@@ -103,16 +104,14 @@ const PriceCeilingCalculationSection = ({data, currentMonth}) => {
                 <>
                     <div className="price-ceiling-value">
                         <label>
-                            Rajaneliöhinta (<>{getHitasQuarter(currentMonth + "-01").label}</>)
+                            Rajaneliöhinta (<>{getHitasQuarter().label}</>)
                         </label>
                         <span>{data.contents[0].value}</span>
                     </div>
-                    <Button
-                        theme="black"
-                        onClick={() => downloadSurfaceAreaPriceCeilingResults(currentMonth + "-01")}
-                    >
-                        Lataa laskentaraportti
-                    </Button>
+                    <DownloadButton
+                        downloadFn={() => downloadSurfaceAreaPriceCeilingResults(currentMonth + "-01")}
+                        buttonText="Lataa laskentaraportti"
+                    />
                 </>
             ) : (
                 <>

--- a/frontend/src/features/functions/PriceCeilingPerSquare.tsx
+++ b/frontend/src/features/functions/PriceCeilingPerSquare.tsx
@@ -21,8 +21,8 @@ const LoadedPriceCeilingPerSquareResultsList = ({data}) => {
     return (
         <div className="results">
             <div className="list-headers">
-                <div className="list-header period">Ajanjakso</div>
-                <div className="list-header value">Rajaneliöhinta (€)</div>
+                <div className="list-header period">Vuosineljännes</div>
+                <div className="list-header value">Rajaneliöhinta (€/m²)</div>
             </div>
             <ul className="results-list">
                 {data?.contents.map((item) => (
@@ -38,34 +38,37 @@ const LoadedPriceCeilingPerSquareResultsList = ({data}) => {
 };
 
 const ListItem = ({month, value}) => {
-    const year = month.slice(0, 4);
-    let timePeriod;
-    switch (month.slice(-2)) {
+    // the month is in the format YYYY-MM
+    const [yearString, monthString] = month.split("-");
+    let timePeriod = month;
+    switch (monthString) {
         case "01":
-            timePeriod = `${getHitasQuarter(month).label.split(" ")[0]}${Number(year) - 1} - ${
+            // add the previous year in the start date for january, as its quarter begins in the previous year
+            timePeriod = `${getHitasQuarter(month).label.split(" ")[0]}${Number(yearString) - 1} - ${
                 getHitasQuarter(month).label.split("-")[1]
-            }${year}`;
+            }${yearString}`;
             break;
         case "02":
         case "05":
         case "08":
-            timePeriod = `${getHitasQuarter(month).label}${year}`;
+            // for the months which start a new quarter, simply add the year to the end of the quarter label
+            timePeriod = `${getHitasQuarter(month).label}${yearString}`;
             break;
         case "11":
-            timePeriod = `${getHitasQuarter(month).label.split(" ")[0]}${year} - ${
+            // add the next year in the end date for the last quarter, as the quarter ends in the next year
+            timePeriod = `${getHitasQuarter(month).label.split(" ")[0]}${yearString} - ${
                 getHitasQuarter(month).label.split("-")[1]
-            }${Number(year) + 1}`;
+            }${Number(yearString) + 1}`;
             break;
         default:
-            return <></>;
+            // for the months which are not the start of a new quarter (or year), do not display the value
+            return <> </>;
     }
-    return timePeriod !== undefined ? (
+    return (
         <li className="results-list__item">
             <div className="period">{timePeriod}</div>
             <div className="value">{value}</div>
         </li>
-    ) : (
-        <></>
     );
 };
 
@@ -124,37 +127,53 @@ const PriceCeilingCalculationSection = ({data, currentMonth}) => {
 const PriceCeilingPerSquare = () => {
     const currentMonth = today().slice(0, 7);
     const [filterParams, setFilterParams] = useState({year: new Date().getFullYear().toString()});
+    const {
+        data: currentCalculationData,
+        error: currentCalculationError,
+        isLoading: isCurrentCalculationLoading,
+    } = useGetIndicesQuery({
+        indexType: "surface-area-price-ceiling",
+        params: {year: today().split("-")[0], limit: 12, page: 1},
+    });
     const {data, error, isLoading} = useGetIndicesQuery({
         indexType: "surface-area-price-ceiling",
         params: {...filterParams, limit: 12, page: 1},
     });
-
     return (
         <div className="view--functions__price-ceiling-per-square">
-            <Heading type="body">Nykyisen neljänneksen rajaneliöhinta</Heading>
+            <Heading type="body">Rajaneliöhinnan laskenta</Heading>
+            <QueryStateHandler
+                data={currentCalculationData}
+                error={currentCalculationError}
+                isLoading={isCurrentCalculationLoading}
+                attemptedAction="Haetaan rajaneliöhintalistausta (tarkistetaan onko nykyinen laskettu)"
+            >
+                <PriceCeilingCalculationSection
+                    data={currentCalculationData}
+                    currentMonth={currentMonth}
+                />
+            </QueryStateHandler>
             <QueryStateHandler
                 data={data}
                 error={error}
                 isLoading={isLoading}
                 attemptedAction="Haetaan rajaneliöhintalistausta"
             >
-                <PriceCeilingCalculationSection
-                    data={data}
-                    currentMonth={currentMonth}
-                />
-                <Heading type="sub">Edelliset rajaneliöhinnat</Heading>
-                <LoadedPriceCeilingPerSquareResultsList data={data} />
+                <Heading type="sub">Rajaneliöhinnat</Heading>
+                <div className="price-ceiling-results">
+                    <FilterTextInputField
+                        label="Vuosi"
+                        filterFieldName="year"
+                        defaultValue={filterParams.year}
+                        filterParams={filterParams}
+                        setFilterParams={setFilterParams}
+                        minLength={4}
+                        maxLength={4}
+                        required
+                    />
+                    {filterParams.year ? <LoadedPriceCeilingPerSquareResultsList data={data} /> : <></>}
+                </div>
             </QueryStateHandler>
-            <div className="year-filter">
-                <FilterTextInputField
-                    label="Vuosi"
-                    filterFieldName="year"
-                    filterParams={filterParams}
-                    setFilterParams={setFilterParams}
-                    minLength={4}
-                    maxLength={4}
-                />
-            </div>
         </div>
     );
 };

--- a/frontend/src/features/functions/PriceCeilingPerSquare.tsx
+++ b/frontend/src/features/functions/PriceCeilingPerSquare.tsx
@@ -79,6 +79,7 @@ const PriceCeilingCalculationSection = ({data, currentMonth}) => {
         calculatePriceCeiling({
             data: {calculation_month: currentMonth},
         })
+            .unwrap()
             .then(() => {
                 hdsToast.success("Rajahinnan laskenta onnistui");
             })

--- a/frontend/src/features/functions/PriceCeilingPerSquare.tsx
+++ b/frontend/src/features/functions/PriceCeilingPerSquare.tsx
@@ -1,12 +1,13 @@
 import {Button} from "hds-react";
 import {useState} from "react";
-import {useForm} from "react-hook-form";
 
-import {hitasQuarters} from "../../common/schemas";
-
-import {useGetIndicesQuery} from "../../app/services";
+import {
+    useCalculatePriceCeilingMutation,
+    useGetIndicesQuery,
+    useGetPriceCeilingCalculationDataQuery,
+} from "../../app/services";
 import {FilterTextInputField, Heading, QueryStateHandler} from "../../common/components";
-import {Select} from "../../common/components/form";
+import {getHitasQuarter, hdsToast, today} from "../../common/utils";
 
 export const years = Array.from({length: 34}, (_, index) => {
     const year = 2023 - index;
@@ -17,7 +18,6 @@ export const years = Array.from({length: 34}, (_, index) => {
 });
 
 const LoadedPriceCeilingPerSquareResultsList = ({data}) => {
-    console.log(data.contents);
     return (
         <div className="results">
             <div className="list-headers">
@@ -27,7 +27,7 @@ const LoadedPriceCeilingPerSquareResultsList = ({data}) => {
             <ul className="results-list">
                 {data?.contents.map((item) => (
                     <ListItem
-                        key={`${item.year}-${item.quarter}`}
+                        key={item.month}
                         month={item.month}
                         year={item.year}
                         value={item.value}
@@ -38,69 +38,105 @@ const LoadedPriceCeilingPerSquareResultsList = ({data}) => {
     );
 };
 
-const CalculateButton = () => (
-    <Button
-        className="calculate-button"
-        theme="black"
-        variant="secondary"
-        onClick={() => console.log("Calculating")}
-    >
-        <span>Laske</span>
-    </Button>
-);
-
 const ListItem = ({month, year, value}) => {
-    console.log(month);
     return (
         <li className="results-list__item">
             <div className="period">
                 {month}
                 {years[new Date().getFullYear() - year]?.label}
             </div>
-            <div className="value">{value ?? <CalculateButton />}</div>
+            <div className="value">{value}</div>
         </li>
     );
 };
 
+const PriceCeilingCalculationResult = ({data, currentMonth}) => {
+    const {
+        data: calculationData,
+        error,
+        isLoading,
+    } = useGetPriceCeilingCalculationDataQuery({calculationMonth: currentMonth});
+    return (
+        <QueryStateHandler
+            data={calculationData}
+            error={error}
+            isLoading={isLoading}
+        >
+            <span>Tälle neljännekselle on laskettu rajaneliöhinta:</span>
+            <span>{data.contents[0].value}</span>
+        </QueryStateHandler>
+    );
+};
+const PriceCeilingCalculationSection = ({data, currentMonth}) => {
+    const [calculatePriceCeiling] = useCalculatePriceCeilingMutation();
+    const handleCalculateButton = () => {
+        calculatePriceCeiling({
+            data: {calculation_month: currentMonth},
+        })
+            .then((data) => {
+                console.log(data);
+                hdsToast.success("Rajahinnan laskenta onnistui");
+            })
+            .catch((e) => {
+                console.warn(e);
+                hdsToast.error("Rajahinnan laskenta epäonnistui");
+            });
+    };
+    const CalculateButton = () => (
+        <Button
+            className="calculate-button"
+            theme="black"
+            onClick={handleCalculateButton}
+        >
+            <span>Laske rajaneliöhinta</span>
+        </Button>
+    );
+    return (
+        <div className="price-ceiling-calculation">
+            {data.contents.some((item) => item.month === currentMonth) ? (
+                <>
+                    <span>Tälle neljännekselle on laskettu rajaneliöhinta:</span>
+                    <span>{data.contents[0].value}</span>
+                    <PriceCeilingCalculationResult
+                        data={data}
+                        currentMonth={currentMonth}
+                    />
+                    <CalculateButton />
+                </>
+            ) : (
+                <>
+                    <p>Tälle neljännekselle ({getHitasQuarter().label}) ei vielä ole laskettu rajaneliöhintaa</p>
+                    <CalculateButton />
+                </>
+            )}
+        </div>
+    );
+};
+
 const PriceCeilingPerSquare = () => {
-    const [filterParams, setFilterParams] = useState({year: "2023"});
+    // FIXME: use today().slice(0, 7) for the current Month, the +3 is a hack for testing
+    const currentMonth = new Date().getFullYear() + "-" + ("0" + (new Date().getMonth() + 1)).slice(-2);
+    const [filterParams, setFilterParams] = useState({year: new Date().getFullYear().toString()});
     const {data, error, isLoading} = useGetIndicesQuery({
         indexType: "surface-area-price-ceiling",
         params: {...filterParams, limit: 12, page: 1},
     });
-    const formObject = useForm({
-        defaultValues: {year: years[1], quarter: hitasQuarters[0]},
-        mode: "all",
-    });
+    console.log(data?.contents[0].month, currentMonth, today().slice(0, 7));
 
     return (
         <div className="view--functions__price-ceiling-per-square">
             <Heading type="body">Rajaneliöhinnan laskenta</Heading>
-            <form>
-                <div>
-                    <Select
-                        label="Vuosi"
-                        options={years}
-                        name="year"
-                        formObject={formObject}
-                        defaultValue={years[0]}
-                    />
-                    <Select
-                        label="Ajanjakso"
-                        options={hitasQuarters}
-                        name="period"
-                        formObject={formObject}
-                        defaultValue={hitasQuarters[0]}
-                    />
-                    <CalculateButton />
-                </div>
-            </form>
-            <Heading type="body">Edelliset rajaneliöhinnat</Heading>
             <QueryStateHandler
                 data={data}
                 error={error}
                 isLoading={isLoading}
+                attemptedAction="Haetaan rajaneliöhintalistausta"
             >
+                <PriceCeilingCalculationSection
+                    data={data}
+                    currentMonth={currentMonth}
+                />
+                <Heading type="sub">Edelliset rajaneliöhinnat</Heading>
                 <LoadedPriceCeilingPerSquareResultsList data={data} />
             </QueryStateHandler>
             <div className="year-filter">

--- a/frontend/src/features/functions/ThirtyYearRegulation.tsx
+++ b/frontend/src/features/functions/ThirtyYearRegulation.tsx
@@ -1,4 +1,4 @@
-import {Button, Tooltip} from "hds-react";
+import {Tooltip} from "hds-react";
 import {useForm} from "react-hook-form";
 import {hitasQuarters} from "../../common/schemas";
 
@@ -11,6 +11,7 @@ import {
     useGetThirtyYearRegulationQuery,
 } from "../../app/services";
 import {Divider, Heading, QueryStateHandler} from "../../common/components";
+import DownloadButton from "../../common/components/DownloadButton";
 import {Select, ToggleInput} from "../../common/components/form";
 import {getHitasQuarter, hdsToast} from "../../common/utils";
 import {ExternalSalesDataImport, ThirtyYearErrorModal, ThirtyYearErrorTest, ThirtyYearResults} from "./components";
@@ -18,6 +19,7 @@ import {ExternalSalesDataImport, ThirtyYearErrorModal, ThirtyYearErrorTest, Thir
 const ThirtyYearRegulation = () => {
     const currentTime = new Date();
     const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
+    // TODO: populate the years options with years starting from 2023, when testing is done
     const years = [
         {label: "2023", value: "2023"},
         {label: "2022", value: "2022"},
@@ -155,10 +157,10 @@ const ThirtyYearRegulation = () => {
                         <div className="actions">
                             <div className="time-period">
                                 <label>
-                                    Ajanjakso
+                                    Vuosineljännes
                                     <Tooltip placement="bottom-start">
-                                        Valitse vuosi ja jakso jonka vapautumisia haluat tarkastella, tai jolle haluat
-                                        suorittaa vertailun mikäli sitä ei ole vielä tehty.
+                                        Valitse vuosi ja neljännes jonka vapautumisia haluat tarkastella, tai jolle
+                                        haluat suorittaa vertailun mikäli sitä ei ole vielä tehty.
                                     </Tooltip>
                                 </label>
                                 <Select
@@ -198,23 +200,21 @@ const ThirtyYearRegulation = () => {
                                     </div>
                                 </QueryStateHandler>
                                 {hasRegulationResults && (
-                                    <Button
-                                        theme="black"
-                                        onClick={() => downloadRegulationResults(formDate)}
-                                    >
-                                        Lataa kokonaisraportti
-                                    </Button>
+                                    <DownloadButton
+                                        downloadFn={() => downloadRegulationResults(formDate)}
+                                        buttonText="Lataa kokonaisraportti"
+                                    />
                                 )}
                             </div>
                         </div>
-                        <Divider size="l" />
-                        <div className="external-sales-data-import">
-                            {hasExternalSalesData ? (
-                                <h3 className="external-sales-data-exists">{`Ajanjaksolle ${formTimePeriod.label} on tallennettu postinumeroalueiden keskineliöhinnat.`}</h3>
-                            ) : (
-                                <ExternalSalesDataImport formDate={formDate} />
-                            )}
-                        </div>
+                        {!hasExternalSalesData && (
+                            <>
+                                <Divider size="l" />
+                                <div className="external-sales-data-import">
+                                    <ExternalSalesDataImport formDate={formDate} />
+                                </div>
+                            </>
+                        )}
                         <ThirtyYearResults
                             hasResults={hasRegulationResults}
                             hasExternalSalesData={hasExternalSalesData}

--- a/frontend/src/features/functions/ThirtyYearRegulation.tsx
+++ b/frontend/src/features/functions/ThirtyYearRegulation.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../app/services";
 import {Divider, Heading, QueryStateHandler} from "../../common/components";
 import {Select, ToggleInput} from "../../common/components/form";
-import {hdsToast} from "../../common/utils";
+import {getHitasQuarter, hdsToast} from "../../common/utils";
 import {ExternalSalesDataImport, ThirtyYearErrorModal, ThirtyYearErrorTest, ThirtyYearResults} from "./components";
 
 const ThirtyYearRegulation = () => {
@@ -23,31 +23,12 @@ const ThirtyYearRegulation = () => {
         {label: "2022", value: "2022"},
         {label: "2021", value: "2021"},
     ];
-    let defaultQuarter = {label: "1.2. - 30.4.", value: "02-01"};
-    // set the correct selected quarter based on date
-    switch (currentTime.getMonth()) {
-        case 0:
-        case 10:
-        case 11:
-            defaultQuarter = {label: "1.11. - 31.1.", value: "11-01"};
-            break;
-        case 4:
-        case 5:
-        case 6:
-            defaultQuarter = {label: "1.5. - 31.7.", value: "05-01"};
-            break;
-        case 7:
-        case 8:
-        case 9:
-            defaultQuarter = {label: "1.8. - 31.10.", value: "08-01"};
-            break;
-    }
 
     // React hook form
     const formObject = useForm({
         defaultValues: {
             year: years[0].value,
-            quarter: defaultQuarter,
+            quarter: getHitasQuarter(),
             file: undefined,
             test: false,
         },

--- a/frontend/src/features/functions/components/ExternalSalesDataImport.tsx
+++ b/frontend/src/features/functions/components/ExternalSalesDataImport.tsx
@@ -52,7 +52,7 @@ export default function ExternalSalesDataImport({formDate}) {
                 id="file-input"
                 buttonLabel="Valitse tiedosto"
                 formObject={formObject}
-                label="Syötä postinumeroalueiden keskineliöhinnat"
+                label="Postinumeroalueiden keskineliöhinnat *"
                 tooltipText="Tilastokeskukselta saatu excel-tiedosto (.xslx)"
                 accept=".xlsx"
                 onChange={() => onSubmit(formObject.getValues())}

--- a/frontend/src/features/functions/components/ThirtyYearResultListItem.tsx
+++ b/frontend/src/features/functions/components/ThirtyYearResultListItem.tsx
@@ -76,7 +76,7 @@ const ThirtyYearResultListItem = ({company, calculationDate, category}) => {
             </div>
             <ConfirmDialogModal
                 modalHeader={`Vapauta ${company.display_name}?`}
-                modalText={`Olet manuaalisesti vapauttamassa yhtiötä (esim tontit-yksikön päätöksestä). Haluatko 
+                modalText={`Olet manuaalisesti vapauttamassa yhtiötä (esim tontit-yksikön päätöksestä). Haluatko
                     varmasti, että ${company.display_name} vapautetaan sääntelyn piiristä?`}
                 isVisible={isModalOpen}
                 setIsVisible={setIsModalOpen}

--- a/frontend/src/features/functions/components/ThirtyYearResultListItem.tsx
+++ b/frontend/src/features/functions/components/ThirtyYearResultListItem.tsx
@@ -1,4 +1,4 @@
-import {Button, IconDocument, IconLockOpen} from "hds-react";
+import {Button, IconLockOpen} from "hds-react";
 import {useState} from "react";
 import {Link} from "react-router-dom";
 import {
@@ -6,6 +6,7 @@ import {
     useReleaseHousingCompanyFromRegulationMutation,
 } from "../../../app/services";
 import ConfirmDialogModal from "../../../common/components/ConfirmDialogModal";
+import DownloadButton from "../../../common/components/DownloadButton";
 import {formatDate, hdsToast} from "../../../common/utils";
 
 const ThirtyYearResultListItem = ({company, calculationDate, category}) => {
@@ -65,20 +66,18 @@ const ThirtyYearResultListItem = ({company, calculationDate, category}) => {
                     </Button>
                 )}
                 {company.current_regulation_status !== "released_by_plot_department" && (
-                    <Button
-                        theme="black"
-                        onClick={handleClickDownloadPDFButton}
+                    <DownloadButton
+                        buttonText="Lataa tiedote"
+                        downloadFn={handleClickDownloadPDFButton}
                         variant={company.letter_fetched ? "secondary" : "primary"}
                         className="download-button"
-                        iconLeft={<IconDocument />}
-                    >
-                        Lataa tiedote
-                    </Button>
+                    />
                 )}
             </div>
             <ConfirmDialogModal
                 modalHeader={`Vapauta ${company.display_name}?`}
-                modalText={`Olet manuaalisesti vapauttamassa yhtiötä (esim tontit-yksikön päätöksestä). Haluatko varmasti, että ${company.display_name} vapautetaan sääntelyn piiristä?`}
+                modalText={`Olet manuaalisesti vapauttamassa yhtiötä (esim tontit-yksikön päätöksestä). Haluatko 
+                    varmasti, että ${company.display_name} vapautetaan sääntelyn piiristä?`}
                 isVisible={isModalOpen}
                 setIsVisible={setIsModalOpen}
                 buttonText="Vapauta"

--- a/frontend/src/styles/abstracts/_typography.sass
+++ b/frontend/src/styles/abstracts/_typography.sass
@@ -26,6 +26,9 @@ body
 [class^="heading--body"]
   font-size: $fontsize-heading-l
 
+[class^="heading--sub"]
+  font-size: $fontsize-heading-m
+
 .query-handler-error
   font-size: 2rem
   font-weight: 700

--- a/frontend/src/styles/components/_Functions.sass
+++ b/frontend/src/styles/components/_Functions.sass
@@ -44,6 +44,9 @@
       &:not(:disabled):hover
         background-color: black
         color: white
+    .year-filter
+      width: 200px
+      margin: 0 auto
     .results-list
       margin-bottom: $spacing-m
       &__item

--- a/frontend/src/styles/components/_Functions.sass
+++ b/frontend/src/styles/components/_Functions.sass
@@ -31,19 +31,12 @@
   &__price-ceiling-per-square
     padding: $spacing-m
     background: $color-black-10
+    .price-ceiling-calculation
+      @include flexbox()
+      @include justify-content(space-between)
+      margin-bottom: $spacing-layout-m
     .calculate-button
-      margin: -10px 0
-      min-height: auto
-      span
-        @include flexbox()
-        @include flex-flow(row nowrap)
-        @include align-items(center)
-        height: 38px
-        margin: 0
-        padding: 7px 0
-      &:not(:disabled):hover
-        background-color: black
-        color: white
+      height: 56px
     .year-filter
       width: 200px
       margin: 0 auto

--- a/frontend/src/styles/components/_Functions.sass
+++ b/frontend/src/styles/components/_Functions.sass
@@ -52,6 +52,14 @@
     .calculate-button
       height: 56px
       width: 250px
+    .price-ceiling-results
+      @include flexbox()
+      @include flex-flow(row nowrap)
+      gap: $spacing-m
+      > :last-child
+        width: 80%
+      > :only-child
+        width: 20%
     .year-filter
       width: 200px
       margin: 0 auto
@@ -59,6 +67,11 @@
       margin-bottom: $spacing-m
       &__item
         @include align-items(center)
+        cursor: default
+        &:hover
+            background: $color-white
+    .list-headers
+      margin-top: 0
     form
       @include flexbox()
       @include justify-content(center)
@@ -220,6 +233,7 @@
           width: 63%
         .buttons
           @include flexbox()
+          @include justify-content(flex-end)
           width: 37%
           padding: $spacing-m
           *:only-child

--- a/frontend/src/styles/components/_Functions.sass
+++ b/frontend/src/styles/components/_Functions.sass
@@ -33,10 +33,25 @@
     background: $color-black-10
     .price-ceiling-calculation
       @include flexbox()
+      @include flex-flow(row nowrap)
       @include justify-content(space-between)
       margin-bottom: $spacing-layout-m
+    .price-ceiling-value
+        @include flexbox()
+        @include flex-flow(column nowrap)
+        @include justify-content(space-between)
+        span
+          font-size: $fontsize-heading-l
+          font-weight: 700
+          margin-top: $spacing-xs
+          &::after
+            content: "€/m²"
+            font-size: $fontsize-heading-s
+            font-weight: 400
+            margin-left: $spacing-xs
     .calculate-button
       height: 56px
+      width: 250px
     .year-filter
       width: 200px
       margin: 0 auto


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds possibility to make the surface area price ceiling calculation in the frontend, and download a report for that calculation.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [ ] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Go to "Toiminnot" and you will probably first see a page, saying that the price for the current hitas quarter has already been calculated. This is due to the relevant values being a part of initial.json.
When using the data from initial.json, you need to first delete the hitas_surfaceareapriceceiling entries for 2023-05, 2023-06 and 2023-07. Then reload the page, and the upper part of the page should now allow you to calculate the surface area price ceiling value.
Once it's done, the page should update to show the freshly calculated value, and allow you to download a report for the calculation.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-432, HT-429