### PR TITLE
Hard delete conditions of sale when using delete endpoint

### DIFF
--- a/backend/hitas/tests/apis/test_api_condition_of_sale.py
+++ b/backend/hitas/tests/apis/test_api_condition_of_sale.py
@@ -1392,7 +1392,6 @@ def test__api__condition_of_sale__update__invalid(api_client: HitasAPIClient, in
 @pytest.mark.django_db
 def test__api__condition_of_sale__delete__different_owners(api_client: HitasAPIClient, freezer, settings):
     freezer.move_to("2023-01-01 00:00:00+00:00")
-    old_time = timezone.now()
 
     owner_1: Owner = OwnerFactory.create()
     owner_2: Owner = OwnerFactory.create()
@@ -1412,15 +1411,7 @@ def test__api__condition_of_sale__delete__different_owners(api_client: HitasAPIC
     # Deletion is allowed since the old and new owners are not the same (created through a household)
     assert response_1.status_code == status.HTTP_204_NO_CONTENT, response_1.json()
 
-    freezer.move_to(old_time + settings.SHOW_FULFILLED_CONDITIONS_OF_SALE_FOR_MONTHS)
-
-    # You can still find it 3 months after
-    response_2 = api_client.get(url)
-    assert response_2.status_code == status.HTTP_200_OK, response_2.json()
-
-    freezer.move_to(old_time + settings.SHOW_FULFILLED_CONDITIONS_OF_SALE_FOR_MONTHS + relativedelta(seconds=1))
-
-    # Can't find it over 3 months after
+    # The condition of sale is hard deleted
     response_2 = api_client.get(url)
     assert response_2.status_code == status.HTTP_404_NOT_FOUND, response_2.json()
 

--- a/backend/hitas/views/condition_of_sale.py
+++ b/backend/hitas/views/condition_of_sale.py
@@ -7,6 +7,7 @@ from django.db.models import Prefetch
 from enumfields.drf import EnumField, EnumSupportSerializerMixin
 from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer
+from safedelete import HARD_DELETE
 
 from hitas.exceptions import ModelConflict
 from hitas.models.apartment import Apartment
@@ -141,7 +142,7 @@ class ConditionOfSaleViewSet(HitasModelViewSet):
         if instance.new_ownership.owner == instance.old_ownership.owner:
             raise ModelConflict("Cannot delete condition of sale between the same owner.", error_code="invalid")
 
-        super().perform_destroy(instance)
+        instance.delete(force_policy=HARD_DELETE)
 
     def get_queryset(self):
         return condition_of_sale_queryset()


### PR DESCRIPTION
# Hitas Pull Request

# Description

Hard-delete conditions of sale if deleted through the delete endpoint.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests
- [ ] Delete conditions of sale through the endpoint and see that it is no longer in the list

## Tickets

This pull request resolves all or part of the following ticket(s): -
