### PR TITLE
Add owner merge modal and API endpoint

### DIFF
--- a/backend/hitas/tests/apis/test_api_owner.py
+++ b/backend/hitas/tests/apis/test_api_owner.py
@@ -593,6 +593,43 @@ def test__api__owner__update__remove_non_disclosure(api_client: HitasAPIClient):
     }
 
 
+@pytest.mark.parametrize(
+    ["should_use_second_owner_details", "expected_name", "expected_identifier", "expected_email"],
+    [
+        [False, "Name 1", "123-ID", "name1@mail.test"],
+        [True, "Name 2", "456-ID", "name2@mail.test"],
+    ],
+)
+@pytest.mark.django_db
+def test__api__owner__merge(
+    api_client: HitasAPIClient, should_use_second_owner_details, expected_name, expected_identifier, expected_email
+):
+    owner_1: Owner = OwnerFactory.create(name="Name 1", identifier="123-ID", email="name1@mail.test")
+    owner_2: Owner = OwnerFactory.create(name="Name 2", identifier="456-ID", email="name2@mail.test")
+    OwnershipFactory.create(owner=owner_1)
+    OwnershipFactory.create(owner=owner_2)
+
+    data = {
+        "first_owner_id": owner_1.uuid.hex,
+        "second_owner_id": owner_2.uuid.hex,
+        "should_use_second_owner_name": should_use_second_owner_details,
+        "should_use_second_owner_identifier": should_use_second_owner_details,
+        "should_use_second_owner_email": should_use_second_owner_details,
+    }
+
+    url = reverse("hitas:owner-merge")
+    response = api_client.post(url, data=data, format="json")
+    assert response.status_code == status.HTTP_204_NO_CONTENT, response.json()
+
+    assert Owner.objects.count() == 1
+    assert Owner.objects.first().ownerships.count() == 2
+
+    owner_1 = Owner.objects.first()
+    assert owner_1.name == expected_name
+    assert owner_1.identifier == expected_identifier
+    assert owner_1.email == expected_email
+
+
 # Delete tests
 
 

--- a/backend/hitas/views/owner.py
+++ b/backend/hitas/views/owner.py
@@ -1,11 +1,13 @@
 from typing import Any, Optional
 
-from rest_framework import status
+from rest_framework import serializers, status
+from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
+from hitas.exceptions import HitasModelNotFound
 from hitas.models import Owner, Ownership
 from hitas.models.owner import NonObfuscatedOwner
 from hitas.models.utils import (
@@ -13,6 +15,7 @@ from hitas.models.utils import (
     check_social_security_number,
     deobfuscate,
 )
+from hitas.services.validation import lookup_id_to_uuid
 from hitas.views.utils import HitasCharFilter, HitasFilterSet, HitasModelMixin, HitasModelSerializer, HitasModelViewSet
 
 
@@ -44,14 +47,30 @@ class OwnerSerializer(HitasModelSerializer):
         ]
 
 
+class OwnerMergeSerializer(serializers.Serializer):
+    first_owner_id = serializers.CharField()
+    second_owner_id = serializers.CharField()
+    should_use_second_owner_name = serializers.BooleanField()
+    should_use_second_owner_identifier = serializers.BooleanField()
+    should_use_second_owner_email = serializers.BooleanField()
+
+
 class OwnerFilterSet(HitasFilterSet):
     name = HitasCharFilter(lookup_expr="icontains")
     identifier = HitasCharFilter(lookup_expr="icontains")
     email = HitasCharFilter(lookup_expr="iexact")
+    search = HitasCharFilter(method="filter_search")
 
     class Meta:
         model = Owner
         fields = ["name", "identifier", "email"]
+
+    def filter_search(self, queryset, name, value):
+        return (
+            queryset.filter(name__icontains=value)
+            | queryset.filter(identifier__icontains=value)
+            | queryset.filter(email__icontains=value)
+        )
 
 
 class OwnerViewSet(HitasModelViewSet):
