### PR TITLE
Move owners list under drop-down to the end of housing company details

### DIFF
--- a/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
@@ -1,4 +1,4 @@
-import {Button, IconPlus, Tabs} from "hds-react";
+import {Button, IconAngleDown, IconAngleUp, IconPlus, Tabs} from "hds-react";
 import {Link} from "react-router-dom";
 
 import React, {useContext, useState} from "react";
@@ -21,6 +21,7 @@ const LoadedHousingCompanyDetails = (): React.JSX.Element => {
     if (!housingCompany) throw new Error("Housing company not found");
 
     const [isModifyPropertyManagerModalVisible, setIsModifyPropertyManagerModalVisible] = useState(false);
+    const [isHousingCompanyOwnersTableVisible, setIsHousingCompanyOwnersTableVisible] = useState(false);
 
     return (
         <div className="company-details">
@@ -219,23 +220,6 @@ const LoadedHousingCompanyDetails = (): React.JSX.Element => {
                     </ul>
                 </div>
             </div>
-            {housingCompany.regulation_status === "regulated" && (
-                <div className="list-wrapper list-wrapper--owners">
-                    <div className="list__wrapper list-wrapper--owners">
-                        <Heading type="list">
-                            <span>Omistajat</span>
-                            <div className="buttons">
-                                <DownloadButton
-                                    buttonText="Lataa raportti"
-                                    onClick={() => downloadHousingCompanyWithOwnersExcel(housingCompany.id)}
-                                    size="small"
-                                />
-                            </div>
-                        </Heading>
-                        <HousingCompanyOwnersTable housingCompanyId={housingCompany.id} />
-                    </div>
-                </div>
-            )}
             <div className="list-wrapper list-wrapper--apartments">
                 <Heading type="list">
                     <span>Asunnot</span>
@@ -257,6 +241,33 @@ const LoadedHousingCompanyDetails = (): React.JSX.Element => {
                     <HousingCompanyApartmentResultsList housingCompanyId={housingCompany.id} />
                 </div>
             </div>
+            {housingCompany.regulation_status === "regulated" && (
+                <div className="list-wrapper list-wrapper--owners">
+                    <Heading type="list">
+                        <button
+                            className="text-button"
+                            onClick={() => {
+                                isHousingCompanyOwnersTableVisible
+                                    ? setIsHousingCompanyOwnersTableVisible(false)
+                                    : setIsHousingCompanyOwnersTableVisible(true);
+                            }}
+                        >
+                            Omistajat
+                            {isHousingCompanyOwnersTableVisible ? <IconAngleUp size="m" /> : <IconAngleDown size="m" />}
+                        </button>
+                        <div className="buttons">
+                            <DownloadButton
+                                buttonText="Lataa raportti"
+                                onClick={() => downloadHousingCompanyWithOwnersExcel(housingCompany.id)}
+                                size="small"
+                            />
+                        </div>
+                    </Heading>
+                    {isHousingCompanyOwnersTableVisible && (
+                        <HousingCompanyOwnersTable housingCompanyId={housingCompany.id} />
+                    )}
+                </div>
+            )}
         </div>
     );
 };

--- a/frontend/src/styles/components/_HousingCompanyPage.sass
+++ b/frontend/src/styles/components/_HousingCompanyPage.sass
@@ -74,6 +74,12 @@
 
   .list-wrapper--owners
     margin: $spacing-layout-m 0
+    .text-button
+        font-size: $fontsize-heading-l
+        display: inline-flex
+        align-items: center
+        svg
+          margin-left: $spacing-2-xs
     .detail-list__list
       .detail-list__list-headers, .detail-list__list-item
         > div


### PR DESCRIPTION
# Hitas Pull Request

# Description

Moves the owners list of regulated housing companies under a drop-down heading, and at the end of the housing company details view.

## Test plan

- Check that the owners list of a regulated housing company can be accessed from the drop-down heading at the end of the housing company details view
- Check that you can download the excel report of the owners

## Tickets

This pull request resolves all or part of the following ticket(s): HT-663
