### PR TITLE
Change regulation status released label

### DIFF
--- a/frontend/src/common/localisation.ts
+++ b/frontend/src/common/localisation.ts
@@ -34,7 +34,7 @@ export const getHousingCompanyRegulationStatusName = (state) => {
         case "regulated":
             return "Ei vapautunut";
         case "released_by_hitas":
-            return "Vapautunut 30v vertailussa";
+            return "Vapautunut vertailussa";
         case "released_by_plot_department":
             return "Vapautunut tontit-yksikön päätöksellä";
         default:


### PR DESCRIPTION
# Hitas Pull Request

# Description

Change `released_by_hitas` in `getHousingCompanyRegulationStatusName` to match both 30 year regulation and half hitas regulation. Previously it referred only to 30 year regulation but was used for both.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-717
