### PR TITLE
Fix purchase date calculation overriding user input

### DIFF
--- a/frontend/src/features/apartment/ApartmentSalePage/fieldsets/MaximumPriceCalculationFieldSet/MaximumPriceCalculationExists.tsx
+++ b/frontend/src/features/apartment/ApartmentSalePage/fieldsets/MaximumPriceCalculationFieldSet/MaximumPriceCalculationExists.tsx
@@ -95,7 +95,6 @@ const MaximumPriceCalculationExists = () => {
             index: calculation.index,
         });
 
-        setValue("purchase_date", calculation.calculation_date);
         setValue("apartment_share_of_housing_company_loans", indexVariables.apartment_share_of_housing_company_loans);
     };
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

When user inputs a purchase date that falls within a calculation with start and end date, the start date of the calculation will override the user input. This happens only once even if the user then changes the date back to their original input, unless another date outside of the range is given.

There seem to be no use case where the input should be updated, instead the input is always the source for the data, both for existing and new calculations.

The fix here removes the setValue that overrides the user input.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-711
