### PR TITLE
Fix the condition of sale removal

### DIFF
--- a/frontend/src/features/apartment/ApartmentConditionsOfSalePage.tsx
+++ b/frontend/src/features/apartment/ApartmentConditionsOfSalePage.tsx
@@ -425,7 +425,7 @@ const ConditionsOfSaleList = ({apartment}: {apartment: IApartmentDetails}) => {
                             </div>
                             <div className="input-wrap sell-by-date">{formatDate(cos.sell_by_date)} </div>
                             <div className="input-wrap fulfillment-date">{formatDate(cos.fulfilled)} </div>
-                            {apartment.ownerships.find((ownership) => ownership.owner.id === cos.owner.id) &&
+                            {!apartment.ownerships.find((ownership) => ownership.owner.id === cos.owner.id) &&
                                 !cos.fulfilled && ( // CoS removable only if current owner and not already fulfilled
                                     <RemoveButton
                                         onClick={() => {
@@ -434,6 +434,7 @@ const ConditionsOfSaleList = ({apartment}: {apartment: IApartmentDetails}) => {
                                         }}
                                         isLoading={false}
                                         size="small"
+                                        buttonText="Poista"
                                     />
                                 )}
                         </li>


### PR DESCRIPTION
# Hitas Pull Request

# Description

The remove button is now shown only where the person is not found among the owners of the apartment, as it should.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [X] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

Create a condition of sale manually, and it should now be removable (and it the removal should of course work, too).

## Tickets

This pull request resolves all or part of the following ticket(s): HT-578