### PR TITLE
Maximum price calculations rework

### DIFF
--- a/backend/hitas/calculations/max_prices/rules_pre_2011.py
+++ b/backend/hitas/calculations/max_prices/rules_pre_2011.py
@@ -51,7 +51,7 @@ class RulesPre2011(CalculatorRules):
         apartment_improvements: Iterable[ApartmentConstructionPriceImprovementWithIndex],
         housing_company_improvements: Iterable[HousingCompanyConstructionPriceImprovementWithIndex],
         calculation_date: datetime.date,
-        housing_company_completion_date: datetime.date,
+        housing_company_completion_date: datetime.date,  # unused in old-hitas rules
     ) -> IndexCalculation:
         if not apartment.realized_housing_company_acquisition_price:
             raise InvalidCalculationResultException(
@@ -165,7 +165,7 @@ class RulesPre2011(CalculatorRules):
                 debt_free_price_m2=debt_free_shares_price / apartment.surface_area,
                 apartment_share_of_housing_company_loans=apartment_share_of_housing_company_loans,
                 apartment_share_of_housing_company_loans_date=apartment_share_of_housing_company_loans_date,
-                completion_date=housing_company_completion_date,
+                completion_date=apartment.completion_date,
                 completion_date_index=apartment.completion_date_cpi,
                 calculation_date=calculation_date,
                 calculation_date_index=apartment.calculation_date_cpi,
@@ -181,7 +181,7 @@ class RulesPre2011(CalculatorRules):
         apartment_improvements: Iterable[ApartmentMarketPriceImprovementWithIndex],
         housing_company_improvements: Iterable[HousingCompanyMarketPriceImprovementWithIndex],
         calculation_date: datetime.date,
-        housing_company_completion_date: datetime.date,
+        housing_company_completion_date: datetime.date,  # unused in old-hitas rules
     ) -> IndexCalculation:
         # Start calculations
 
@@ -267,7 +267,7 @@ class RulesPre2011(CalculatorRules):
                 debt_free_price_m2=debt_free_shares_price / apartment.surface_area,
                 apartment_share_of_housing_company_loans=apartment_share_of_housing_company_loans,
                 apartment_share_of_housing_company_loans_date=apartment_share_of_housing_company_loans_date,
-                completion_date=housing_company_completion_date,
+                completion_date=apartment.completion_date,
                 completion_date_index=apartment.completion_date_mpi,
                 calculation_date=calculation_date,
                 calculation_date_index=apartment.calculation_date_mpi,

