### PR TITLE
Change half hitas first sale after release from regulation to be allowed

### DIFF
--- a/backend/hitas/views/apartment_sale.py
+++ b/backend/hitas/views/apartment_sale.py
@@ -88,7 +88,12 @@ class ApartmentSaleCreateSerializer(HitasModelSerializer):
             raise HitasModelNotFound(model=Apartment) from error
 
         if apartment.housing_company.regulation_status != RegulationStatus.REGULATED:
-            raise ModelConflict("Cannot sell an unregulated apartment.", error_code="invalid")
+            hitas_type = apartment.housing_company.hitas_type
+            if hitas_type == HitasType.HALF_HITAS and apartment.latest_purchase_date is None:
+                # Allow half hitas sales after release from regulation if the sale is a first sale.
+                pass
+            else:
+                raise ModelConflict("Cannot sell an unregulated apartment.", error_code="invalid")
 
         if apartment.housing_company.hitas_type == HitasType.HALF_HITAS and apartment.latest_purchase_date is not None:
             raise ModelConflict("Cannot re-sell a half-hitas housing company apartment.", error_code="invalid")

--- a/frontend/src/features/apartment/ApartmentDetailsPage/components/ApartmentConditionsOfSaleCard.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage/components/ApartmentConditionsOfSaleCard.tsx
@@ -25,6 +25,9 @@ const ApartmentSalesPageLinkButton = ({
     apartment: IApartmentDetails;
 }) => {
     let apartmentCantBeSoldErrorMessage;
+    const isCreateButtonEnabled =
+        housingCompany.regulation_status === "regulated" ||
+        (housingCompany.hitas_type === "half_hitas" && apartment.prices.first_purchase_date === null);
 
     if (!apartment.surface_area) {
         apartmentCantBeSoldErrorMessage = "Asunnolta puuttuu pinta-ala";
@@ -41,14 +44,18 @@ const ApartmentSalesPageLinkButton = ({
     } else if (apartment.prices.first_purchase_date && housingCompany.hitas_type === "half_hitas") {
         apartmentCantBeSoldErrorMessage = "Puolihitas-taloyhtiön asuntoa ei voida jälleenmyydä";
     } else if (housingCompany.regulation_status !== "regulated") {
-        apartmentCantBeSoldErrorMessage = "Vapautetun taloyhtiön asuntoa ei voida jälleenmyydä";
+        if (housingCompany.hitas_type === "half_hitas" && apartment.prices.first_purchase_date === null) {
+            // Allow half hitas sales after release from regulation if the sale is a first sale.
+        } else {
+            apartmentCantBeSoldErrorMessage = "Vapautetun taloyhtiön asuntoa ei voida jälleenmyydä";
+        }
     }
 
     if (apartmentCantBeSoldErrorMessage) {
         return (
             <ApartmentSaleButton
                 onClick={() => hdsToast.error(apartmentCantBeSoldErrorMessage)}
-                disabled={housingCompany.regulation_status !== "regulated"}
+                disabled={!isCreateButtonEnabled}
             />
         );
     } else {
@@ -56,7 +63,7 @@ const ApartmentSalesPageLinkButton = ({
             <Link to="sales">
                 <ApartmentSaleButton
                     onClick={undefined}
-                    disabled={housingCompany.regulation_status !== "regulated"}
+                    disabled={!isCreateButtonEnabled}
                 />
             </Link>
         );


### PR DESCRIPTION
# Hitas Pull Request

# Description

In general, sales are not allowed in housing companies that have been released from regulation.

Half hitas companies need an exception to allow first sale after release from regulation.

This PR adds that exception.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added

## Tickets

HT-713
