### PR TITLE
Add data migration to format existing property identifiers

### DIFF
--- a/backend/hitas/migrations/0013_format_real_estate_property_identifiers.py
+++ b/backend/hitas/migrations/0013_format_real_estate_property_identifiers.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+
+def format_real_estate_property_identifiers(apps, schema_editor):
+    RealEstate = apps.get_model("hitas", "RealEstate")
+    real_estates_missing_dashes = RealEstate.objects.exclude(property_identifier__contains="-")
+    for real_estate in real_estates_missing_dashes:
+        # Format `12312312341234` as `123-123-1234-1234`
+        real_estate.property_identifier = (
+            f"{real_estate.property_identifier[:3]}"
+            "-"
+            f"{real_estate.property_identifier[3:6]}"
+            "-"
+            f"{real_estate.property_identifier[6:10]}"
+            "-"
+            f"{real_estate.property_identifier[10:]}"
+        )
+        real_estate.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("hitas", "0012_nonobfuscatedowner"),
+    ]
+
+    operations = [
+        migrations.RunPython(format_real_estate_property_identifiers, reverse_code=migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
# Hitas Pull Request

# Description

`RealEstate.property_identifier` already has a validator `validate_property_id`, but this validator has not been enforced on existing data.

Added a data migration to format existing data.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
- **Database**
  - [x] Database migrations will work in the DEV & TEST environments
  - [x] initial.json has been verified to work with migrations
- **Documentation**
  - [ ] Test instructions have been written for the customer in the appropriate ticket in Jira

## Tickets

HT-697