@@ -74,6 +93,31 @@ class OwnerViewSet(HitasModelViewSet):
             )
 
         self.perform_destroy(instance)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(detail=False, methods=["post"])
+    def merge(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        serializer = OwnerMergeSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        first_owner_uuid = lookup_id_to_uuid(data["first_owner_id"], Owner)
+        second_owner_uuid = lookup_id_to_uuid(data["second_owner_id"], Owner)
+        try:
+            first_owner = Owner.objects.get(uuid=first_owner_uuid)
+            second_owner = Owner.objects.get(uuid=second_owner_uuid)
+        except Owner.DoesNotExist as error:
+            raise HitasModelNotFound(Owner) from error
+        # Transfer ownerships from second owner to first owner
+        Ownership.objects.filter(owner=second_owner).update(owner=first_owner)
+        # Update first owner with data from second owner if requested
+        if data["should_use_second_owner_name"]:
+            first_owner.name = second_owner.name
+        if data["should_use_second_owner_identifier"]:
+            first_owner.identifier = second_owner.identifier
+        if data["should_use_second_owner_email"]:
+            first_owner.email = second_owner.email
+        first_owner.save()
+        second_owner.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @staticmethod

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2106,6 +2106,14 @@ paths:
             type: string
             minLength: 2
             example: matti.meikalainen@example.com
+        - name: search
+          description: Search owners whose name, identifier or email address match the given search string (case-insensitive)
+          required: false
+          in: query
+          schema:
+            type: string
+            minLength: 2
+            example: Matti
         - $ref: "#/components/parameters/PagingLimitParameter"
         - $ref: "#/components/parameters/PagingPageParameter"
       responses:
@@ -2289,6 +2297,52 @@ paths:
           $ref: "#/components/responses/NotFound"
         "406":
           $ref: "#/components/responses/NotAcceptable"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  # Owner merging
+
+  /api/v1/owners/merge:
+    post:
+      description: Merge two owners removing the duplicate one. Ownerships are transferred from the second owner to the first owner and the second owner is removed.
+      operationId: merge-owners
+      tags:
+        - Owners
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                first_owner_id:
+                  type: string
+                  description: The ID of the first owner
+                second_owner_id:
+                  type: string
+                  description: The ID of the second owner
+                should_use_second_owner_name:
+                  type: boolean
+                  description: Flag indicating whether to update the name of the first owner using the name of the second owner
+                should_use_second_owner_identifier:
+                  type: boolean
+                  description: Flag indicating whether to update the identifier of the first owner using the identifier of the second owner
+                should_use_second_owner_email:
+                  type: boolean
+                  description: Flag indicating whether to update the email of the first owner using the email of the second owner
+      responses:
+        "204":
+          description: Successfully merged owner
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "406":
+          $ref: "#/components/responses/NotAcceptable"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
 

--- a/frontend/src/common/components/OwnershipList.tsx
+++ b/frontend/src/common/components/OwnershipList.tsx
@@ -44,7 +44,7 @@ const OwnershipList = () => {
                                     label="Omistaja"
                                     required
                                     queryFunction={useGetOwnersQuery}
-                                    relatedModelSearchField="name"
+                                    relatedModelSearchField="search"
                                     name={`ownerships.${index}.owner`}
                                     transform={(obj) => formatOwner(obj)}
                                     RelatedModelMutateComponent={OwnerMutateForm}

--- a/frontend/src/common/components/mutateComponents/OwnerMergeMutateForm.tsx
+++ b/frontend/src/common/components/mutateComponents/OwnerMergeMutateForm.tsx
@@ -1,0 +1,255 @@
+import {Button, Dialog, IconArrowLeft} from "hds-react";
+import {TextInput as HDSTextInput, RadioButton} from "hds-react";
+import {useRef, useState} from "react";
+import {FormProviderForm, RelatedModelInput} from "../forms";
+import {useGetOwnersQuery, useMergeOwnersMutation} from "../../services";
+import {formatOwner, hdsToast} from "../../utils";
+import {useForm} from "react-hook-form";
+import {IOwner, IOwnerMergeData} from "../../schemas";
+import {SaveButton} from "../index";
+
+export function OwnerMergeForm({firstOwner, cancelAction, closeModal}) {
+    const [mergeOwners, {isLoading: isMergeOwnersLoading}] = useMergeOwnersMutation();
+    const [isFirstOwnerNameSelected, setIsFirstOwnerNameSelected] = useState(null as boolean | null);
+    const [isFirstOwnerIdentifierSelected, setIsFirstOwnerIdentifierSelected] = useState(null as boolean | null);
+    const [isFirstOwnerEmailSelected, setIsFirstOwnerEmailSelected] = useState(null as boolean | null);
+
+    const formObject = useForm({
+        defaultValues: {
+            secondOwner: null as IOwner | null,
+        },
+        mode: "all",
+    });
+    const formRef = useRef<HTMLFormElement>(null);
+    const secondOwner = formObject.watch("secondOwner");
+
+    const handleSave = () => {
+        if (secondOwner === null) {
+            hdsToast.error("Valitse yhdistettävä omistaja!");
+            return;
+        }
+        if (isFirstOwnerNameSelected === null) {
+            hdsToast.error("Valitse säilytettävä nimi!");
+            return;
+        }
+        if (isFirstOwnerIdentifierSelected === null) {
+            hdsToast.error("Valitse säilytettävä henkilö- tai Y-tunnus!");
+            return;
+        }
+        if (isFirstOwnerEmailSelected === null) {
+            hdsToast.error("Valitse säilytettävä sähköpostiosoite!");
+            return;
+        }
+        const data: IOwnerMergeData = {
+            first_owner_id: firstOwner.id,
+            second_owner_id: secondOwner.id,
+            should_use_second_owner_name: isFirstOwnerNameSelected === false,
+            should_use_second_owner_identifier: isFirstOwnerIdentifierSelected === false,
+            should_use_second_owner_email: isFirstOwnerEmailSelected === false,
+        };
+        mergeOwners({data})
+            .unwrap()
+            .then((_response) => {
+                hdsToast.success("Omistajan tiedot tallennettu onnistuneesti!");
+                closeModal();
+            })
+            .catch((_error) => {
+                hdsToast.error("Virhe omistajan tietojen tallentamisessa!");
+            });
+    };
+
+    return (
+        <FormProviderForm
+            formObject={formObject}
+            formRef={formRef}
+            onSubmit={() => {}}
+            onSubmitError={() => {}}
+        >
+            <>
+                <div className="row owners-container-row">
+                    <div className="column owners-column">
+                        <div>
+                            <div className="first-owner-heading-label">Valittu omistaja</div>
+                            <div className="first-owner-heading">{formatOwner(firstOwner)}</div>
+                        </div>
+                    </div>
+                    <div className="column owners-column">
+                        <div>
+                            <RelatedModelInput
+                                label="Hae yhdistettävä omistaja"
+                                required
+                                queryFunction={useGetOwnersQuery}
+                                relatedModelSearchField="search"
+                                name="secondOwner"
+                                transform={(obj) => formatOwner(obj)}
+                            />
+                        </div>
+                    </div>
+                </div>
+                <h2 className="owner-merge-details-heading">Valitse säilytettävät tiedot</h2>
+                <div className="row owners-container-row">
+                    <div className="column owners-column">
+                        <div className="row owner-row">
+                            <label
+                                className="owner-row-overlay-label"
+                                htmlFor="first-owner-radio-name"
+                            />
+                            <RadioButton
+                                id="first-owner-radio-name"
+                                name="owner-radio-name"
+                                checked={isFirstOwnerNameSelected === true}
+                                onChange={() => setIsFirstOwnerNameSelected(true)}
+                            />
+                            <HDSTextInput
+                                id="first-owner-name"
+                                name="first-owner-name"
+                                label="Nimi"
+                                value={firstOwner.name}
+                                disabled
+                            />
+                        </div>
+                        <div className="row owner-row">
+                            <label
+                                className="owner-row-overlay-label"
+                                htmlFor="first-owner-radio-identifier"
+                            />
+                            <RadioButton
+                                id="first-owner-radio-identifier"
+                                name="owner-radio-identifier"
+                                checked={isFirstOwnerIdentifierSelected === true}
+                                onChange={() => setIsFirstOwnerIdentifierSelected(true)}
+                            />
+                            <HDSTextInput
+                                id="first-owner-identifier"
+                                name="first-owner-identifier"
+                                label="Henkilö- tai Y-tunnus"
+                                value={firstOwner.identifier}
+                                disabled
+                            />
+                        </div>
+                        <div className="row owner-row">
+                            <label
+                                className="owner-row-overlay-label"
+                                htmlFor="first-owner-radio-email"
+                            />
+                            <RadioButton
+                                id="first-owner-radio-email"
+                                name="owner-radio-email"
+                                checked={isFirstOwnerEmailSelected === true}
+                                onChange={() => setIsFirstOwnerEmailSelected(true)}
+                            />
+                            <HDSTextInput
+                                id="first-owner-email"
+                                name="first-owner-email"
+                                label="Sähköpostiosoite"
+                                value={firstOwner.email}
+                                disabled
+                            />
+                        </div>
+                    </div>
+                    <div className="column owners-column">
+                        <div className="row owner-row">
+                            <label
+                                className="owner-row-overlay-label"
+                                htmlFor="second-owner-radio-name"
+                            />
+                            <HDSTextInput
+                                id="second-owner-name"
+                                name="second-owner-name"
+                                label="Nimi"
+                                value={secondOwner?.name ?? ""}
+                                disabled
+                            />
+                            <RadioButton
+                                id="second-owner-radio-name"
+                                name="owner-radio-name"
+                                checked={isFirstOwnerNameSelected === false}
+                                onChange={() => setIsFirstOwnerNameSelected(false)}
+                            />
+                        </div>
+                        <div className="row owner-row">
+                            <label
+                                className="owner-row-overlay-label"
+                                htmlFor="second-owner-radio-identifier"
+                            />
+                            <HDSTextInput
+                                id="second-owner-identifier"
+                                name="second-owner-identifier"
+                                label="Henkilö- tai Y-tunnus"
+                                value={secondOwner?.identifier ?? ""}
+                                disabled
+                            />
+                            <RadioButton
+                                id="second-owner-radio-identifier"
+                                name="owner-radio-identifier"
+                                checked={isFirstOwnerIdentifierSelected === false}
+                                onChange={() => setIsFirstOwnerIdentifierSelected(false)}
+                            />
+                        </div>
+                        <div className="row owner-row">
+                            <label
+                                className="owner-row-overlay-label"
+                                htmlFor="second-owner-radio-email"
+                            />
+                            <HDSTextInput
+                                id="second-owner-email"
+                                name="second-owner-email"
+                                label="Sähköpostiosoite"
+                                value={secondOwner?.email ?? ""}
+                                disabled
+                            />
+                            <RadioButton
+                                id="second-owner-radio-email"
+                                name="owner-radio-email"
+                                checked={isFirstOwnerEmailSelected === false}
+                                onChange={() => setIsFirstOwnerEmailSelected(false)}
+                            />
+                        </div>
+                    </div>
+                </div>
+                <div className="row row--buttons">
+                    <Button
+                        theme="black"
+                        iconLeft={<IconArrowLeft />}
+                        onClick={cancelAction}
+                    >
+                        Peruuta
+                    </Button>
+                    <SaveButton
+                        onClick={handleSave}
+                        isLoading={isMergeOwnersLoading}
+                        buttonText="Tallenna"
+                    />
+                </div>
+            </>
+        </FormProviderForm>
+    );
+}
+
+export const OwnerMergeModal = ({firstOwner, closeModal, isVisible, setIsVisible}) => {
+    return (
+        <Dialog
+            id="owner-merge-modal"
+            aria-labelledby="owner-merge-modal__title"
+            className="owner-merge-modal"
+            closeButtonLabelText="args.closeButtonLabelText"
+            isOpen={isVisible}
+            close={closeModal}
+            theme={{
+                "--accent-line-color": "var(--color-black-80)",
+            }}
+        >
+            <Dialog.Header
+                id="owner-merge-modal__title"
+                title="Omistajien yhdistäminen"
+            />
+            <Dialog.Content>
+                <OwnerMergeForm
+                    firstOwner={firstOwner}
+                    cancelAction={() => setIsVisible(false)}
+                    closeModal={closeModal}
+                />
+            </Dialog.Content>
+        </Dialog>
+    );
+};

--- a/frontend/src/common/components/mutateComponents/OwnerMutateForm.tsx
+++ b/frontend/src/common/components/mutateComponents/OwnerMutateForm.tsx
@@ -1,6 +1,6 @@
 import {zodResolver} from "@hookform/resolvers/zod/dist/zod";
-import {Button, IconArrowLeft} from "hds-react";
-import {useEffect, useRef} from "react";
+import {Button, IconArrowLeft, IconUser} from "hds-react";
+import {useEffect, useRef, useState} from "react";
 import {useForm} from "react-hook-form";
 import {z} from "zod";
 import {IOwner, OwnerSchema} from "../../schemas";
@@ -8,6 +8,7 @@ import {useSaveOwnerMutation} from "../../services";
 import {hdsToast, setAPIErrorsForFormFields, validateBusinessId, validateSocialSecurityNumber} from "../../utils";
 import {CheckboxInput, SaveFormButton, TextInput} from "../forms";
 import FormProviderForm from "../forms/FormProviderForm";
+import {OwnerMergeModal} from "./OwnerMergeMutateForm";
 
 interface IOwnerMutateForm {
     defaultObject?: IOwner;
@@ -23,6 +24,7 @@ export default function OwnerMutateForm({
 }: IOwnerMutateForm) {
     const isInitialIdentifierValid = owner !== undefined && validateSocialSecurityNumber(owner.identifier);
     const [saveOwner, {isLoading: isSaveOwnerLoading}] = useSaveOwnerMutation();
+    const [isOwnerMergeModalVisible, setIsOwnerMergeModalVisible] = useState(false);
 
     const closeModal = () => {
         closeModalAction();
@@ -107,57 +109,80 @@ export default function OwnerMutateForm({
     }, []);
 
     return (
-        <FormProviderForm
-            formObject={formObject}
-            formRef={formRef}
-            onSubmit={onFormSubmitValid}
-            onSubmitError={onFormSubmitInvalid}
-        >
-            <TextInput
-                name="name"
-                label="Nimi"
-                required
-            />
-            <TextInput
-                name="identifier"
-                label="Henkilö- tai Y-tunnus"
-                required
-            />
-            <TextInput
-                name="email"
-                label="Sähköpostiosoite"
-            />
-            <CheckboxInput
-                label="Turvakielto"
-                name="non_disclosure"
-                tooltipText="Asuntolistauksessa turvakiellon alaisen omistajan nimen tilalla näytetään ***, muualla käyttöliittymässä nimen alkuun lisätään ***. Raporteissa ja PDFissä nimeä ei näytetä."
-            />
-            {
-                // show warning when saving malformed identifier is enabled
-                isInvalidIdentifierSaveWarningShown && !isSaveDisabled && (
-                    <p className="error-message">
-                        '{formObject.watch("identifier")}' on virheellinen henkilö- tai Y-tunnus.
-                        <br />
-                        Tallennetaanko silti?
-                    </p>
-                )
-            }
-            <div className="row row--buttons">
-                <Button
-                    theme="black"
-                    iconLeft={<IconArrowLeft />}
-                    onClick={closeModal}
-                >
-                    Peruuta
-                </Button>
-
-                <SaveFormButton
-                    formRef={formRef}
-                    isLoading={isSaveOwnerLoading}
-                    buttonText={isInvalidIdentifierSaveWarningShown ? "Tallenna silti" : "Tallenna"}
-                    disabled={isSaveDisabled}
+        <>
+            <FormProviderForm
+                formObject={formObject}
+                formRef={formRef}
+                onSubmit={onFormSubmitValid}
+                onSubmitError={onFormSubmitInvalid}
+            >
+                <TextInput
+                    name="name"
+                    label="Nimi"
+                    required
                 />
-            </div>
-        </FormProviderForm>
+                <TextInput
+                    name="identifier"
+                    label="Henkilö- tai Y-tunnus"
+                    required
+                />
+                <TextInput
+                    name="email"
+                    label="Sähköpostiosoite"
+                />
+                <CheckboxInput
+                    label="Turvakielto"
+                    name="non_disclosure"
+                    tooltipText="Asuntolistauksessa turvakiellon alaisen omistajan nimen tilalla näytetään ***, muualla käyttöliittymässä nimen alkuun lisätään ***. Raporteissa ja PDFissä nimeä ei näytetä."
+                />
+                {
+                    // show warning when saving malformed identifier is enabled
+                    isInvalidIdentifierSaveWarningShown && !isSaveDisabled && (
+                        <p className="error-message">
+                            '{formObject.watch("identifier")}' on virheellinen henkilö- tai Y-tunnus.
+                            <br />
+                            Tallennetaanko silti?
+                        </p>
+                    )
+                }
+                <div className="row row--buttons">
+                    <Button
+                        theme="black"
+                        iconLeft={<IconArrowLeft />}
+                        onClick={closeModal}
+                    >
+                        Peruuta
+                    </Button>
+
+                    {owner !== undefined && (
+                        <Button
+                            theme="black"
+                            iconLeft={<IconUser />}
+                            onClick={() => {
+                                setIsOwnerMergeModalVisible(true);
+                            }}
+                        >
+                            Yhdistä
+                        </Button>
+                    )}
+
+                    <SaveFormButton
+                        formRef={formRef}
+                        isLoading={isSaveOwnerLoading}
+                        buttonText={isInvalidIdentifierSaveWarningShown ? "Tallenna silti" : "Tallenna"}
+                        disabled={isSaveDisabled}
+                    />
+                </div>
+            </FormProviderForm>
+            <OwnerMergeModal
+                firstOwner={owner}
+                closeModal={() => {
+                    closeModal();
+                    setIsOwnerMergeModalVisible(false);
+                }}
+                isVisible={isOwnerMergeModalVisible}
+                setIsVisible={setIsOwnerMergeModalVisible}
+            />
+        </>
     );
 }

--- a/frontend/src/common/schemas/owner.ts
+++ b/frontend/src/common/schemas/owner.ts
@@ -104,3 +104,12 @@ export const FilterOwnersQuerySchema = object({
     page: number().int().optional(),
 });
 export type IFilterOwnersQuery = z.infer<typeof FilterOwnersQuerySchema>;
+
+export const OwnerMergeDataSchema = object({
+    first_owner_id: APIIdString,
+    second_owner_id: APIIdString,
+    should_use_second_owner_name: boolean(),
+    should_use_second_owner_identifier: boolean(),
+    should_use_second_owner_email: boolean(),
+});
+export type IOwnerMergeData = z.infer<typeof OwnerMergeDataSchema>;

--- a/frontend/src/common/services/hitasApi/codes.ts
+++ b/frontend/src/common/services/hitasApi/codes.ts
@@ -10,6 +10,7 @@ import {
     IIndexQuery,
     IIndexResponse,
     IOwner,
+    IOwnerMergeData,
     IOwnersResponse,
     IPostalCodeResponse,
     IPropertyManager,
@@ -136,7 +137,22 @@ const ownerApi = hitasApi.injectEndpoints({
                 }
             },
         }),
+        mergeOwners: builder.mutation<IOwner, {data: IOwnerMergeData}>({
+            query: ({data}) => ({
+                url: `owners/merge`,
+                method: "POST",
+                body: data,
+            }),
+            invalidatesTags: (result, error) => {
+                return safeInvalidate(error, [
+                    {type: "Owner"},
+                    {type: "ObfuscatedOwners"},
+                    {type: "ObfuscatedOwner"},
+                    {type: "Apartment"},
+                ]);
+            },
+        }),
     }),
 });
 
