### PR TITLE
backend: Round maximum price before wordifying it

### DIFF
--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -129,7 +129,7 @@
     <br>
 
     <p class="plain-text">
-        Huoneiston vahvistettu enimmäismyyntihinta on {{ maximum_price_calculation.maximum_price|wordify }} ({{ maximum_price_calculation.maximum_price|intcomma(0) }}) euroa.
+        Huoneiston vahvistettu enimmäismyyntihinta on {{ maximum_price_calculation.maximum_price|round|wordify }} ({{ maximum_price_calculation.maximum_price|intcomma(0) }}) euroa.
         {% if is_surface_area_maximum %}
             Enimmäismyyntihinta on vahvistettu rajahinnan perusteella ja laskelma on voimassa {{ maximum_price_calculation.valid_until|format_date }} asti.
         {% else %}


### PR DESCRIPTION
# Hitas Pull Request

# Description

- Fix decimal numbers being wordifyed in max price calculations

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [ ] Changes have been tested
  - [ ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ ] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan

&lt;help your fellow reviewer and write a short description what's the fastest way to test your changes&gt;

## Tickets

This pull request resolves all or part of the following ticket(s): Slack communications
