### PR TITLE
Remove sale front

### DIFF
--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -538,6 +538,7 @@ def test__api__apartment__retrieve(api_client: HitasAPIClient):
 
     sale_1: ApartmentSale = ApartmentSaleFactory.create(
         apartment=ap1,
+        purchase_date=datetime.date(2020, 1, 1),
         purchase_price=80000.1,
         apartment_share_of_housing_company_loans=15000.3,
         ownerships=[],
@@ -597,6 +598,7 @@ def test__api__apartment__retrieve(api_client: HitasAPIClient):
             "catalog_share_of_housing_company_loans": float(ap1.catalog_primary_loan_amount),
             "catalog_acquisition_price": float(ap1.catalog_acquisition_price),
             "first_purchase_date": str(ap1.first_purchase_date),
+            "latest_sale_id": sale_1.uuid.hex,
             "latest_sale_purchase_price": ap1.latest_sale_purchase_price,
             "latest_purchase_date": ap1.latest_purchase_date,
             "construction": {
@@ -1361,6 +1363,7 @@ def test__api__apartment__update(api_client: HitasAPIClient, minimal_data: bool)
                 "catalog_share_of_housing_company_loans": None,
                 "catalog_acquisition_price": None,
                 "first_purchase_date": None,
+                "latest_sale_id": None,
                 "latest_sale_purchase_price": None,
                 "latest_purchase_date": None,
                 "construction": {

--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -598,7 +598,7 @@ def test__api__apartment__retrieve(api_client: HitasAPIClient):
             "catalog_share_of_housing_company_loans": float(ap1.catalog_primary_loan_amount),
             "catalog_acquisition_price": float(ap1.catalog_acquisition_price),
             "first_purchase_date": str(ap1.first_purchase_date),
-            "latest_sale_id": sale_1.uuid.hex,
+            "current_sale_id": sale_1.uuid.hex,
             "latest_sale_purchase_price": ap1.latest_sale_purchase_price,
             "latest_purchase_date": ap1.latest_purchase_date,
             "construction": {
@@ -1363,7 +1363,7 @@ def test__api__apartment__update(api_client: HitasAPIClient, minimal_data: bool)
                 "catalog_share_of_housing_company_loans": None,
                 "catalog_acquisition_price": None,
                 "first_purchase_date": None,
-                "latest_sale_id": None,
+                "current_sale_id": None,
                 "latest_sale_purchase_price": None,
                 "latest_purchase_date": None,
                 "construction": {

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -379,6 +379,7 @@ class PricesSerializer(serializers.Serializer):
     catalog_share_of_housing_company_loans = serializers.SerializerMethodField()
     catalog_acquisition_price = serializers.SerializerMethodField()
     first_purchase_date = serializers.SerializerMethodField()
+    latest_sale_id = serializers.SerializerMethodField()
     latest_sale_purchase_price = serializers.SerializerMethodField()
     latest_purchase_date = serializers.SerializerMethodField()
     construction = ConstructionPrices(source="*", required=False, allow_null=True)
@@ -413,11 +414,18 @@ class PricesSerializer(serializers.Serializer):
         return instance.first_purchase_date
 
     @staticmethod
+    def get_latest_sale_id(instance: ApartmentWithAnnotations) -> Optional[str]:
+        # This id is from the latest sale, ALSO counting the first sale.
+        return instance.sales.first().uuid.hex if instance.sales.exists() else None
+
+    @staticmethod
     def get_latest_sale_purchase_price(instance: ApartmentWithAnnotations) -> Optional[Decimal]:
+        # This price is from the latest sale, NOT counting the first sale.
         return instance.latest_sale_purchase_price
 
     @staticmethod
     def get_latest_purchase_date(instance: ApartmentWithAnnotations) -> Optional[datetime.date]:
+        # This date is from the latest sale, NOT counting the first sale.
         return instance.latest_purchase_date
 
     def get_maximum_prices(self, instance: Apartment) -> Dict[str, Any]:

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -379,7 +379,7 @@ class PricesSerializer(serializers.Serializer):
     catalog_share_of_housing_company_loans = serializers.SerializerMethodField()
     catalog_acquisition_price = serializers.SerializerMethodField()
     first_purchase_date = serializers.SerializerMethodField()
-    latest_sale_id = serializers.SerializerMethodField()
+    current_sale_id = serializers.SerializerMethodField()
     latest_sale_purchase_price = serializers.SerializerMethodField()
     latest_purchase_date = serializers.SerializerMethodField()
     construction = ConstructionPrices(source="*", required=False, allow_null=True)
@@ -414,7 +414,7 @@ class PricesSerializer(serializers.Serializer):
         return instance.first_purchase_date
 
     @staticmethod
-    def get_latest_sale_id(instance: ApartmentWithAnnotations) -> Optional[str]:
+    def get_current_sale_id(instance: ApartmentWithAnnotations) -> Optional[str]:
         # This id is from the latest sale, ALSO counting the first sale.
         return instance.sales.first().uuid.hex if instance.sales.exists() else None
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -6890,20 +6890,25 @@ components:
           minimum: 0
           nullable: true
           example: 55430
+        latest_sale_id:
+          description: ID of the latest sale, ALSO counting first sale (used for cancelling sales)
+          type: string
+          nullable: true
+          example: a3181b8fa60b47df8ccba0d554a913bb
         latest_sale_purchase_price:
-          description: TBD
+          description: Purchase price from the latest sale, NOT counting first sale
           type: number
           minimum: 0
           nullable: true
           example: 51222
         first_purchase_date:
-          description: TBD
+          description: Date of the first purchase for this apartment
           type: string
           format: date
           nullable: true
           example: 1985-12-10
         latest_purchase_date:
-          description: TBD
+          description: Date of the latest purchase for this apartment, NOT counting first sale
           type: string
           format: date
           nullable: true

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -6890,7 +6890,7 @@ components:
           minimum: 0
           nullable: true
           example: 55430
-        latest_sale_id:
+        current_sale_id:
           description: ID of the latest sale, ALSO counting first sale (used for cancelling sales)
           type: string
           nullable: true

--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -581,6 +581,17 @@ const mutationApi = hitasApi.injectEndpoints({
                 {type: "HousingCompany", id: arg.housingCompanyId},
             ],
         }),
+        deleteSale: builder.mutation<unknown, {housingCompanyId: string; apartmentId: string; saleId: string}>({
+            query: ({housingCompanyId, apartmentId, saleId}) => ({
+                url: `housing-companies/${housingCompanyId}/apartments/${apartmentId}/sales/${saleId}`,
+                method: "DELETE",
+                headers: mutationApiJsonHeaders(),
+            }),
+            invalidatesTags: (result, error, arg) => [
+                {type: "Apartment"},
+                {type: "HousingCompany", id: arg.housingCompanyId},
+            ],
+        }),
         createConditionOfSale: builder.mutation<
             {conditions_of_sale: IConditionOfSale[]},
             {data: ICreateConditionOfSale}
@@ -713,6 +724,7 @@ export const {
     useSaveApartmentMaximumPriceMutation,
     useSaveIndexMutation,
     useCreateSaleMutation,
+    useDeleteSaleMutation,
     useCreateConditionOfSaleMutation,
     useUpdateConditionOfSaleMutation,
     useCreateThirtyYearRegulationMutation,

--- a/frontend/src/common/components/RemoveButton.tsx
+++ b/frontend/src/common/components/RemoveButton.tsx
@@ -3,10 +3,16 @@ import {Button, IconCrossCircleFill} from "hds-react";
 interface RemoveButtonProps {
     onClick: () => void;
     isLoading: boolean;
+    buttonText?: string;
     disabled?: boolean;
 }
 
-export default function RemoveButton({onClick, isLoading, disabled = false}: RemoveButtonProps): JSX.Element {
+export default function RemoveButton({
+    onClick,
+    isLoading,
+    disabled = false,
+    buttonText = "Poista",
+}: RemoveButtonProps): JSX.Element {
     return (
         <Button
             iconLeft={<IconCrossCircleFill />}
@@ -15,7 +21,7 @@ export default function RemoveButton({onClick, isLoading, disabled = false}: Rem
             isLoading={isLoading}
             disabled={disabled}
         >
-            Poista
+            {buttonText}
         </Button>
     );
 }

--- a/frontend/src/common/components/RemoveButton.tsx
+++ b/frontend/src/common/components/RemoveButton.tsx
@@ -5,6 +5,8 @@ interface RemoveButtonProps {
     isLoading: boolean;
     buttonText?: string;
     disabled?: boolean;
+    variant?: "primary" | "secondary" | "success" | "danger";
+    className?: string;
 }
 
 export default function RemoveButton({
@@ -12,6 +14,7 @@ export default function RemoveButton({
     isLoading,
     disabled = false,
     buttonText = "Poista",
+    ...rest
 }: RemoveButtonProps): JSX.Element {
     return (
         <Button
@@ -20,6 +23,7 @@ export default function RemoveButton({
             onClick={onClick}
             isLoading={isLoading}
             disabled={disabled}
+            {...rest}
         >
             {buttonText}
         </Button>

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -471,6 +471,7 @@ const ApartmentWritablePricesSchema = ApartmentPricesSchema.omit({
     first_sale_share_of_housing_company_loans: true,
     first_sale_acquisition_price: true,
     first_purchase_date: true,
+    latest_sale_id: true,
     latest_sale_purchase_price: true,
     latest_purchase_date: true,
     maximum_prices: true,

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -441,6 +441,7 @@ const ApartmentPricesSchema = object({
     first_sale_share_of_housing_company_loans: number().nullable(), // Read only
     first_sale_acquisition_price: number().optional(), // Read only. (purchase_price + share_of_housing_company_loans)
     first_purchase_date: string().nullable(), // Read only
+    latest_sale_id: string().nullable(), // Read only
     latest_sale_purchase_price: number().nullable(), // Read only
     latest_purchase_date: string().nullable(), // Read only
     catalog_purchase_price: number().nullable(), // Read only

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -441,7 +441,7 @@ const ApartmentPricesSchema = object({
     first_sale_share_of_housing_company_loans: number().nullable(), // Read only
     first_sale_acquisition_price: number().optional(), // Read only. (purchase_price + share_of_housing_company_loans)
     first_purchase_date: string().nullable(), // Read only
-    latest_sale_id: string().nullable(), // Read only
+    current_sale_id: string().nullable(), // Read only
     latest_sale_purchase_price: number().nullable(), // Read only
     latest_purchase_date: string().nullable(), // Read only
     catalog_purchase_price: number().nullable(), // Read only
@@ -471,7 +471,7 @@ const ApartmentWritablePricesSchema = ApartmentPricesSchema.omit({
     first_sale_share_of_housing_company_loans: true,
     first_sale_acquisition_price: true,
     first_purchase_date: true,
-    latest_sale_id: true,
+    current_sale_id: true,
     latest_sale_purchase_price: true,
     latest_purchase_date: true,
     maximum_prices: true,

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -574,6 +574,7 @@ const LoadedApartmentDetails = ({
                                             <RemoveButton
                                                 onClick={() => setIsRemoveSaleModalVisible(true)}
                                                 isLoading={false}
+                                                buttonText="Peru kauppa"
                                             />
                                             <Dialog
                                                 id="remove-sale-modal"
@@ -603,6 +604,7 @@ const LoadedApartmentDetails = ({
                                                     <RemoveButton
                                                         onClick={handleRemoveSaleButtonClick}
                                                         isLoading={false}
+                                                        buttonText="Peru kauppa"
                                                     />
                                                 </Dialog.ActionButtons>
                                             </Dialog>

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -594,7 +594,10 @@ const LoadedApartmentDetails = ({
                                                 buttonText="Peru kauppa"
                                                 variant="secondary"
                                                 className="delete-sale-button"
-                                                disabled={!apartment.prices.current_sale_id}
+                                                disabled={
+                                                    !apartment.prices.current_sale_id ||
+                                                    !apartment.prices.latest_purchase_date
+                                                }
                                             />
                                         </div>
                                         <Divider size="s" />

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -5,6 +5,7 @@ import {Link, useParams} from "react-router-dom";
 import {
     downloadApartmentMaximumPricePDF,
     downloadApartmentUnconfirmedMaximumPricePDF,
+    useDeleteSaleMutation,
     useGetApartmentDetailQuery,
     useGetHousingCompanyDetailQuery,
     useSavePropertyManagerMutation,
@@ -459,7 +460,21 @@ const LoadedApartmentDetails = ({
         setIsModifyOwnerModalVisible(true);
         setOwner(selectedOwner);
     };
+    const [removeSale, {isLoading}] = useDeleteSaleMutation();
     const handleRemoveSaleButtonClick = () => {
+        removeSale({
+            housingCompanyId: housingCompany.id,
+            apartmentId: apartment.id,
+            saleId: apartment.prices.latest_sale_id,
+        })
+            .then(() => {
+                hdsToast.success("Viimeisin kauppa peruttu onnistuneesti");
+            })
+            .catch((e) => {
+                hdsToast.error("Viimeisimmän kaupan peruminen epäonnistui");
+                // eslint-disable-next-line no-console
+                console.warn(e);
+            });
         setIsRemoveSaleModalVisible(false);
     };
 
@@ -573,7 +588,7 @@ const LoadedApartmentDetails = ({
                                             />
                                             <RemoveButton
                                                 onClick={() => setIsRemoveSaleModalVisible(true)}
-                                                isLoading={false}
+                                                isLoading={isLoading}
                                                 buttonText="Peru kauppa"
                                             />
                                             <Dialog
@@ -603,7 +618,7 @@ const LoadedApartmentDetails = ({
                                                     </Button>
                                                     <RemoveButton
                                                         onClick={handleRemoveSaleButtonClick}
-                                                        isLoading={false}
+                                                        isLoading={isLoading}
                                                         buttonText="Peru kauppa"
                                                     />
                                                 </Dialog.ActionButtons>

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -17,6 +17,7 @@ import {
     MutateModal,
     OwnerMutateForm,
     QueryStateHandler,
+    RemoveButton,
 } from "../../common/components";
 import {DateInput, TextAreaInput} from "../../common/components/form";
 import {
@@ -449,15 +450,18 @@ const LoadedApartmentDetails = ({
     apartment: IApartmentDetails;
     housingCompany: IHousingCompanyDetails;
 }): JSX.Element => {
-    // Handle visibility of the modify owner info modal
+    // Handle visibility of the relevant modals
     const [isModifyOwnerModalVisible, setIsModifyOwnerModalVisible] = useState(false);
+    const [isModifyPropertyManagerModalVisible, setIsModifyPropertyManagerModalVisible] = useState(false);
+    const [isRemoveSaleModalVisible, setIsRemoveSaleModalVisible] = useState(false);
     const [owner, setOwner] = useState<IOwner | undefined>(undefined);
     const modifyOwnerHandler = (selectedOwner: IOwner) => {
         setIsModifyOwnerModalVisible(true);
         setOwner(selectedOwner);
     };
-    // Handle visibility of the modify property manager info modal
-    const [isModifyPropertyManagerModalVisible, setIsModifyPropertyManagerModalVisible] = useState(false);
+    const handleRemoveSaleButtonClick = () => {
+        setIsRemoveSaleModalVisible(false);
+    };
 
     return (
         <>
@@ -493,7 +497,7 @@ const LoadedApartmentDetails = ({
                         </Tabs.TabList>
                         <Tabs.TabPanel>
                             <div className="apartment-details__tab basic-details">
-                                <div className="row">
+                                <div className="row top-row">
                                     <DetailField
                                         label="Viimeisin kauppahinta"
                                         value={formatMoney(apartment.prices.latest_sale_purchase_price)}
@@ -562,11 +566,47 @@ const LoadedApartmentDetails = ({
                                         </div>
                                     </div>
                                     <div className="column">
-                                        <DetailField
-                                            label="Viimeisin kauppapäivä"
-                                            value={formatDate(apartment.prices.latest_purchase_date)}
-                                        />
-
+                                        <div className="row">
+                                            <DetailField
+                                                label="Viimeisin kauppapäivä"
+                                                value={formatDate(apartment.prices.latest_purchase_date)}
+                                            />
+                                            <RemoveButton
+                                                onClick={() => setIsRemoveSaleModalVisible(true)}
+                                                isLoading={false}
+                                            />
+                                            <Dialog
+                                                id="remove-sale-modal"
+                                                aria-labelledby="remove-sale-modal"
+                                                isOpen={isRemoveSaleModalVisible}
+                                            >
+                                                <Dialog.Header
+                                                    title="Viimeisimmän kaupan peruminen"
+                                                    id="remove-sale-modal-header"
+                                                />
+                                                <Dialog.Content>
+                                                    <p>
+                                                        Haluatko varmasti perua viimeisimmän kaupan?
+                                                        <br />(
+                                                        {formatDate(apartment.prices.latest_purchase_date) + ", "}
+                                                        {formatMoney(apartment.prices.latest_sale_purchase_price)})
+                                                    </p>
+                                                </Dialog.Content>
+                                                <Dialog.ActionButtons>
+                                                    <Button
+                                                        theme="black"
+                                                        variant="secondary"
+                                                        onClick={() => setIsRemoveSaleModalVisible(false)}
+                                                    >
+                                                        Peruuta
+                                                    </Button>
+                                                    <RemoveButton
+                                                        onClick={handleRemoveSaleButtonClick}
+                                                        isLoading={false}
+                                                    />
+                                                </Dialog.ActionButtons>
+                                            </Dialog>
+                                        </div>
                                         <Divider size="s" />
 
                                         <DetailField

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -455,6 +455,7 @@ const LoadedApartmentDetails = ({
     const [isModifyOwnerModalVisible, setIsModifyOwnerModalVisible] = useState(false);
     const [isModifyPropertyManagerModalVisible, setIsModifyPropertyManagerModalVisible] = useState(false);
     const [isRemoveSaleModalVisible, setIsRemoveSaleModalVisible] = useState(false);
+
     const [owner, setOwner] = useState<IOwner | undefined>(undefined);
     const modifyOwnerHandler = (selectedOwner: IOwner) => {
         setIsModifyOwnerModalVisible(true);
@@ -465,8 +466,9 @@ const LoadedApartmentDetails = ({
         removeSale({
             housingCompanyId: housingCompany.id,
             apartmentId: apartment.id,
-            saleId: apartment.prices.latest_sale_id,
+            saleId: apartment.prices.latest_sale_id as string,
         })
+            .unwrap()
             .then(() => {
                 hdsToast.success("Viimeisin kauppa peruttu onnistuneesti");
             })
@@ -590,39 +592,10 @@ const LoadedApartmentDetails = ({
                                                 onClick={() => setIsRemoveSaleModalVisible(true)}
                                                 isLoading={isLoading}
                                                 buttonText="Peru kauppa"
+                                                variant="secondary"
+                                                className="delete-sale-button"
+                                                disabled={!apartment.prices.latest_sale_id}
                                             />
-                                            <Dialog
-                                                id="remove-sale-modal"
-                                                aria-labelledby="remove-sale-modal"
-                                                isOpen={isRemoveSaleModalVisible}
-                                            >
-                                                <Dialog.Header
-                                                    title="Viimeisimmän kaupan peruminen"
-                                                    id="remove-sale-modal-header"
-                                                />
-                                                <Dialog.Content>
-                                                    <p>
-                                                        Haluatko varmasti perua viimeisimmän kaupan?
-                                                        <br />(
-                                                        {formatDate(apartment.prices.latest_purchase_date) + ", "}
-                                                        {formatMoney(apartment.prices.latest_sale_purchase_price)})
-                                                    </p>
-                                                </Dialog.Content>
-                                                <Dialog.ActionButtons>
-                                                    <Button
-                                                        theme="black"
-                                                        variant="secondary"
-                                                        onClick={() => setIsRemoveSaleModalVisible(false)}
-                                                    >
-                                                        Peruuta
-                                                    </Button>
-                                                    <RemoveButton
-                                                        onClick={handleRemoveSaleButtonClick}
-                                                        isLoading={isLoading}
-                                                        buttonText="Peru kauppa"
-                                                    />
-                                                </Dialog.ActionButtons>
-                                            </Dialog>
                                         </div>
                                         <Divider size="s" />
 
@@ -743,6 +716,40 @@ const LoadedApartmentDetails = ({
                     editPath={`/housing-companies/${housingCompany.id}/improvements`}
                 />
             </div>
+            <Dialog
+                id="remove-sale-modal"
+                aria-labelledby="remove-sale-modal"
+                isOpen={isRemoveSaleModalVisible}
+            >
+                <Dialog.Header
+                    title="Viimeisimmän kaupan peruminen"
+                    id="remove-sale-modal-header"
+                />
+                <Dialog.Content>
+                    <p>
+                        Haluatko varmasti perua viimeisimmän kaupan?
+                        <br />({formatDate(apartment.prices.latest_purchase_date) + ", "}
+                        {formatMoney(
+                            apartment.prices.latest_sale_purchase_price ?? apartment.prices.first_sale_purchase_price
+                        )}
+                        )
+                    </p>
+                </Dialog.Content>
+                <Dialog.ActionButtons>
+                    <Button
+                        theme="black"
+                        variant="secondary"
+                        onClick={() => setIsRemoveSaleModalVisible(false)}
+                    >
+                        Peruuta
+                    </Button>
+                    <RemoveButton
+                        onClick={handleRemoveSaleButtonClick}
+                        isLoading={isLoading}
+                        buttonText="Vahvista kaupan peruminen"
+                    />
+                </Dialog.ActionButtons>
+            </Dialog>
         </>
     );
 };

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -466,7 +466,7 @@ const LoadedApartmentDetails = ({
         removeSale({
             housingCompanyId: housingCompany.id,
             apartmentId: apartment.id,
-            saleId: apartment.prices.latest_sale_id as string,
+            saleId: apartment.prices.current_sale_id as string,
         })
             .unwrap()
             .then(() => {
@@ -594,7 +594,7 @@ const LoadedApartmentDetails = ({
                                                 buttonText="Peru kauppa"
                                                 variant="secondary"
                                                 className="delete-sale-button"
-                                                disabled={!apartment.prices.latest_sale_id}
+                                                disabled={!apartment.prices.current_sale_id}
                                             />
                                         </div>
                                         <Divider size="s" />

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -218,6 +218,15 @@
 
     .row
       @include justify-content(space-between)
+      .delete-sale-button
+        opacity: 0.6
+        &:not(:disabled):hover
+          opacity: 1
+
+  .delete-sale-button
+    border-color: $color-black-70
+    &:hover
+      border-color: $color-black
 
   [class^="Tabs-module_tablistBar"]
     background: white

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -204,7 +204,7 @@
           cursor: pointer
           color: $color-black-70
 
-    .row
+    .top-row
       @include justify-content(space-between)
 
       .detail-field-horizontal
@@ -215,6 +215,9 @@
 
       .detail-field-value
         font-size: $fontsize-heading-m
+
+    .row
+      @include justify-content(space-between)
 
   [class^="Tabs-module_tablistBar"]
     background: white


### PR DESCRIPTION
# Hitas Pull Request

# Description

Adds a "remove last sale" button to the apartment details page, next to the price of the last sale. It should prompt for a confirmation before deleting.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [X] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [X] OpenAPI definitions have been updated
  - [X] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Go to an apartment and make a sale for it, the specs don't matter. Then delete that sale from the apartment details view. The details should update accordingly, and a success toast is shown.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-605