### PR TITLE
Calculate deprecation multiplier to calculation date not month

### DIFF
--- a/backend/hitas/services/email.py
+++ b/backend/hitas/services/email.py
@@ -96,7 +96,6 @@ def get_apartment_for_unconfirmed_max_price_calculation(
     apartment_id: UUID,
     calculation_date: datetime.date,
 ) -> ApartmentWithAnnotations:
-    calculation_month = monthify(calculation_date)
     completion_date: Optional[datetime.date] = (
         Apartment.objects.filter(uuid=apartment_id).values_list("completion_date", flat=True).first()
     )
@@ -135,25 +134,25 @@ def get_apartment_for_unconfirmed_max_price_calculation(
             cpi=subquery_apartment_first_sale_acquisition_price_index_adjusted(
                 ConstructionPriceIndex,
                 completion_date=completion_date,
-                calculation_month=calculation_month,
+                calculation_date=calculation_date,
             ),
             mpi=subquery_apartment_first_sale_acquisition_price_index_adjusted(
                 MarketPriceIndex,
                 completion_date=completion_date,
-                calculation_month=calculation_month,
+                calculation_date=calculation_date,
             ),
             cpi_2005_100=subquery_apartment_first_sale_acquisition_price_index_adjusted(
                 ConstructionPriceIndex2005Equal100,
                 completion_date=completion_date,
-                calculation_month=calculation_month,
+                calculation_date=calculation_date,
             ),
             mpi_2005_100=subquery_apartment_first_sale_acquisition_price_index_adjusted(
                 MarketPriceIndex2005Equal100,
                 completion_date=completion_date,
-                calculation_month=calculation_month,
+                calculation_date=calculation_date,
             ),
             sapc=subquery_apartment_current_surface_area_price(
-                calculation_month=calculation_month,
+                calculation_date=calculation_date,
             ),
         )
         .first()

--- a/backend/hitas/services/indices.py
+++ b/backend/hitas/services/indices.py
@@ -285,9 +285,9 @@ def build_surface_area_price_ceiling_report_excel(results: SurfaceAreaPriceCeili
 
 
 def subquery_apartment_current_surface_area_price(
-    calculation_month: Optional[datetime.date] = None,
+    calculation_date: Optional[datetime.date] = None,
 ) -> RoundWithPrecision:
-    calculation_month = monthify(timezone.now().date()) if calculation_month is None else calculation_month
+    calculation_month = monthify(timezone.now().date()) if calculation_date is None else monthify(calculation_date)
 
     current_value = Subquery(
         SurfaceAreaPriceCeiling.objects.filter(month=calculation_month).values("value"),
@@ -308,9 +308,10 @@ def subquery_apartment_first_sale_acquisition_price_index_adjusted(
         type[ConstructionPriceIndex2005Equal100],
     ],
     completion_date: Optional[datetime.date] = None,
-    calculation_month: Optional[datetime.date] = None,
+    calculation_date: Optional[datetime.date] = None,
 ) -> RoundWithPrecision:
-    calculation_month = monthify(timezone.now().date()) if calculation_month is None else calculation_month
+    calculation_date = timezone.now().date() if calculation_date is None else calculation_date
+    calculation_month = monthify(calculation_date)
 
     original_value = Subquery(
         table.objects.filter(month=OuterRef("completion_month")).values("value"),
@@ -341,7 +342,7 @@ def subquery_apartment_first_sale_acquisition_price_index_adjusted(
         # and index price will be null, so we can skip this calculation freely
         if completion_date is not None:
             depreciation = Value(
-                depreciation_multiplier(months_between_dates(completion_date, calculation_month)),
+                depreciation_multiplier(months_between_dates(completion_date, calculation_date)),
                 output_field=HitasModelDecimalField(),
             )
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

Fixed deprecation multiplier calculation for price estimates (use completion date instead of completion month).

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [ ] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- [x] Automated tests

## Tickets

This pull request resolves all or part of the following ticket(s): -