--- a/backend/hitas/services/email.py
+++ b/backend/hitas/services/email.py
@@ -132,6 +132,7 @@ def get_apartment_for_unconfirmed_max_price_calculation(
         )
     )
     qs = annotate_apartment_unconfirmed_prices(
+        apartment_uuid=apartment_id,
         queryset=qs,
         housing_company=housing_company,
         calculation_date=calculation_date,

--- a/backend/hitas/services/indices.py
+++ b/backend/hitas/services/indices.py
@@ -315,17 +315,17 @@ def subquery_apartment_first_sale_acquisition_price_index_adjusted(
     """
     If 'completion_date' is missing, calculating index for that month will fail
     and index price will be null, so we can skip this calculation freely
+
+    Requires `completion_month` to be annotated to the queryset
     """
     if completion_date is None:
         return RoundWithPrecision(None, output_field=HitasModelDecimalField())
-
-    completion_month = monthify(completion_date)
 
     calculation_date = timezone.now().date() if calculation_date is None else calculation_date
     calculation_month = monthify(calculation_date)
 
     original_value = Subquery(
-        table.objects.filter(month=completion_month).values("value"),
+        table.objects.filter(month=OuterRef("completion_month")).values("value"),
         output_field=HitasModelDecimalField(),
     )
     current_value = Subquery(

--- a/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
@@ -494,9 +494,11 @@ def test__api__apartment_max_price__market_price_index__pre_2011(api_client: Hit
         sales=[],
         building__real_estate__housing_company__hitas_type=HitasType.HITAS_I,
     )
-    # Create another apartment with rest of the surface area
+    # Create another apartment with a later completion date and rest of the surface area.
+    # As Old-Hitas rules use the apartment completion date for the maximum price calculation,
+    # this apartment should not affect the calculation.
     ApartmentFactory.create(
-        completion_date=datetime.date(2003, 5, 9),
+        completion_date=datetime.date(2003, 6, 9),
         building__real_estate__housing_company=a.housing_company,
         surface_area=3336,
         share_number_start=3,
@@ -627,7 +629,7 @@ def test__api__apartment_max_price__market_price_index__pre_2011(api_client: Hit
             "debt_free_price_m2": 3326.51,
             "apartment_share_of_housing_company_loans": 0,
             "apartment_share_of_housing_company_loans_date": "2022-09-05",
-            "completion_date": "2003-05-09",
+            "completion_date": str(a.completion_date),
             "completion_date_index": 244.9,
             "calculation_date": "2022-09-07",
             "calculation_date_index": 364.4,
@@ -743,7 +745,7 @@ def test__api__apartment_max_price__market_price_index__pre_2011(api_client: Hit
             "debt_free_price_m2": 5759.04,
             "apartment_share_of_housing_company_loans": 0,
             "apartment_share_of_housing_company_loans_date": "2022-09-05",
-            "completion_date": "2003-05-09",
+            "completion_date": str(a.completion_date),
             "completion_date_index": 263.6,
             "calculation_date": "2022-09-07",
             "calculation_date_index": 583.3,
@@ -797,9 +799,8 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
         sales__apartment_share_of_housing_company_loans=0.5,
     )
     # Create another apartment with a later completion date and rest of the acquisition price.
-    # Now the completion date used in the calculation should be this apartments completion date, since
-    # it becomes the latest apartment in the housing company, and thus its completion date is used for the
-    # housing company's completion date.
+    # As Old-Hitas rules use the apartment completion date for the maximum price calculation,
+    # this apartment should not affect the calculation.
     ApartmentFactory.create(
         building__real_estate__housing_company=a.housing_company,
         completion_date=datetime.date(2012, 7, 28),
@@ -829,8 +830,8 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
     o1: Ownership = OwnershipFactory.create(percentage=100.0, sale=sale)
 
     # Create necessary housing company's completion date indices
-    ConstructionPriceIndexFactory.create(month=datetime.date(2012, 7, 1), value=296.10)
-    MarketPriceIndexFactory.create(month=datetime.date(2012, 7, 1), value=263.60)
+    ConstructionPriceIndexFactory.create(month=datetime.date(2012, 6, 1), value=296.10)
+    MarketPriceIndexFactory.create(month=datetime.date(2012, 6, 1), value=263.60)
 
     # Create necessary calculation date indices
     ConstructionPriceIndexFactory.create(month=datetime.date(2022, 11, 1), value=364.60)
@@ -950,7 +951,7 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
             "debt_free_price_m2": 5228.62,
             "apartment_share_of_housing_company_loans": 3000,
             "apartment_share_of_housing_company_loans_date": "2022-11-20",
-            "completion_date": "2012-07-28",
+            "completion_date": str(a.completion_date),
             "completion_date_index": 296.10,
             "calculation_date": "2022-11-21",
             "calculation_date_index": 364.6,
@@ -1002,7 +1003,7 @@ def test__api__apartment_max_price__construction_price_index__pre_2011(api_clien
             "debt_free_price_m2": 8564.47,
             "apartment_share_of_housing_company_loans": 3000,
             "apartment_share_of_housing_company_loans_date": "2022-11-20",
-            "completion_date": "2012-07-28",
+            "completion_date": str(a.completion_date),
             "completion_date_index": 263.6,
             "calculation_date": "2022-11-21",
             "calculation_date_index": 567.1,

--- a/backend/hitas/tests/apis/apartment_max_price/test_api_unconfirmed_max_price_pdf.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_unconfirmed_max_price_pdf.py
@@ -6,6 +6,7 @@ from typing import Literal, NamedTuple
 
 import pytest
 from django.urls import reverse
+from django.utils import timezone
 from pypdf import PdfReader
 from rest_framework import status
 
@@ -142,6 +143,14 @@ def test__api__unconfirmed_max_price_pdf__old_hitas_ruleset(api_client: HitasAPI
         sales__apartment_share_of_housing_company_loans=15000,
     )
 
+    # Create another apartment with a later completion date.
+    # As Old-Hitas rules use the apartment completion date for the maximum price calculation,
+    # this apartment should not affect the calculation.
+    ApartmentFactory.create(
+        completion_date=datetime.date(2011, 1, 1),
+        building__real_estate__housing_company=apartment.housing_company,
+    )
+
     ownership: Ownership = apartment.latest_sale(include_first_sale=True).ownerships.first()
 
     body = PDFBodyFactory.create(
@@ -149,7 +158,7 @@ def test__api__unconfirmed_max_price_pdf__old_hitas_ruleset(api_client: HitasAPI
         texts=["||foo||", "||bar||", "||baz||"],
     )
 
-    this_month = datetime.date.today().replace(day=1)
+    this_month = timezone.now().date().replace(day=1)
     completion_month = apartment.completion_date.replace(day=1)
 
     # Completion month indices
@@ -300,7 +309,7 @@ def test__api__unconfirmed_max_price_pdf__indices_missing(
         texts=["||foo||", "||bar||", "||baz||"],
     )
 
-    this_month = datetime.date.today().replace(day=1)
+    this_month = timezone.now().date().replace(day=1)
     completion_month = apartment.completion_date.replace(day=1)
 
     # Completion month indices
@@ -361,7 +370,7 @@ def test__api__unconfirmed_max_price_pdf__past_date(api_client: HitasAPIClient, 
         texts=["||foo||", "||bar||", "||baz||"],
     )
 
-    this_month = datetime.date.today().replace(day=1)
+    this_month = timezone.now().date().replace(day=1)
     past_month = datetime.date(2021, 5, 1)
     completion_month = apartment.completion_date.replace(day=1)
 
@@ -552,7 +561,7 @@ def test__api__unconfirmed_max_price_pdf__missing_template(api_client: HitasAPIC
         sales__apartment_share_of_housing_company_loans=15000,
     )
 
-    this_month = datetime.date.today().replace(day=1)
+    this_month = timezone.now().date().replace(day=1)
     completion_month = apartment.completion_date.replace(day=1)
 
     # Completion month indices

--- a/backend/hitas/tests/factories/apartment.py
+++ b/backend/hitas/tests/factories/apartment.py
@@ -58,6 +58,10 @@ class ApartmentFactory(DjangoModelFactory):
 
         if extracted is None:
             kwargs.setdefault("apartment", self)
+            if self.completion_date:
+                # Use completion date as default for purchase date, as this can affect the indices for
+                # old-hitas CPI calculations, when the apartment was sold after the completion date.
+                kwargs.setdefault("purchase_date", self.completion_date)
             extracted = [ApartmentSaleFactory.create(**kwargs)]
 
         for ownership in extracted:

--- a/backend/hitas/tests/factories/apartment_sale.py
+++ b/backend/hitas/tests/factories/apartment_sale.py
@@ -18,7 +18,9 @@ class ApartmentSaleFactory(DjangoModelFactory):
         sales=factory.LazyAttribute(lambda _: []),  # prevents another sale from being created
     )
     notification_date = fuzzy.FuzzyDate(date(2010, 1, 1))
-    purchase_date = fuzzy.FuzzyDate(date(2010, 1, 1))
+    purchase_date = factory.LazyAttribute(
+        lambda self: (self.apartment.completion_date or fuzzy.FuzzyDate(date(2010, 1, 1)).fuzz())
+    )
     purchase_price = fuzzy.FuzzyDecimal(100_000, 200_000)
     apartment_share_of_housing_company_loans = fuzzy.FuzzyDecimal(10000, 20000)
     exclude_from_statistics = False

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -864,6 +864,7 @@ class ApartmentViewSet(HitasModelViewSet):
             _latest_purchase_date=get_latest_sale_purchase_date("id"),
         )
         return annotate_apartment_unconfirmed_prices(
+            apartment_uuid=self.kwargs["uuid"],
             queryset=qs,
             housing_company=housing_company,
             calculation_date=calculation_date,

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -9,7 +9,6 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Count, Prefetch, Q
 from django.db.models.expressions import Case, F, Subquery, When
-from django.db.models.functions import TruncMonth
 from django.http import HttpResponse
 from django.urls import reverse
 from django.utils import timezone
@@ -22,7 +21,6 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 
 from hitas.calculations.exceptions import IndexMissingException
-from hitas.calculations.max_prices.max_price import get_housing_company_completion_date
 from hitas.exceptions import HitasModelNotFound, ModelConflict
 from hitas.models import (
     Apartment,
@@ -864,7 +862,6 @@ class ApartmentViewSet(HitasModelViewSet):
             _first_purchase_date=get_first_sale_purchase_date("id"),
             _latest_sale_purchase_price=get_latest_sale_purchase_price("id"),
             _latest_purchase_date=get_latest_sale_purchase_date("id"),
-            completion_month=TruncMonth("completion_date"),  # Used for calculating indexes
         )
         return annotate_apartment_unconfirmed_prices(
             queryset=qs,

--- a/frontend/src/common/components/SurfaceAreaPriceCeilingTable.tsx
+++ b/frontend/src/common/components/SurfaceAreaPriceCeilingTable.tsx
@@ -9,6 +9,8 @@ import {FilterTextInputField} from "./filters";
 import {QueryStateHandler} from "./index";
 
 const DownloadSurfaceAreaPriceCeilingReportButton = ({calculation}) => {
+    if (calculation.value === undefined) return null;
+
     return (
         <div className="text-right">
             <DownloadButton

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -245,30 +245,30 @@ export const getHitasQuarterFullLabel = (
 
     // Add last year for the start date, as January's quarter begins in the previous year
     const formatJan = () =>
-        `${hitasQuarter.split(" ")[0]}${Number(yearString) - 1} - ${hitasQuarter.split("-")[1]}${yearString} (Q4)`;
+        `${hitasQuarter.split(" ")[0]}${Number(yearString) - 1} - ${hitasQuarter.split("-")[1]}${yearString} (Q3)`;
 
     // Add the next year in the end date for the last quarter, as the quarter ends in the next year
     const formatNovDec = () =>
-        `${hitasQuarter.split(" ")[0]}${yearString} - ${hitasQuarter.split("-")[1]}${Number(yearString) + 1} (Q4)`;
+        `${hitasQuarter.split(" ")[0]}${yearString} - ${hitasQuarter.split("-")[1]}${Number(yearString) + 1} (Q3)`;
 
     switch (monthString) {
         case "01":
             return formatJan();
         case "02":
-            return formatQuarter(1);
+            return formatQuarter(4);
         case "03":
         case "04":
-            return onlyCalculationMonths ? undefined : formatQuarter(1);
+            return onlyCalculationMonths ? undefined : formatQuarter(4);
         case "05":
-            return formatQuarter(2);
+            return formatQuarter(1);
         case "06":
         case "07":
-            return onlyCalculationMonths ? undefined : formatQuarter(2);
+            return onlyCalculationMonths ? undefined : formatQuarter(1);
         case "08":
-            return formatQuarter(3);
+            return formatQuarter(2);
         case "09":
         case "10":
-            return onlyCalculationMonths ? undefined : formatQuarter(3);
+            return onlyCalculationMonths ? undefined : formatQuarter(2);
         case "11":
             return formatNovDec();
         case "12":

--- a/frontend/src/features/apartment/ApartmentDetailsPage/components/ApartmentMaximumPricesCard.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage/components/ApartmentMaximumPricesCard.tsx
@@ -87,7 +87,9 @@ const UnconfirmedPricesDownloadModalButton = () => {
                         unconfirmedPrices.market_price_index.value &&
                         unconfirmedPrices.construction_price_index.value &&
                         unconfirmedPrices.surface_area_price_ceiling.value
-                    ) || housingCompany.regulation_status !== "regulated"
+                    ) ||
+                    housingCompany.regulation_status !== "regulated" ||
+                    housingCompany.hitas_type === "half_hitas"
                 }
             />
             <GenericActionModal
@@ -156,9 +158,9 @@ const MaximumPriceDownloadModalButton = () => {
                 onClick={() => setIsModalOpen(true)}
                 size="small"
                 disabled={
-                    !apartment.prices.maximum_prices.confirmed ||
-                    !apartment.prices.maximum_prices.confirmed.id ||
-                    housingCompany.regulation_status !== "regulated"
+                    !apartment.prices.maximum_prices.confirmed?.id ||
+                    housingCompany.regulation_status !== "regulated" ||
+                    housingCompany.hitas_type === "half_hitas"
                 }
             />
             <GenericActionModal

--- a/frontend/src/features/codes/CodesPage.tsx
+++ b/frontend/src/features/codes/CodesPage.tsx
@@ -29,9 +29,11 @@ const CodesPage = (): React.JSX.Element => {
                 </Tabs.TabPanel>
                 <Tabs.TabPanel className="view--codes__tab--postalcodes">
                     <h1>Postinumerot</h1>
+                    <p>Tämä sivu on vielä työn alla.</p>
                 </Tabs.TabPanel>
                 <Tabs.TabPanel className="view--codes__tab--financing-methods">
                     <h1>Rahoitusmuodot</h1>
+                    <p>Tämä sivu on vielä työn alla.</p>
                 </Tabs.TabPanel>
                 <Tabs.TabPanel className="view--codes__tab--owners">
                     <MutateSearchList

--- a/frontend/src/features/housingCompany/components/HousingCompanyHeader.tsx
+++ b/frontend/src/features/housingCompany/components/HousingCompanyHeader.tsx
@@ -30,16 +30,20 @@ const HousingCompanyHeaderContent = ({housingCompany}: {housingCompany: IHousing
             <div>
                 <StatusLabel>{getHousingCompanyHitasTypeName(housingCompany.hitas_type)}</StatusLabel>
                 <StatusLabel>{housingCompany.completed ? "Valmis" : "Ei valmis"}</StatusLabel>
+
                 {housingCompany.completed ? (
                     <>
-                        <StatusLabel>
-                            {housingCompany.over_thirty_years_old ? "Yli 30 vuotta" : "Alle 30 vuotta"}
-                        </StatusLabel>
+                        {housingCompany.hitas_type !== "half_hitas" ? (
+                            <StatusLabel>
+                                {housingCompany.over_thirty_years_old ? "Yli 30 vuotta" : "Alle 30 vuotta"}
+                            </StatusLabel>
+                        ) : null}
                         <StatusLabel>
                             {getHousingCompanyRegulationStatusName(housingCompany.regulation_status)}
                         </StatusLabel>
                     </>
                 ) : null}
+
                 {housingCompany.exclude_from_statistics ? <StatusLabel>Ei tilastoihin</StatusLabel> : null}
             </div>
         </>

--- a/frontend/src/styles/components/_Functions.sass
+++ b/frontend/src/styles/components/_Functions.sass
@@ -48,6 +48,9 @@
     background: $color-black-10
     padding: $spacing-m
 
+    [class^="Notification-module_notification"]
+      margin-bottom: $spacing-2-xl
+
     .price-ceiling-calculation
       @include flexbox()
       @include flex-flow(row nowrap)


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Use apartment completion date for old-hitas max price calculations
- When old-hitas apartment's first sale date is after the completion date, use it instead for selecting indice month
- Small frontend fixes

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

- Automatic tests

## Tickets

This pull request resolves all or part of the following ticket(s): HT-646, HT-545
