### PR TITLE
frontend: Change housing-company and apartment views to allow editing of non-regulated companies

### DIFF
--- a/frontend/src/features/apartment/components/ApartmentHeader.tsx
+++ b/frontend/src/features/apartment/components/ApartmentHeader.tsx
@@ -80,8 +80,8 @@ const ApartmentHeader = () => {
     const {pathname} = useLocation();
     const isApartmentSubPage = pathname.split("/").pop() !== params.apartmentId;
 
-    // Edit button is visible only if the housing company is regulated and user is on the apartment main page
-    const isEditButtonVisible = housingCompanyData?.regulation_status === "regulated" && !isApartmentSubPage;
+    // Edit button is visible only if the user is on the apartment main page
+    const isEditButtonVisible = !isApartmentSubPage;
 
     return (
         <Heading

--- a/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyDetailsPage.tsx
@@ -179,10 +179,7 @@ const LoadedHousingCompanyDetails = (): React.JSX.Element => {
                 <div className="list-wrapper list-wrapper--real-estates">
                     <Heading type="list">
                         <span>Kiinteistöt</span>
-                        <EditButton
-                            pathname="real-estates"
-                            disabled={housingCompany.regulation_status !== "regulated"}
-                        />
+                        <EditButton pathname="real-estates" />
                     </Heading>
 
                     <ul className="detail-list__list">
@@ -200,10 +197,7 @@ const LoadedHousingCompanyDetails = (): React.JSX.Element => {
                 <div className="list-wrapper list-wrapper--buildings">
                     <Heading type="list">
                         <span>Rakennukset</span>
-                        <EditButton
-                            pathname="buildings"
-                            disabled={housingCompany.regulation_status !== "regulated"}
-                        />
+                        <EditButton pathname="buildings" />
                     </Heading>
                     <ul className="detail-list__list">
                         {housingCompany.real_estates.flatMap((realEstate) => {

--- a/frontend/src/features/housingCompany/components/HousingCompanyHeader.tsx
+++ b/frontend/src/features/housingCompany/components/HousingCompanyHeader.tsx
@@ -89,8 +89,8 @@ const HousingCompanyHeaderContent = ({housingCompany}: {housingCompany: IHousing
     const {pathname} = useLocation();
     const isHousingCompanySubPage = pathname.split("/").pop() !== housingCompany.id;
 
-    // Edit button is visible only if the housing company is regulated and user is on the housing company main page
-    const isEditButtonVisible = housingCompany.regulation_status === "regulated" && !isHousingCompanySubPage;
+    // Edit button is visible only if the user is on the housing company main page
+    const isEditButtonVisible = !isHousingCompanySubPage;
 
     return (
         <>


### PR DESCRIPTION
# Hitas Pull Request

# Description

Released housing company details should still be editable by Hitas.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
- **Documentation**
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira

## Test plan

- Change a housing company to be not regulated, if there are none http://localhost:8080/admin/hitas/housingcompany/7/change/ Regulation status -> Released by Hitas.
- Go to the housing company in http://localhost:3000/housing-companies/ and check that it can be edited along with its housing and buildings.

## Tickets

HT-695
