### PR TITLE
backend: Support for getting owners by housing company report

### DIFF
--- a/backend/hitas/models/owner.py
+++ b/backend/hitas/models/owner.py
@@ -17,6 +17,8 @@ class OwnerT(TypedDict):
 
 
 class Owner(AuditableMaskedModelMixin, ExternalSafeDeleteHitasModel):
+    OBFUSCATED_OWNER_NAME = "***"
+
     name: str = models.CharField(max_length=256, blank=True)
     identifier: Optional[str] = models.CharField(max_length=11, blank=True, null=True)
     valid_identifier: bool = models.BooleanField(default=False)

--- a/backend/hitas/services/owner.py
+++ b/backend/hitas/services/owner.py
@@ -114,3 +114,14 @@ def find_owners_with_multiple_ownerships() -> list[OwnershipWithApartmentCount]:
             "sale__apartment__street_address",
         )
     )
+
+
+def find_apartments_by_housing_company(housing_company_id: int) -> list[Ownership]:
+    return (
+        Ownership.objects.filter(
+            sale__apartment__building__real_estate__housing_company_id=housing_company_id,
+            sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        )
+        .select_related("sale", "sale__apartment", "owner")
+        .order_by("sale__apartment__apartment_number")
+    )

--- a/backend/hitas/urls.py
+++ b/backend/hitas/urls.py
@@ -120,6 +120,21 @@ router.register(
     basename="multiple-ownerships-report",
 )
 