-export const {useGetOwnersQuery, useSaveOwnerMutation} = ownerApi;
+export const {useGetOwnersQuery, useSaveOwnerMutation, useMergeOwnersMutation} = ownerApi;

--- a/frontend/src/styles/components/_OwnerMerge.sass
+++ b/frontend/src/styles/components/_OwnerMerge.sass
@@ -1,0 +1,58 @@
+@use '../imports' as *
+
+.owner-merge-modal
+  &.owner-merge-modal
+    width: 1000px
+
+  .owner-merge-details-heading
+    margin-top: 0
+    font-size: var(--fontsize-heading-xs)
+
+  .owners-container-row
+    gap: $spacing-m
+
+  .owners-column
+    gap: $spacing-m
+    flex-grow: 1
+    width: 100%
+
+  .owner-row
+    position: relative
+    align-items: center
+    gap: $spacing-xs
+
+    input[disabled]
+      color: inherit
+
+    .owner-row-overlay-label
+      position: absolute
+      top: 0
+      left: 0
+      right: 0
+      bottom: 0
+      width: auto
+      height: auto
+      cursor: pointer
+      z-index: 1
+
+    [class*="TextInput-module_root"]
+      flex-grow: 1
+
+    [class*="RadioButton-module_radioButton"]
+      margin-top: 18px
+
+    // Ref HDS-2142
+    label[class*="RadioButton-module_label"]
+      padding-left: var(--size)
+
+  .first-owner-heading-label
+    margin-bottom: 4px
+    font-weight: 700
+    padding: 0 calc(var(--spacing-xs) + 24px)
+
+  .first-owner-heading
+    display: flex
+    align-items: center
+    height: 58px
+    padding: 0 calc(var(--spacing-xs) + 24px)
+    font-size: 18px

--- a/frontend/src/styles/components/index.sass
+++ b/frontend/src/styles/components/index.sass
@@ -13,4 +13,5 @@
 @forward "HousingCompanyPage"
 @forward "ImprovementsTable"
 @forward "OwnershipsList"
+@forward "OwnerMerge"
 @forward "Reports"


### PR DESCRIPTION
# Hitas Pull Request

# Description

There can be duplicate Owners for example when the same Owner has been entered with date-of-birth only and with full identifier.

This pull request adds functionality for merging such Owners.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Documentation**
  - [x] OpenAPI definitions have been updated

## Screenshots

![image](https://github.com/City-of-Helsinki/hitas/assets/8503840/b8ed9d85-2526-44e3-b752-d96cc623cfff)

![image](https://github.com/City-of-Helsinki/hitas/assets/8503840/f3bd3183-15ef-4dd6-8d10-b9b6c87a101c)

![image](https://github.com/City-of-Helsinki/hitas/assets/8503840/68b98d59-84b3-4fce-aa5a-f45af304c693)

## Tickets

HT-706
