### PR TITLE
 Change sapc_calculation maximum_price to have two decimal places in maximum price report

### DIFF
--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -251,7 +251,7 @@
             <td></td>
             <td></td>
             <td></td>
-            <td class="text-right">{{ sapc_calculation.maximum_price|intcomma(0) }} euroa</td>
+            <td class="text-right">{{ sapc_calculation.maximum_price|intcomma }} euroa</td>
         </tr>
     </table>
 {% endmacro %}


### PR DESCRIPTION
# Hitas Pull Request

# Description

Change sapc_calculation maximum_price to have two decimal places in maximum price report.

Most fields already have this, but this field did not.

## Tickets

HT-719