+# /api/v1/reports/ownership-by-housing-company/<pk>
+router.register(
+    r"reports/ownership-by-housing-company-report",
+    views.OwnershipsByCompanyJSONReportView,
+    basename="ownership-by-housing-company-report",
+)
+
+# /api/v1/reports/download-ownership-by-housing-company/<pk>
+router.register(
+    r"reports/download-ownership-by-housing-company-report",
+    views.OwnershipsByHousingCompanyReport,
+    basename="download-ownership-by-housing-company-report",
+)
+
+
 # /api/v1/job-performance/{source}
 router.register(
     r"job-performance",

--- a/backend/hitas/views/__init__.py
+++ b/backend/hitas/views/__init__.py
@@ -32,6 +32,8 @@ from hitas.views.reports import (
     HousingCompanyStatesJSONReportView,
     HousingCompanyStatesReportView,
     MultipleOwnershipsReportView,
+    OwnershipsByCompanyJSONReportView,
+    OwnershipsByHousingCompanyReport,
     RegulateHousingCompaniesReportView,
     SalesByPostalCodeAndAreaReportView,
     SalesReportView,

--- a/backend/hitas/views/reports.py
+++ b/backend/hitas/views/reports.py
@@ -7,23 +7,27 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
+from hitas.models import HousingCompany, Owner, Ownership
 from hitas.services.apartment_sale import find_sales_on_interval_for_reporting
 from hitas.services.housing_company import (
     find_housing_companies_for_state_reporting,
     find_regulated_housing_companies_for_reporting,
     find_unregulated_housing_companies_for_reporting,
 )
-from hitas.services.owner import find_owners_with_multiple_ownerships
+from hitas.services.owner import find_apartments_by_housing_company, find_owners_with_multiple_ownerships
 from hitas.services.reports import (
     build_housing_company_state_report_excel,
     build_multiple_ownerships_report_excel,
+    build_owners_by_housing_companies_report_excel,
     build_regulated_housing_companies_report_excel,
     build_sales_by_postal_code_and_area_report_excel,
     build_sales_report_excel,
     build_unregulated_housing_companies_report_excel,
     sort_housing_companies_by_state,
 )
+from hitas.services.validation import lookup_model_by_uuid
 from hitas.types import HitasJSONRenderer
+from hitas.views.utils import HitasDecimalField
 from hitas.views.utils.excel import ExcelRenderer, get_excel_response
 
 
@@ -123,4 +127,48 @@ class MultipleOwnershipsReportView(ViewSet):
         ownerships = find_owners_with_multiple_ownerships()
         workbook = build_multiple_ownerships_report_excel(ownerships)
         filename = "Useamman sääntelyn piirissä olevan asunnon omistavat omistajat.xlsx"
+        return get_excel_response(filename=filename, excel=workbook)
+
+
+class OwnershipsByHousingCompanyReportSerializer(serializers.ModelSerializer):
+    number = serializers.IntegerField(source="sale.apartment.apartment_number")
+    surface_area = HitasDecimalField(source="sale.apartment.surface_area")
+    share_numbers = serializers.SerializerMethodField()
+    purchase_date = serializers.DateField(source="sale.purchase_date")
+    owner_name = serializers.SerializerMethodField()
+    owner_ssn = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Ownership
+        fields = ("number", "surface_area", "share_numbers", "purchase_date", "owner_name", "owner_ssn")
+
+    def get_share_numbers(self, obj):
+        return f"{obj.sale.apartment.share_number_start}-{obj.sale.apartment.share_number_end}"
+
+    def get_owner_name(self, obj):
+        return Owner.OBFUSCATED_OWNER_NAME if obj.owner.non_disclosure else obj.owner.name
+
+    def get_owner_ssn(self, obj):
+        return "" if obj.owner.non_disclosure else obj.owner.identifier
+
+
+class OwnershipsByCompanyJSONReportView(ViewSet):
+    def retrieve(self, request: Request, *args, **kwargs) -> Response:
+        housing_company_obj: HousingCompany = lookup_model_by_uuid(kwargs.get("pk"), HousingCompany)
+
+        serializer = OwnershipsByHousingCompanyReportSerializer(
+            data=find_apartments_by_housing_company(housing_company_obj.id), many=True
+        )
+        serializer.is_valid()
+        return Response(data=serializer.data, status=status.HTTP_200_OK)
+
+
+class OwnershipsByHousingCompanyReport(ViewSet):
+    renderer_classes = [HitasJSONRenderer, ExcelRenderer]
+
+    def retrieve(self, request: Request, *args, **kwargs) -> HttpResponse:
+        housing_company_obj: HousingCompany = lookup_model_by_uuid(kwargs.get("pk"), HousingCompany)
+        owners_by_companies = find_apartments_by_housing_company(housing_company_obj.id)
+        workbook = build_owners_by_housing_companies_report_excel(owners_by_companies)
+        filename = f"Omistajat yhtiölle {housing_company_obj.display_name}.xlsx"
         return get_excel_response(filename=filename, excel=workbook)

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -4076,6 +4076,65 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/v1/reports/ownership-by-housing-company-report/{housing_company_id}:
+    get:
+      description: Get report in JSON format for one regulated housing company
+      parameters:
+        - name: housing_company_id
+          required: true
+          in: path
+          description: Housing company ID
+          schema:
+            type: string
+            example: a3181b8fa60b47df8ccba0d554a913bb
+      tags:
+        - Reports
+      responses:
+        "200":
+          description: Successfully fetched JSON report for housing company owners ordered by apartment number
+          content:
+            application/json:
+              schema:
+                description: List of owners for one housing company
+                type: array
+                items:
+                  $ref: '#/components/schemas/OwnerByHousingCompany'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/v1/reports/download-ownership-by-housing-company-report/{housing_company_id}:
+    get:
+      description: Download excel report for one regulated housing company
+      parameters:
+        - name: housing_company_id
+          required: true
+          in: path
+          description: Housing company ID
+          schema:
+            type: string
+            example: a3181b8fa60b47df8ccba0d554a913bb
+      tags:
+        - Reports
+      responses:
+        '200':
+            description: Successfully downloaded excel report for housing company owners ordered by apartment number
+            content:
+              application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+                schema:
+                  type: string
+                  format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+
   /api/v1/job-performance/confirmed-maximum-price:
     get:
       description: Get Job Performance data for the timeframe on Confirmed Maximum Price calculations
@@ -4724,6 +4783,49 @@ components:
               type: string
               nullable: true
               example: "https://example.com/api/v1/housing-companies?page=2"
+
+    OwnerByHousingCompany:
+      description: Single Owner information for a Housing company
+      type: object
+      additionalProperties: false
+      required:
+        - number
+        - surface_area
+        - share_numbers
+        - purchase_date
+        - owner_name
+        - owner_ssn
+      properties:
+        number:
+          description: Apartment number
+          type: integer
+          example: 20
+          readOnly: true
+        surface_area:
+          description: Surface area of the apartment
+          type: number
+          example: 50.2
+          readOnly: true
+        share_numbers:
+          description: Share number range
+          type: string
+          example: 1-100
+          readOnly: true
+        purchase_date:
+          description: Date of the purchase
+          type: string
+          example: 2023-09-21
+          readOnly: true
+        owner_name:
+          description: Name of the owner
+          type: string
+          example: Olli Omistaja
+          readOnly: true
+        owner_ssn:
+          description: SSN of the owner
+          type: string
+          example:  010105A957L
+          readOnly: true
 
     HousingCompany:
       description: Single housing company


### PR DESCRIPTION
# Hitas Pull Request

# Description
API to get report data for owners by housing company. Both JSON and Excel report endpoints added.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [ x] Changes have been tested
  - [x ] Automatic tests have been added
- **Database**
  - [ ] Database migrations will work in the DEV & TEST environments
  - [ ] initial.json has been updated to work with migrations
  - [ ] Oracle migration has been updated
- **Documentation**
  - [ ] Tooltips have been added in the frontend for all new fields
  - [ x] OpenAPI definitions have been updated
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira
  - [ ] Terminology page in Confluence has been updated

## Test plan
URL to get excel report for housing company with id=1, /api/v1/reports/ownership-by-housing-company/1
URL to get JSON report for housing company with id=1 /api/v1/reports/download-ownership-by-housing-company/1

## Tickets

HT-663 backend part