### PR TITLE
backend: Add fallback to sort by id descending, when multiple NULLs in results

### DIFF
--- a/backend/hitas/views/housing_company.py
+++ b/backend/hitas/views/housing_company.py
@@ -409,7 +409,7 @@ class HousingCompanyViewSet(HitasModelViewSet):
         return (
             HousingCompany.objects.select_related("postal_code")
             .annotate(_completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"))
-            .order_by(F("_completion_date").desc(nulls_last=False))
+            .order_by(F("_completion_date").desc(nulls_last=False), "-id")
         )
 
     def get_detail_queryset(self):


### PR DESCRIPTION

# Hitas Pull Request

# Description

Currently housing companies are sorted by max apartment completion date, NULLs first.

But there can be multiple pages of NULLs, that are not ordered among themselves.

Added fallback to sort by id descending in case of multiple NULLs.

## Tickets

HT-694
