### PR TITLE
Fix thirty_year_regulation_report calculation of difference

### DIFF
--- a/backend/hitas/services/thirty_year_regulation.py
+++ b/backend/hitas/services/thirty_year_regulation.py
@@ -801,19 +801,19 @@ def get_thirty_year_regulation_results_for_housing_company(
     )
     if results is None:
         raise HitasModelNotFound(ThirtyYearRegulationResultsRow)
-
     results.turned_30 = results.completion_date + relativedelta(years=30)
-    results.difference = results.adjusted_average_price_per_square_meter - Decimal(
-        results.parent.sales_data["price_by_area"].get(results.postal_code, 0)
+    price_by_area = Decimal(results.parent.sales_data["price_by_area"].get(results.postal_code, 0))
+    difference_from = max(
+        results.parent.surface_area_price_ceiling,
+        results.adjusted_average_price_per_square_meter,
     )
-
+    results.difference = difference_from - price_by_area
     return results
 
 
 def build_thirty_year_regulation_report_excel(results: ThirtyYearRegulationResults) -> Workbook:
     workbook = Workbook()
     worksheet: Worksheet = workbook.active
-
     column_headers = ReportColumns(
         display_name="Yhtiö",
         acquisition_price="Hankinta-arvo",

--- a/backend/hitas/tests/apis/thirty_year_regulation/test_api_thirty_year_regulation_report_calculation.py
+++ b/backend/hitas/tests/apis/thirty_year_regulation/test_api_thirty_year_regulation_report_calculation.py
@@ -1,0 +1,58 @@
+import datetime
+from decimal import Decimal
+
+import pytest
+
+from hitas.models.thirty_year_regulation import (
+    RegulationResult,
+    ThirtyYearRegulationResults,
+    ThirtyYearRegulationResultsRow,
+)
+from hitas.services.thirty_year_regulation import get_thirty_year_regulation_results_for_housing_company
+from hitas.tests.apis.thirty_year_regulation.utils import create_thirty_year_old_housing_company
+
+
+@pytest.mark.parametrize(
+    "surface_area_price_ceiling, adjusted_average_price_per_square_meter, expected_difference",
+    [
+        # ceiling lower, average higher, should use average
+        ("5000.00", "12000.00", "7100.00"),
+        # ceiling higher, average lower, should use ceiling
+        ("13000.00", "12000.00", "8100.00"),
+    ],
+)
+@pytest.mark.django_db
+def test__api__results_difference_logic(
+    surface_area_price_ceiling: str,
+    adjusted_average_price_per_square_meter: str,
+    expected_difference: str,
+):
+    old_housing_company = create_thirty_year_old_housing_company()
+    created_results = ThirtyYearRegulationResults.objects.create(
+        regulation_month=datetime.datetime(1993, 2, 1),
+        calculation_month=datetime.date(2023, 2, 1),
+        surface_area_price_ceiling=Decimal(surface_area_price_ceiling),
+        sales_data={
+            "external": {},
+            "internal": {"00001": {"2022Q4": {"price": 4900.0, "sale_count": 1}}},
+            "price_by_area": {"00001": 4900.0},
+        },
+        replacement_postal_codes=[],
+    )
+    ThirtyYearRegulationResultsRow.objects.create(
+        parent=created_results,
+        housing_company=old_housing_company,
+        completion_date=datetime.date(1993, 2, 1),
+        surface_area=Decimal("10.00"),
+        postal_code="00001",
+        realized_acquisition_price=Decimal("60000.00"),
+        unadjusted_average_price_per_square_meter=Decimal("6000.00"),
+        adjusted_average_price_per_square_meter=Decimal(adjusted_average_price_per_square_meter),
+        completion_month_index=Decimal("100.00"),
+        calculation_month_index=Decimal("200.00"),
+        regulation_result=RegulationResult.RELEASED_FROM_REGULATION,
+    )
+    results = get_thirty_year_regulation_results_for_housing_company(
+        old_housing_company.uuid, datetime.date(2023, 2, 1)
+    )
+    assert results.difference == Decimal(expected_difference)


### PR DESCRIPTION
# Hitas Pull Request

# Description

thirty_year_regulation_report difference field was calculated:

difference = average price - postal code area price

but if surface area price ceiling is higher than average price, it should instead use that:

difference = max(average price, ceiling price) - postal code area price

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Documentation**
  - [x] Test instructions have been written for the customer in the appropriate ticket in Jira

## Tickets

HT-710
