### PR TITLE
frontend: Fix basequery prepareHeaders to not override content-type

### DIFF
--- a/frontend/src/common/services/apis.ts
+++ b/frontend/src/common/services/apis.ts
@@ -32,7 +32,9 @@ const baseQuery = fetchBaseQuery({
     prepareHeaders: (headers, api) => {
         Config.token && headers.set("Authorization", "Bearer " + Config.token);
         if (api.type === "mutation") {
-            headers.set("Content-type", "application/json; charset=UTF-8");
+            if (!headers.has("Content-Type")) {
+                headers.set("Content-type", "application/json; charset=UTF-8");
+            }
             const csrfToken = getCookie("csrftoken");
             csrfToken && headers.set("X-CSRFToken", csrfToken);
         }
@@ -41,6 +43,7 @@ const baseQuery = fetchBaseQuery({
     },
     ...(!Config.token && {credentials: "include"}),
 });
+
 const baseQueryWithReAuth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = async (
     args,
     api,


### PR DESCRIPTION
- Fixes an issue where sending excel files to the API were sent with content-type application/json, when their specific endpoints set it explicitly to xlsx

# Hitas Pull Request

# Description

&lt;write your pull request description here&gt;

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

&lt;help your fellow reviewer and write a short description what's the fastest way to test your changes&gt;

## Tickets

This pull request resolves all or part of the following ticket(s): &lt;Please enter ticket number(s), and elaborate
below if necessary&gt;
