### PR TITLE
frontend: Change condition of sale delete button to be always visible

### DIFF
--- a/frontend/src/features/apartment/ApartmentConditionsOfSalePage.tsx
+++ b/frontend/src/features/apartment/ApartmentConditionsOfSalePage.tsx
@@ -7,7 +7,7 @@ import {useFieldArray, useForm, useFormContext} from "react-hook-form";
 import {DeleteButton, GenericActionModal, Heading, NavigateBackButton, SaveButton} from "../../common/components";
 import {FormProviderForm, RelatedModelInput, SaveFormButton} from "../../common/components/forms";
 import {getConditionOfSaleGracePeriodLabel} from "../../common/localisation";
-import {IApartmentConditionOfSale, IApartmentDetails, IOwner, IOwnership} from "../../common/schemas";
+import {IApartmentConditionOfSale, IOwner, IOwnership} from "../../common/schemas";
 import {
     useCreateConditionOfSaleMutation,
     useDeleteConditionOfSaleMutation,
@@ -325,7 +325,7 @@ const DeleteConditionOfSaleButton = ({conditionOfSale}: {conditionOfSale: IApart
     );
 };
 
-const getConditionsOfSaleTableColumns = (apartment: IApartmentDetails) => {
+const getConditionsOfSaleTableColumns = () => {
     return [
         {
             key: "stair",
@@ -392,12 +392,7 @@ const getConditionsOfSaleTableColumns = (apartment: IApartmentDetails) => {
         {
             key: "delete",
             headerName: "",
-            transform: (obj) =>
-                !apartment.ownerships.find((ownership) => ownership.owner.id === obj.owner.id) && !obj.fulfilled ? (
-                    <DeleteConditionOfSaleButton conditionOfSale={obj} />
-                ) : (
-                    ""
-                ),
+            transform: (obj) => <DeleteConditionOfSaleButton conditionOfSale={obj} />,
         },
     ];
 };
@@ -413,7 +408,7 @@ const LoadedConditionsOfSalePage = () => {
                 {apartment.conditions_of_sale.length ? (
                     <Table
                         id="conditions-of-sale-table"
-                        cols={getConditionsOfSaleTableColumns(apartment)}
+                        cols={getConditionsOfSaleTableColumns()}
                         rows={apartment.conditions_of_sale}
                         indexKey="id"
                         variant="light"


### PR DESCRIPTION
# Hitas Pull Request

> **Käyttäjätarina:** Kun asunnolla on myyntiehto, asuntosihteerin pitäisi pystyä se poistamaan ilman myyntiehdon täyttämistä. Poisto tehtäisiin muokkaa myyntiehtoja -näytön kautta, rivin päädyssä olevan poista “painikkeen” kautta. 
> 
> Painikkeeseen tulee varmistus, että oletko varma, että haluat poistaa myyntiehdon → hyväsyminen.
> 
> **Hyväksymiskriteerit:** Myyntiehto on mahdollista poistaa varmistuksen kautta.

Condition of sale delete button was visible when a person is not listed as an owner for the apartment that the condition of sale points to **and** when the condition of sale has not yet been fulfilled.

Changed condition of sale delete button to be always visible.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-704
