### PR TITLE
Download and list owners by housing company 

### DIFF
--- a/frontend/src/common/components/HousingCompanyOwnersTable.tsx
+++ b/frontend/src/common/components/HousingCompanyOwnersTable.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import {LoadingSpinner} from "hds-react";
+import {useGetHousingCompanyOwnersQuery} from "../services";
+
+export default function HousingCompanyOwnersTable({housingCompanyId}: {housingCompanyId: string}): React.JSX.Element {
+    const {
+        data: housingCompanyOwners,
+        isLoading: isHousingCompanyOwnersLoading,
+        error: housingCompanyOwnersError,
+    } = useGetHousingCompanyOwnersQuery(housingCompanyId);
+
+    return (
+        <ul className="detail-list__list detail-list__list--owners">
+            {housingCompanyOwners?.length ? (
+                <>
+                    <li className="detail-list__list-headers">
+                        <div>
+                            Asunnon
+                            <br />
+                            numero
+                        </div>
+                        <div>
+                            Asunnon <br />
+                            pinta-ala
+                        </div>
+                        <div>Osakenumerot</div>
+                        <div>Kauppakirjapäivä</div>
+                        <div>Nimi</div>
+                        <div>Henkilötunnus</div>
+                    </li>
+                    {housingCompanyOwners.map((item, index) => (
+                        <li
+                            className="detail-list__list-item"
+                            key={`owner-item-${index}`}
+                        >
+                            <div>{item.number}</div>
+                            <div>{item.surface_area}</div>
+                            <div>{item.share_numbers}</div>
+                            <div>{item.purchase_date}</div>
+                            <div>{item.owner_name}</div>
+                            <div>{item.owner_ssn}</div>
+                        </li>
+                    ))}
+                </>
+            ) : (
+                <>
+                    {!housingCompanyOwners?.length && !housingCompanyOwnersError && !isHousingCompanyOwnersLoading && (
+                        <p>Ei omistajia</p>
+                    )}
+                    {isHousingCompanyOwnersLoading && (
+                        <div className="spinner-wrap">
+                            <LoadingSpinner />
+                        </div>
+                    )}
+                    {housingCompanyOwnersError && (
+                        <div>
+                            <p>Virhe rajapintakutsussa 😞</p>
+                        </div>
+                    )}
+                </>
+            )}
+        </ul>
+    );
+}

--- a/frontend/src/common/schemas/common.ts
+++ b/frontend/src/common/schemas/common.ts
@@ -81,6 +81,7 @@ z.setErrorMap(customErrorMap);
 // ********************************
 
 export const APIIdString = string().min(32, errorMessages.APIIdMin).max(32, errorMessages.APIIdMax);
