### PR TITLE
backend: Fix depreciation multiplier for apartment maximum price tests

### DIFF
--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -981,7 +981,8 @@ def test__api__apartment__retrieve__pre_2011__indices_set(api_client: HitasAPICl
 
 
 @pytest.mark.django_db
-def test__api__apartment__retrieve__pre_2011__old_hitas_ruleset(api_client: HitasAPIClient):
+def test__api__apartment__retrieve__pre_2011__old_hitas_ruleset(api_client: HitasAPIClient, freezer):
+    freezer.move_to("2023-06-01 00:00:00+00:00")  # Required for depreciation multiplier calculation
     _test_max_prices(
         api_client,
         completion_date=PRE_2011_DATE,
@@ -1022,7 +1023,8 @@ def test__api__apartment__retrieve__pre_2011__indices_missing(api_client: HitasA
 
 
 @pytest.mark.django_db
-def test__api__apartment__retrieve__pre_2005__old_hitas_ruleset(api_client: HitasAPIClient):
+def test__api__apartment__retrieve__pre_2005__old_hitas_ruleset(api_client: HitasAPIClient, freezer):
+    freezer.move_to("2023-06-01 00:00:00+00:00")  # Required for depreciation multiplier calculation
     _test_max_prices(
         api_client,
         completion_date=PRE_2005_DATE,


### PR DESCRIPTION
# Hitas Pull Request

# Description

Fixes tests failing on any other month than 2023-06 due to changing depreciation multiplier value and hardcoded calculation results

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [ ] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- Automatic tests

## Tickets

This pull request resolves all or part of the following ticket(s): -