### PR TITLE
Frontend: Changes text in confirmation modal for extending grace period

### DIFF
--- a/frontend/src/features/apartment/ApartmentConditionsOfSalePage.tsx
+++ b/frontend/src/features/apartment/ApartmentConditionsOfSalePage.tsx
@@ -271,13 +271,13 @@ const ExtendGracePeriodModal = ({
                             </li>
                         </ul>
                         {apartmentConditionOfSale.grace_period === "not_given" && (
-                            <p>Lisäaikaa ei ole vielä myönnetty. Myönnetäänkö 3kk lisäaikaa asunnon myyntiehtoon? </p>
+                            <p>Lisäaikaa ei ole vielä myönnetty. Myönnetäänkö 3kk lisäaikaa asunnon myymiseen? </p>
                         )}
                         {apartmentConditionOfSale.grace_period === "three_months" && (
-                            <p>Lisäaikaa on jo myönnetty 3kk. Myönnetäänkö 3kk lisää aikaa asunnon myyntiehtoon?</p>
+                            <p>Lisäaikaa on jo myönnetty 3kk. Myönnetäänkö vielä 3kk lisäaikaa asunnon myymiseen?</p>
                         )}
                         {apartmentConditionOfSale.grace_period === "six_months" && (
-                            <p>Lisäaikaa asunnon myyntiehtoon on jo myönnetty 6kk, enempää ei voi myöntää.</p>
+                            <p>Lisäaikaa asunnon myymiseen on jo myönnetty 6kk, enempää ei voi myöntää.</p>
                         )}
                     </div>
                 </Dialog.Content>


### PR DESCRIPTION
# Hitas Pull Request

# Description

Frontend: Changes text in the confirmation modal for extending grace period

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Open the conditions of sale view in apartment details page for an apartment that has conditions of sale data where the grace period for sale has not been extended to 6 months yet. Extend grace period and ensure the word "myyntiehtoon" has been changed to "myymiseen" in the text in the confirmation modal. 

## Tickets

This pull request resolves all or part of the following ticket(s): HT-350