+export type IAPIIdString = z.infer<typeof APIIdString>;
 
 export const nullishNumber = number({
     invalid_type_error: errorMessages.numberType,

--- a/frontend/src/common/schemas/housingCompany.ts
+++ b/frontend/src/common/schemas/housingCompany.ts
@@ -76,6 +76,16 @@ export const HousingCompanySchema = object({
 });
 export type IHousingCompany = z.infer<typeof HousingCompanySchema>;
 
+export const HousingCompanyOwnerSchema = object({
+    number: number(),
+    surface_area: number(),
+    share_numbers: string(),
+    purchase_date: string(),
+    owner_name: string(),
+    owner_ssn: string(),
+});
+export type IHousingCompanyOwner = z.infer<typeof HousingCompanyOwnerSchema>;
+
 export const HousingCompanyDetailsSchema = object({
     id: APIIdString,
     business_id: string().nullable(),

--- a/frontend/src/common/services/hitasApi/housingCompany.ts
+++ b/frontend/src/common/services/hitasApi/housingCompany.ts
@@ -1,4 +1,5 @@
 import {
+    IAPIIdString,
     IApartmentListResponse,
     IBuilding,
     IBuildingWritable,
@@ -6,6 +7,7 @@ import {
     IHousingCompanyApartmentQuery,
     IHousingCompanyDetails,
     IHousingCompanyListResponse,
+    IHousingCompanyOwner,
     IHousingCompanyWritable,
     IRealEstate,
 } from "../../schemas";
@@ -30,6 +32,10 @@ const housingCompanyApi = hitasApi.injectEndpoints({
                 {type: "PropertyManager", id: result?.property_manager?.id},
                 {type: "Developer", id: result?.developer?.id},
             ],
+        }),
+        getHousingCompanyOwners: builder.query<IHousingCompanyOwner[], IAPIIdString>({
+            query: (id) => `reports/ownership-by-housing-company-report/${id}`,
+            providesTags: (result, error, arg) => [{type: "HousingCompany", id: arg}],
         }),
         // MODIFY
         saveHousingCompany: builder.mutation<IHousingCompanyDetails, {data: IHousingCompanyWritable; id?: string}>({
@@ -157,6 +163,7 @@ export const {
     useGetHousingCompaniesQuery,
     useGetHousingCompanyApartmentsQuery,
     useGetHousingCompanyDetailQuery,
+    useGetHousingCompanyOwnersQuery,
     usePatchHousingCompanyMutation,
     useSaveBuildingMutation,
     useSaveHousingCompanyMutation,

--- a/frontend/src/common/services/hitasApi/reports.ts
+++ b/frontend/src/common/services/hitasApi/reports.ts
@@ -1,7 +1,11 @@
-import {ApartmentSalesJobPerformanceResponse, IApartmentDetails, JobPerformanceResponse} from "../../schemas";
+import {
+    ApartmentSalesJobPerformanceResponse,
+    IAPIIdString,
+    IApartmentDetails,
+    JobPerformanceResponse,
+} from "../../schemas";
 import {hdsToast} from "../../utils";
 import {fetchAndDownloadPDF, handleDownloadPDF, safeInvalidate} from "../utils";
-
 import {hitasApi} from "../apis";
 
 export const downloadApartmentUnconfirmedMaximumPricePDF = (
@@ -66,6 +70,9 @@ export const downloadHousingCompanyStatesReportPDF = () =>
 
 export const downloadMultipleOwnershipsReportPDF = () =>
     fetchAndDownloadPDF("/reports/download-multiple-ownerships-report");
+
+export const downloadHousingCompanyWithOwnersExcel = (id: IAPIIdString) =>
+    fetchAndDownloadPDF(`/reports/download-ownership-by-housing-company-report/${id}`);
 
 // Mutations are used to allow invalidating cache when PDF is downloaded
 export const reportsApi = hitasApi.injectEndpoints({

--- a/frontend/src/features/apartment/ApartmentConditionsOfSalePage.tsx
+++ b/frontend/src/features/apartment/ApartmentConditionsOfSalePage.tsx
@@ -217,6 +217,7 @@ const ConditionOfSaleGracePeriodButton = ({conditionOfSale}: {conditionOfSale: I
     return (
         <>
             <button
+                title="Myönnä lisäaikaa"
                 className="text-button"
                 onClick={() => setIsModalOpen(true)}
             >

--- a/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
@@ -2,7 +2,7 @@ import {Button, IconPlus, Tabs} from "hds-react";
 import {Link} from "react-router-dom";
 
 import React, {useContext, useState} from "react";
-import {DetailField, EditButton, Heading, ImprovementsTable} from "../../common/components";
+import {DetailField, DownloadButton, EditButton, Heading, ImprovementsTable} from "../../common/components";
 import {MutateForm, MutateModal, propertyManagerMutateFormProps} from "../../common/components/mutateComponents";
 import {IPropertyManager} from "../../common/schemas";
 import {formatAddress, formatDate, formatMoney} from "../../common/utils";
@@ -13,6 +13,7 @@ import {
     HousingCompanyViewContextProvider,
 } from "./components/HousingCompanyViewContextProvider";
 import SalesCatalogImport from "./components/SalesCatalogImport";
+import {downloadHousingCompanyWithOwnersExcel} from "../../common/services";
 
 const LoadedHousingCompanyDetails = (): React.JSX.Element => {
     const {housingCompany} = useContext(HousingCompanyViewContext);
@@ -102,6 +103,7 @@ const LoadedHousingCompanyDetails = (): React.JSX.Element => {
                                 <div>
                                     <label className="detail-field-label">Huomioitavaa</label>
                                     <textarea
+                                        placeholder="Ei huomioitavaa"
                                         readOnly
                                         value={housingCompany.notes || ""}
                                     />
@@ -216,6 +218,20 @@ const LoadedHousingCompanyDetails = (): React.JSX.Element => {
                     </ul>
                 </div>
             </div>
+            {housingCompany.regulation_status === "regulated" && (
+                <div className="list-wrapper list-wrapper--owners">
+                    <Heading type="list">
+                        <span>Omistajat</span>
+                        <div className="buttons">
+                            <DownloadButton
+                                buttonText="Lataa raportti"
+                                onClick={() => downloadHousingCompanyWithOwnersExcel(housingCompany.id)}
+                                size="small"
+                            />
+                        </div>
+                    </Heading>
+                </div>
+            )}
             <div className="list-wrapper list-wrapper--apartments">
                 <Heading type="list">
                     <span>Asunnot</span>

--- a/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "./components/HousingCompanyViewContextProvider";
 import SalesCatalogImport from "./components/SalesCatalogImport";
 import {downloadHousingCompanyWithOwnersExcel} from "../../common/services";
+import HousingCompanyOwnersTable from "../../common/components/HousingCompanyOwnersTable";
 
 const LoadedHousingCompanyDetails = (): React.JSX.Element => {
     const {housingCompany} = useContext(HousingCompanyViewContext);
@@ -220,16 +221,19 @@ const LoadedHousingCompanyDetails = (): React.JSX.Element => {
             </div>
             {housingCompany.regulation_status === "regulated" && (
                 <div className="list-wrapper list-wrapper--owners">
-                    <Heading type="list">
-                        <span>Omistajat</span>
-                        <div className="buttons">
-                            <DownloadButton
-                                buttonText="Lataa raportti"
-                                onClick={() => downloadHousingCompanyWithOwnersExcel(housingCompany.id)}
-                                size="small"
-                            />
-                        </div>
-                    </Heading>
+                    <div className="list__wrapper list-wrapper--owners">
+                        <Heading type="list">
+                            <span>Omistajat</span>
+                            <div className="buttons">
+                                <DownloadButton
+                                    buttonText="Lataa raportti"
+                                    onClick={() => downloadHousingCompanyWithOwnersExcel(housingCompany.id)}
+                                    size="small"
+                                />
+                            </div>
+                        </Heading>
+                        <HousingCompanyOwnersTable housingCompanyId={housingCompany.id} />
+                    </div>
                 </div>
             )}
             <div className="list-wrapper list-wrapper--apartments">

--- a/frontend/src/styles/components/_HousingCompanyPage.sass
+++ b/frontend/src/styles/components/_HousingCompanyPage.sass
@@ -72,6 +72,26 @@
   .list-wrapper--real-estates, .list-wrapper--buildings
     width: 50%
 
+  .list-wrapper--owners
+    margin: $spacing-layout-m 0
+    .detail-list__list
+      .detail-list__list-headers, .detail-list__list-item
+        > div
+          width: 15%
+          display: flex
+          justify-content: center
+          &:first-child
+            width: 10%
+            justify-content: start
+          &:nth-child(2)
+            width: 10%
+          &:nth-child(5)
+            width: 35%
+            justify-content: start
+            padding-right: $spacing-xs
+          &:last-child
+            justify-content: end
+
   .results
     grid-column-start: 1
     grid-column-end: 3


### PR DESCRIPTION
# Hitas Pull Request

Adds button to the details view of regulated housing companies for to download owners in Excel.
Adds owners list to the details view of regulated housing companies.

## Pull request checklist

## Test plan

Check that the owners excel can be loaded from the details view of a regulated housing company.
Check that you can see the list of owners (if there are any) in the details view of a regulated housing company.

## Tickets

This pull request resolves all or part of the following ticket(s): HT-663
