### PR TITLE
Fix unconfirmed prices date

### DIFF
--- a/backend/hitas/calculations/max_prices/max_price.py
+++ b/backend/hitas/calculations/max_prices/max_price.py
@@ -128,10 +128,10 @@ def validate_apartment_for_max_price_calculation(apartment: ApartmentWithAnnotat
             error_code="missing_completion_date",
             message="Cannot create max price calculation for an apartment without completion date.",
         )
-    elif apartment.completion_date > timezone.now().date():
+    elif apartment.housing_company.completion_date > timezone.now().date():
         raise InvalidCalculationResultException(
             error_code="completion_date_in_future",
-            message="Cannot create max price calculation for an apartment that has not been completed yet.",
+            message="Cannot create max price calculation for a housing company with completion date in the future.",
         )
 
     if apartment.housing_company.release_date:

--- a/backend/hitas/calculations/max_prices/max_price.py
+++ b/backend/hitas/calculations/max_prices/max_price.py
@@ -45,6 +45,13 @@ def create_max_price_calculation(
     additional_info: Optional[str],
 ) -> Dict[str, Any]:
     housing_company_completion_date = get_housing_company_completion_date(housing_company_uuid)
+
+    if housing_company_completion_date is None:
+        raise InvalidCalculationResultException(
+            error_code="missing_housing_company_completion_date",
+            message="Cannot create max price calculation for a housing company without completion date.",
+        )
+
     apartment = fetch_apartment(
         housing_company_uuid=housing_company_uuid,
         apartment_uuid=apartment_uuid,
@@ -85,7 +92,7 @@ def create_max_price_calculation(
     return calculation
 
 
-def get_housing_company_completion_date(housing_company_uuid: uuid.UUID) -> datetime.date:
+def get_housing_company_completion_date(housing_company_uuid: uuid.UUID) -> Optional[datetime.date]:
     completion_date: Optional[datetime.date] = (
         HousingCompany.objects.filter(uuid=housing_company_uuid)
         .annotate(
@@ -94,11 +101,6 @@ def get_housing_company_completion_date(housing_company_uuid: uuid.UUID) -> date
         .values_list("completion_date", flat=True)
         .first()
     )
-    if completion_date is None:
-        raise InvalidCalculationResultException(
-            error_code="missing_housing_company_completion_date",
-            message="Cannot create max price calculation for a housing company without completion date.",
-        )
 
     return completion_date
 

--- a/backend/hitas/services/email.py
+++ b/backend/hitas/services/email.py
@@ -93,7 +93,7 @@ def get_apartment_for_unconfirmed_max_price_calculation(
     calculation_date: datetime.date,
 ) -> ApartmentWithAnnotations:
     completion_date: Optional[datetime.date] = (
-        Apartment.objects.filter(uuid=apartment_id).values_list("completion_date", flat=True).first()
+        Apartment.objects.filter(uuid=apartment_id).first().housing_company.completion_date
     )
 
     qs = (

--- a/backend/hitas/services/email.py
+++ b/backend/hitas/services/email.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.mail import EmailMessage
 from django.db.models import Prefetch
-from django.db.models.functions import TruncMonth
 from django.utils import timezone
 
 from hitas.exceptions import HitasModelNotFound, get_hitas_object_or_404
@@ -130,7 +129,6 @@ def get_apartment_for_unconfirmed_max_price_calculation(
             _first_sale_share_of_housing_company_loans=get_first_sale_loan_amount("id"),
             _latest_sale_purchase_price=get_latest_sale_purchase_price("id"),
             _latest_purchase_date=get_latest_sale_purchase_date("id"),
-            completion_month=TruncMonth("completion_date"),  # Used for calculating indexes
             cpi=subquery_apartment_first_sale_acquisition_price_index_adjusted(
                 ConstructionPriceIndex,
                 completion_date=completion_date,

--- a/backend/hitas/services/indices.py
+++ b/backend/hitas/services/indices.py
@@ -318,11 +318,13 @@ def subquery_apartment_first_sale_acquisition_price_index_adjusted(
     if completion_date is None:
         return RoundWithPrecision(None, output_field=HitasModelDecimalField())
 
+    completion_month = monthify(completion_date)
+
     calculation_date = timezone.now().date() if calculation_date is None else calculation_date
     calculation_month = monthify(calculation_date)
 
     original_value = Subquery(
-        table.objects.filter(month=OuterRef("completion_month")).values("value"),
+        table.objects.filter(month=completion_month).values("value"),
         output_field=HitasModelDecimalField(),
     )
 

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -21,6 +21,7 @@ from rest_framework.fields import empty
 from rest_framework.response import Response
 
 from hitas.calculations.exceptions import IndexMissingException
+from hitas.calculations.max_prices.max_price import get_housing_company_completion_date
 from hitas.exceptions import HitasModelNotFound, ModelConflict
 from hitas.models import (
     Apartment,
@@ -822,11 +823,11 @@ class ApartmentViewSet(HitasModelViewSet):
         return self.get_base_queryset().filter(building__real_estate__housing_company__id=hc_id)
 
     def get_detail_queryset(self):
+        completion_date: Optional[datetime.date] = get_housing_company_completion_date(
+            self.kwargs["housing_company_uuid"]
+        )
         calculation_date: datetime.date = from_iso_format_or_today_if_none(
             self.request.query_params.get("calculation_date") or self.request.data.get("calculation_date")
-        )
-        completion_date: Optional[datetime.date] = (
-            Apartment.objects.filter(uuid=self.kwargs["uuid"]).values_list("completion_date", flat=True).first()
         )
 
         qs = self.get_list_queryset().annotate(

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -80,7 +80,7 @@ const ApartmentSalesPageLinkButton = ({
             <Button
                 theme="black"
                 iconLeft={<IconGlyphEuro />}
-                onClick={() => hdsToast.error("Valmistumatonta asuntoa ei voida jälleenmyydä.")}
+                onClick={() => hdsToast.error("Valmistumattoman taloyhtiön asuntoa ei voida jälleenmyydä.")}
                 disabled={housingCompany.regulation_status !== "regulated"}
             >
                 Kauppatapahtuma

--- a/frontend/src/features/apartment/ApartmentDetailsPage.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage.tsx
@@ -67,6 +67,40 @@ const SingleApartmentConditionOfSale = ({conditionsOfSale}: {conditionsOfSale: I
     );
 };
 
+const ApartmentSalesPageLinkButton = ({
+    housingCompany,
+    apartment,
+}: {
+    housingCompany: IHousingCompanyDetails;
+    apartment: IApartmentDetails;
+}) => {
+    // If apartment has been sold for the first time, and it's company not fully completed, it can not be re-sold
+    if (!housingCompany.date && apartment.prices.first_purchase_date) {
+        return (
+            <Button
+                theme="black"
+                iconLeft={<IconGlyphEuro />}
+                onClick={() => hdsToast.error("Valmistumatonta asuntoa ei voida jälleenmyydä.")}
+                disabled={housingCompany.regulation_status !== "regulated"}
+            >
+                Kauppatapahtuma
+            </Button>
+        );
+    } else {
+        return (
+            <Link to="sales">
+                <Button
+                    theme="black"
+                    iconLeft={<IconGlyphEuro />}
+                    disabled={housingCompany.regulation_status !== "regulated" || !apartment.surface_area}
+                >
+                    Kauppatapahtuma
+                </Button>
+            </Link>
+        );
+    }
+};
+
 const ApartmentConditionsOfSaleCard = ({
     apartment,
     housingCompany,
@@ -97,38 +131,13 @@ const ApartmentConditionsOfSaleCard = ({
         return groupedConditionsOfSale[a].length - groupedConditionsOfSale[b].length;
     });
 
-    const ApartmentSalesPageLinkButton = () => {
-        // If apartment has been sold for the first time, and it's company not fully completed, it can not be re-sold
-        if (!housingCompany.date && apartment.prices.first_purchase_date) {
-            return (
-                <Button
-                    theme="black"
-                    iconLeft={<IconGlyphEuro />}
-                    onClick={() => hdsToast.error("Valmistumatonta asuntoa ei voida jälleenmyydä.")}
-                    disabled={housingCompany.regulation_status !== "regulated"}
-                >
-                    Kauppatapahtuma
-                </Button>
-            );
-        } else {
-            return (
-                <Link to="sales">
-                    <Button
-                        theme="black"
-                        iconLeft={<IconGlyphEuro />}
-                        disabled={housingCompany.regulation_status !== "regulated" || !apartment.surface_area}
-                    >
-                        Kauppatapahtuma
-                    </Button>
-                </Link>
-            );
-        }
-    };
-
     return (
         <Card>
             <div className="row row--buttons">
-                <ApartmentSalesPageLinkButton />
+                <ApartmentSalesPageLinkButton
+                    housingCompany={housingCompany}
+                    apartment={apartment}
+                />
                 <Link to="conditions-of-sale">
                     <Button
                         theme="black"


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Before unconfirmed prices were using the apartment completion date, now it correctly uses the housing company completion date.
- Optimise the calculation a bit by removing unnecessary steps

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan



## Tickets

This pull request resolves all or part of the following ticket(s): HT-
