### PR TITLE
Change download button to recalculate button in SurfaceAreaPriceCeiling view

### DIFF
--- a/frontend/src/features/functions/SurfaceAreaPriceCeilingTab.tsx
+++ b/frontend/src/features/functions/SurfaceAreaPriceCeilingTab.tsx
@@ -30,7 +30,11 @@ const DownloadSurfaceAreaPriceCeilingResultsButton = ({extraOnClickAction}: {ext
     );
 };
 
-const CalculateSurfaceAreaPriceCeilingButton = ({handleCalculateButtonOnClick, isLoading}) => {
+const CalculateSurfaceAreaPriceCeilingButton = ({
+    isCurrentQuarterCalculated,
+    handleCalculateButtonOnClick,
+    isLoading,
+}) => {
     return (
         <Button
             theme="black"
@@ -38,12 +42,17 @@ const CalculateSurfaceAreaPriceCeilingButton = ({handleCalculateButtonOnClick, i
             iconLeft={<IconCogwheels />}
             isLoading={isLoading}
         >
-            Laske rajaneliöhinta
+            {isCurrentQuarterCalculated ? "Laske rajaneliöhinta uudelleen" : "Laske rajaneliöhinta"}
         </Button>
     );
 };
 
-const CurrentMonthCalculationExists = ({sapcIndexData}) => {
+const CurrentMonthCalculationExists = ({
+    sapcIndexData,
+    isCurrentQuarterCalculated,
+    handleCalculateButtonOnClick,
+    isLoading,
+}) => {
     const currentMonth = today().slice(0, 7);
 
     return (
@@ -52,12 +61,16 @@ const CurrentMonthCalculationExists = ({sapcIndexData}) => {
                 <label>Rajaneliöhinta {getHitasQuarterFullLabel(currentMonth)}</label>
                 <span>{sapcIndexData.contents[0].value}</span>
             </div>
-            <DownloadSurfaceAreaPriceCeilingResultsButton />
+            <CalculateSurfaceAreaPriceCeilingButton
+                isCurrentQuarterCalculated={isCurrentQuarterCalculated}
+                handleCalculateButtonOnClick={handleCalculateButtonOnClick}
+                isLoading={isLoading}
+            />
         </>
     );
 };
 
-const CurrentMonthCalculationMissing = ({handleCalculateButtonOnClick, isLoading}) => {
+const CurrentMonthCalculationMissing = ({isCurrentQuarterCalculated, handleCalculateButtonOnClick, isLoading}) => {
     const currentMonth = today().slice(0, 7);
 
     return (
@@ -67,6 +80,7 @@ const CurrentMonthCalculationMissing = ({handleCalculateButtonOnClick, isLoading
                 rajaneliöhintaa.
             </p>
             <CalculateSurfaceAreaPriceCeilingButton
+                isCurrentQuarterCalculated={isCurrentQuarterCalculated}
                 handleCalculateButtonOnClick={handleCalculateButtonOnClick}
                 isLoading={isLoading}
             />
@@ -114,9 +128,15 @@ const SurfaceAreaPriceCeilingCalculationSection = ({sapcIndexData}) => {
             )}
             <div className="price-ceiling-calculation">
                 {isCurrentQuarterCalculated ? (
-                    <CurrentMonthCalculationExists sapcIndexData={sapcIndexData} />
+                    <CurrentMonthCalculationExists
+                        sapcIndexData={sapcIndexData}
+                        isCurrentQuarterCalculated={isCurrentQuarterCalculated}
+                        handleCalculateButtonOnClick={handleCalculateButtonOnClick}
+                        isLoading={isLoading}
+                    />
                 ) : (
                     <CurrentMonthCalculationMissing
+                        isCurrentQuarterCalculated={isCurrentQuarterCalculated}
                         handleCalculateButtonOnClick={handleCalculateButtonOnClick}
                         isLoading={isLoading}
                     />


### PR DESCRIPTION
# Hitas Pull Request

# Description

Recalculation of the latest SurfaceAreaPriceCeiling is sometimes required.

In addition, the download button in the same view is redundant, since the reports can be downloaded separately.

The solution here is to change the download button to recalculate button in SurfaceAreaPriceCeiling view.

The backend already works by going through the months in the current quarter and calculating their value. It seems that if the month exists already the value is updated.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-688
