### PR TITLE
Change aparment sale deletion condition from 3 months to 12 months

### DIFF
--- a/backend/hitas/tests/apis/test_api_apartment_sale.py
+++ b/backend/hitas/tests/apis/test_api_apartment_sale.py
@@ -1724,10 +1724,10 @@ def test__api__apartment_sale__delete__under_three_months(api_client: HitasAPICl
 
 
 @pytest.mark.django_db
-def test__api__apartment_sale__delete__over_three_months(api_client: HitasAPIClient, freezer):
+def test__api__apartment_sale__delete__over_threshold(api_client: HitasAPIClient, freezer):
     freezer.move_to("2023-01-01")
 
-    under_three_months = timezone.now().date() - relativedelta(months=3) - relativedelta(days=1)
+    under_three_months = timezone.now().date() - relativedelta(months=12) - relativedelta(days=1)
 
     sale: ApartmentSale = ApartmentSaleFactory.create(
         purchase_date=under_three_months,
@@ -1754,10 +1754,10 @@ def test__api__apartment_sale__delete__over_three_months(api_client: HitasAPICli
 
 
 @pytest.mark.django_db
-def test__api__apartment_sale__delete__over_three_months__condition_of_sale__new(api_client: HitasAPIClient, freezer):
+def test__api__apartment_sale__delete__over_threshold__condition_of_sale__new(api_client: HitasAPIClient, freezer):
     freezer.move_to("2023-01-01")
 
-    under_three_months = timezone.now().date() - relativedelta(months=3) - relativedelta(days=1)
+    under_three_months = timezone.now().date() - relativedelta(months=12) - relativedelta(days=1)
 
     sale: ApartmentSale = ApartmentSaleFactory.create(
         purchase_date=under_three_months,
@@ -1778,10 +1778,10 @@ def test__api__apartment_sale__delete__over_three_months__condition_of_sale__new
 
 
 @pytest.mark.django_db
-def test__api__apartment_sale__delete__over_three_months__condition_of_sale__old(api_client: HitasAPIClient, freezer):
+def test__api__apartment_sale__delete__over_threshold__condition_of_sale__old(api_client: HitasAPIClient, freezer):
     freezer.move_to("2023-01-01")
 
-    under_three_months = timezone.now().date() - relativedelta(months=3) - relativedelta(days=1)
+    under_three_months = timezone.now().date() - relativedelta(months=12) - relativedelta(days=1)
 
     sale: ApartmentSale = ApartmentSaleFactory.create(
         purchase_date=under_three_months,

--- a/backend/hitas/views/apartment_sale.py
+++ b/backend/hitas/views/apartment_sale.py
@@ -202,9 +202,9 @@ class ApartmentSaleViewSet(HitasModelViewSet):
             comparison_date = max(instance.apartment.completion_date, instance.purchase_date)
 
             # The sale can be cancelled:
-            # - Within 3 months of the comparison date
+            # - Within 12 months of the comparison date
             # - If the apartment has conditions of sale, where it is considered the new apartment
-            if comparison_date < timezone.now().date() - relativedelta(months=3) and not any(
+            if comparison_date < timezone.now().date() - relativedelta(months=12) and not any(
                 ownership.conditions_of_sale_new.exists() for ownership in instance.ownerships.all()
             ):
                 raise ModelConflict("This sale can no longer be cancelled", error_code="invalid")

--- a/frontend/src/features/apartment/ApartmentDetailsPage/components/RemoveApartmentLatestSaleModalButton.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage/components/RemoveApartmentLatestSaleModalButton.tsx
@@ -18,9 +18,6 @@ const canApartmentSaleBeDeleted = (apartment) => {
     // First sale can be removed before apartment is completed (Completion date is in the future)
     if (today < completionDate) return true;
 
-    const threeMonthsAgo = new Date(today);
-    threeMonthsAgo.setMonth(today.getMonth() - 3);
-
     const comparisonDate = [
         completionDate,
         new Date(apartment.prices.first_purchase_date),
@@ -28,9 +25,6 @@ const canApartmentSaleBeDeleted = (apartment) => {
     ]
         .sort((a, b) => a.getTime() - b.getTime())
         .reverse()[0];
-
-    // Apartment sale can be removed within 3 months of the sale or completion date
-    if (comparisonDate > threeMonthsAgo) return true;
 
     // Apartment sale can be removed if there are conditions of sale, and this is the new apartment
     if (apartment.conditions_of_sale?.length > 0) {
@@ -40,7 +34,7 @@ const canApartmentSaleBeDeleted = (apartment) => {
 
         // If the comparison date is within a year of today, it's most likely the new apartment
         const oneYearAgo = new Date(today);
-        threeMonthsAgo.setFullYear(today.getFullYear() - 1);
+        oneYearAgo.setFullYear(today.getFullYear() - 1);
         if (comparisonDate > oneYearAgo) return true;
     }
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

Sales are sometimes input later than 3 months after the fact. This can cause them to be immediately undeletable. As a workaround for now extend deletion from 3 to 12 months.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-718
