### PR TITLE
Frontend: Extend grace period -feature in conditions of sale view

### DIFF
--- a/frontend/src/app/services.ts
+++ b/frontend/src/app/services.ts
@@ -199,6 +199,7 @@ export const hitasApi = createApi({
     }),
     tagTypes: [
         "HousingCompany",
+        "ConditionOfSale",
         "Apartment",
         "Index",
         "Owner",
@@ -325,6 +326,12 @@ const detailApi = hitasApi.injectEndpoints({
                 url: `housing-companies/${params.housingCompanyId}/apartments/${params.apartmentId}`,
             }),
             providesTags: (result, error, arg) => [{type: "Apartment", id: arg.apartmentId}, {type: "Owner"}],
+        }),
+        getConditionOfSale: builder.query<IConditionOfSale, string>({
+            query: (id) => ({
+                url: `conditions-of-sale/${id}`,
+            }),
+            providesTags: (result, error, arg) => [{type: "ConditionOfSale", id: arg}],
         }),
         getApartmentMaximumPrice: builder.query<IApartmentMaximumPrice, object>({
             query: ({
@@ -587,6 +594,16 @@ const mutationApi = hitasApi.injectEndpoints({
             invalidatesTags: (result, error) =>
                 !error && result && result.conditions_of_sale.length ? [{type: "Apartment"}] : [],
         }),
+        updateConditionOfSale: builder.mutation<IConditionOfSale, IConditionOfSale>({
+            query: (conditionOfSale) => ({
+                url: `conditions-of-sale${idOrBlank(conditionOfSale.id)}`,
+                method: "PUT",
+                body: conditionOfSale,
+                headers: mutationApiJsonHeaders(),
+            }),
+            invalidatesTags: (result, error, arg) =>
+                !error && result ? [{type: "Apartment"}, {type: "ConditionOfSale", id: arg.id}] : [],
+        }),
         createThirtyYearRegulation: builder.mutation<IThirtyYearRegulationResponse, {data: IThirtyYearRegulationQuery}>(
             {
                 query: ({data}) => ({
@@ -672,6 +689,7 @@ export const {
 
 export const {
     useGetHousingCompanyDetailQuery,
+    useLazyGetConditionOfSaleQuery,
     useGetApartmentDetailQuery,
     useGetApartmentMaximumPriceQuery,
     useGetExternalSalesDataQuery,
@@ -696,6 +714,7 @@ export const {
     useSaveIndexMutation,
     useCreateSaleMutation,
     useCreateConditionOfSaleMutation,
+    useUpdateConditionOfSaleMutation,
     useCreateThirtyYearRegulationMutation,
     useSaveExternalSalesDataMutation,
     useValidateSalesCatalogMutation,

--- a/frontend/src/common/components/OwnerMutateForm.tsx
+++ b/frontend/src/common/components/OwnerMutateForm.tsx
@@ -21,9 +21,9 @@ export default function OwnerMutateForm({
 }: IOwnerMutateForm) {
     const [isInitialIdentifierValid, setIsInitialIdentifierValid] = useState<boolean>(false);
     const [saveOwner, {isLoading: isSaveOwnerLoading}] = useSaveOwnerMutation();
-    const runSaveOwner = (data) => {
+    const runSaveOwner = (data: IOwner) => {
         // submit the form values
-        saveOwner({data: data})
+        saveOwner({data})
             .unwrap()
             .then(() => {
                 hdsToast.success("Omistajan tiedot tallennettu onnistuneesti!");

--- a/frontend/src/common/schemas.ts
+++ b/frontend/src/common/schemas.ts
@@ -397,7 +397,7 @@ const ApartmentConditionOfSaleSchema = object({
 });
 
 const ConditionOfSaleSchema = object({
-    id: string(),
+    id: string().optional(),
     new_ownership: ownershipSchema.and(
         object({
             apartment: object({
@@ -417,7 +417,7 @@ const ConditionOfSaleSchema = object({
         })
     ),
     grace_period: z.enum(["not_given", "three_months", "six_months"]),
-    fulfilled: string().nullable(),
+    fulfilled: string().nullable().optional(),
 });
 const ApartmentUnconfirmedMaximumPriceSchema = object({maximum: boolean(), value: number()});
 

--- a/frontend/src/styles/components/_CreatePage.sass
+++ b/frontend/src/styles/components/_CreatePage.sass
@@ -200,7 +200,7 @@
   .conditions-of-sale-headers
     position: relative
     display: grid
-    grid-template-columns: auto 500px 150px 100px
+    grid-template-columns: auto 500px 150px 150px 100px
     gap: $spacing-layout-2-xs
     grid-row: 1
     height: $spacing-layout-s
@@ -220,12 +220,23 @@
     &-item
       background: white
       display: grid
-      grid-template-columns: auto 500px 150px 100px
+      grid-template-columns: auto 500px 150px 150px 100px
       gap: 1em
       height: $spacing-layout-m
       @include align-items(center)
       .grace-period
         padding-left: 18px
+        .text-button
+          margin-left: $spacing-m
+          &:hover
+            cursor: pointer
+          .icon
+            width: $spacing-m
+            height: $spacing-m
+            &:hover
+              width: $spacing-l
+              height: $spacing-l
+
       .fulfillment-date
         align-items: center
         margin: 0 auto

--- a/frontend/src/styles/components/_DialogModule.sass
+++ b/frontend/src/styles/components/_DialogModule.sass
@@ -11,6 +11,11 @@
     margin-bottom: 0
     color: $color-error
 
+  ul.info-text
+    margin-left: $spacing-xs
+    .title
+      font-weight: bold
+
 .input-field--related-model--modal--content
   display: flex
   flex-flow: column nowrap


### PR DESCRIPTION
# Hitas Pull Request

# Description

Admit or extend grace period of sell by date -feature in conditions of sale view. 
Adds extend grace period button in the conditions of sale list for each owner whose sell by date can be delayed.
Hovering the button changes the column title and clicking it opens a confirmation modal to extend the grace period.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Open the conditions of sale view in apartment details page for an apartment that has conditions of sale data.
- Ensure the extend grace period button appears for every owner who has been admitted less than 6 months grace period
- Ensure hovering the button changes the column title
- Ensure the data changes correspondingly after you have clicked the button and confirmed the extension on the confirmation modal

## Tickets

This pull request resolves all or part of the following ticket(s): HT-350
