### PR TITLE
Add regulated ownerships report

### DIFF
--- a/backend/hitas/services/owner.py
+++ b/backend/hitas/services/owner.py
@@ -100,6 +100,27 @@ def obfuscate_owners_without_regulated_apartments() -> list[OwnerT]:
     return obfuscated_owners
 
 
+def find_regulated_ownerships() -> list[Ownership]:
+    return list(
+        Ownership.objects.select_related(
+            "owner",
+            "sale__apartment__building__real_estate__housing_company__postal_code",
+            "sale__apartment__building__real_estate__housing_company",
+        )
+        .filter(
+            sale__apartment__building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
+        )
+        .exclude(
+            sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.HALF_HITAS,
+        )
+        .order_by(
+            "owner__name",
+            "sale__apartment__building__real_estate__housing_company__postal_code__value",
+            "sale__apartment__street_address",
+        )
+    )
+
+
 def find_owners_with_multiple_ownerships() -> list[OwnershipWithApartmentCount]:
     return list(
         Ownership.objects.select_related(

--- a/backend/hitas/tests/apis/test_api_reports.py
+++ b/backend/hitas/tests/apis/test_api_reports.py
@@ -1441,6 +1441,17 @@ def test__api__multiple_ownerships_report__no_owners(api_client: HitasAPIClient)
 
 
 @pytest.mark.django_db
+def test__api__regulated_ownerships_report__no_owners(api_client: HitasAPIClient):
+    url = reverse("hitas:regulated-ownerships-report-list")
+    response: HttpResponse = api_client.get(url)
+
+    workbook: Workbook = load_workbook(BytesIO(response.content), data_only=False)
+    worksheet: Worksheet = workbook.worksheets[0]
+
+    assert len(list(worksheet.values)) == 1, "There should be only the header row"
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize("non_disclosure", [False, True])
 def test__api__multiple_ownerships_report__single_owner(api_client: HitasAPIClient, non_disclosure):
     owner: Owner = OwnerFactory.create(non_disclosure=non_disclosure)
@@ -1452,7 +1463,7 @@ def test__api__multiple_ownerships_report__single_owner(api_client: HitasAPIClie
     ownership_2: Ownership = OwnershipFactory.create(
         owner=owner,
         sale__apartment__building__real_estate__housing_company__postal_code__value="00002",
-        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_II,
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
     )
 
     url = reverse("hitas:multiple-ownerships-report-list")
@@ -1497,6 +1508,30 @@ def test__api__multiple_ownerships_report__single_owner(api_client: HitasAPIClie
             ownership_2.apartment.postal_code.cost_area,
         ),
     ]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("non_disclosure", [False, True])
+def test__api__regulated_ownerships_report__single_owner(api_client: HitasAPIClient, non_disclosure):
+    owner: Owner = OwnerFactory.create(non_disclosure=non_disclosure)
+    OwnershipFactory.create(
+        owner=owner,
+        sale__apartment__building__real_estate__housing_company__postal_code__value="00001",
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
+    )
+    OwnershipFactory.create(
+        owner=owner,
+        sale__apartment__building__real_estate__housing_company__postal_code__value="00002",
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
+    )
+
+    url = reverse("hitas:regulated-ownerships-report-list")
+    response: HttpResponse = api_client.get(url)
+
+    workbook: Workbook = load_workbook(BytesIO(response.content), data_only=False)
+    worksheet: Worksheet = workbook.worksheets[0]
+
+    assert len(list(worksheet.values)) == 3, "There should be 2 ownership rows and 1 header row"
 
 
 @pytest.mark.django_db
@@ -1608,6 +1643,46 @@ def test__api__multiple_ownerships_report__multiple_owners(api_client: HitasAPIC
             ownership_5.apartment.postal_code.cost_area,
         ),
     ]
+
+
+@pytest.mark.django_db
+def test__api__regulated_ownerships_report__multiple_owners(api_client: HitasAPIClient):
+    owner_1: Owner = OwnerFactory.create(name="Owner 1")
+    OwnershipFactory.create(
+        owner=owner_1,
+        sale__apartment__building__real_estate__housing_company__postal_code__value="00001",
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
+    )
+    OwnershipFactory.create(
+        owner=owner_1,
+        sale__apartment__building__real_estate__housing_company__postal_code__value="00002",
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
+    )
+
+    owner_2: Owner = OwnerFactory.create(name="Owner 2", non_disclosure=True)
+    OwnershipFactory.create(
+        owner=owner_2,
+        sale__apartment__building__real_estate__housing_company__postal_code__value="00001",
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
+    )
+    OwnershipFactory.create(
+        owner=owner_2,
+        sale__apartment__building__real_estate__housing_company__postal_code__value="00002",
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
+    )
+    OwnershipFactory.create(
+        owner=owner_2,
+        sale__apartment__building__real_estate__housing_company__postal_code__value="00003",
+        sale__apartment__building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
+    )
+
+    url = reverse("hitas:regulated-ownerships-report-list")
+    response: HttpResponse = api_client.get(url)
+
+    workbook: Workbook = load_workbook(BytesIO(response.content), data_only=False)
+    worksheet: Worksheet = workbook.worksheets[0]
+
+    assert len(list(worksheet.values)) == 6, "There should be 5 ownership rows and 1 header row"
 
 
 @pytest.mark.django_db

--- a/backend/hitas/urls.py
+++ b/backend/hitas/urls.py
@@ -120,6 +120,13 @@ router.register(
     basename="sales-by-postal-code-and-area-report",
 )
 
+# /api/v1/reports/download-regulated-ownerships-report
+router.register(
+    r"reports/download-regulated-ownerships-report",
+    views.RegulatedOwnershipsReportView,
+    basename="regulated-ownerships-report",
+)
+
 # /api/v1/reports/download-multiple-ownerships-report
 router.register(
     r"reports/download-multiple-ownerships-report",

--- a/backend/hitas/views/__init__.py
+++ b/backend/hitas/views/__init__.py
@@ -36,6 +36,7 @@ from hitas.views.reports import (
     OwnershipsByHousingCompanyReport,
     RegulatedHalfHitasHousingCompaniesReportView,
     RegulatedHousingCompaniesReportView,
+    RegulatedOwnershipsReportView,
     SalesByPostalCodeAndAreaReportView,
     SalesReportView,
     UnregulatedHousingCompaniesReportView,

--- a/backend/hitas/views/reports.py
+++ b/backend/hitas/views/reports.py
@@ -15,12 +15,17 @@ from hitas.services.housing_company import (
     find_regulated_housing_companies_for_reporting,
     find_unregulated_housing_companies_for_reporting,
 )
-from hitas.services.owner import find_apartments_by_housing_company, find_owners_with_multiple_ownerships
+from hitas.services.owner import (
+    find_apartments_by_housing_company,
+    find_owners_with_multiple_ownerships,
+    find_regulated_ownerships,
+)
 from hitas.services.reports import (
     build_housing_company_state_report_excel,
     build_multiple_ownerships_report_excel,
     build_owners_by_housing_companies_report_excel,
     build_regulated_housing_companies_report_excel,
+    build_regulated_ownerships_report_excel,
     build_sales_by_postal_code_and_area_report_excel,
     build_sales_report_excel,
     build_unregulated_housing_companies_report_excel,
@@ -128,6 +133,16 @@ class SalesByPostalCodeAndAreaReportView(ViewSet):
         sales = find_sales_on_interval_for_reporting(start, end)
         workbook = build_sales_by_postal_code_and_area_report_excel(sales)
         filename = f"Yhtiöt postinumero ja kalleusalueittain aikavälillä {start.isoformat()} - {end.isoformat()}.xlsx"
+        return get_excel_response(filename=filename, excel=workbook)
+
+
+class RegulatedOwnershipsReportView(ViewSet):
+    renderer_classes = [HitasJSONRenderer, ExcelRenderer]
+
+    def list(self, request: Request, *args, **kwargs) -> HttpResponse:
+        ownerships = find_regulated_ownerships()
+        workbook = build_regulated_ownerships_report_excel(ownerships)
+        filename = "Sääntelyn piirissä olevien asuntojen omistajat.xlsx"
         return get_excel_response(filename=filename, excel=workbook)
 
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -4130,6 +4130,27 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /api/v1/reports/download-regulated-ownerships-report:
+    get:
+      description: Download an Excel report of owners with ownerships to regulated hitas apartments
+      operationId: fetch-regulated-ownerships-report-excel
+      tags:
+        - Reports
+      responses:
+        '200':
+          description: Successfully downloaded a report of owners with ownerships to regulated hitas apartments
+          content:
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/v1/reports/download-multiple-ownerships-report:
     get:
       description: Download an Excel report of owners with multiple ownerships to regulated hitas apartments

--- a/frontend/src/common/services/hitasApi/reports.ts
+++ b/frontend/src/common/services/hitasApi/reports.ts
@@ -68,6 +68,9 @@ export const downloadUnregulatedHousingCompaniesPDF = () =>
 export const downloadHousingCompanyStatesReportPDF = () =>
     fetchAndDownloadPDF("/reports/download-housing-company-states-report");
 
+export const downloadRegulatedOwnershipsReportExcel = () =>
+    fetchAndDownloadPDF("/reports/download-regulated-ownerships-report");
+
 export const downloadMultipleOwnershipsReportPDF = () =>
     fetchAndDownloadPDF("/reports/download-multiple-ownerships-report");
 

--- a/frontend/src/features/reports/components/OwnerReports.tsx
+++ b/frontend/src/features/reports/components/OwnerReports.tsx
@@ -1,22 +1,40 @@
 import {DownloadButton, Heading} from "../../../common/components";
-import {downloadMultipleOwnershipsReportPDF} from "../../../common/services";
+import {downloadMultipleOwnershipsReportPDF, downloadRegulatedOwnershipsReportExcel} from "../../../common/services";
 
 const OwnerReports = () => {
     return (
-        <div className="report-container">
-            <div className="column">
-                <Heading type="sub">Usean Hitas-asunnon omistajat</Heading>
-                <span>
-                    Listaus henkilöistä, jotka omistavat useamman kuin yhden Hitas-asunnon, sekä heidän omistuksistaan.
-                </span>
-                <div>
-                    <DownloadButton
-                        buttonText="Lataa raportti"
-                        onClick={downloadMultipleOwnershipsReportPDF}
-                    />
+        <>
+            <div className="report-container">
+                <div className="column">
+                    <Heading type="sub">Usean Hitas-asunnon omistajat</Heading>
+                    <span>
+                        Listaus henkilöistä, jotka omistavat useamman kuin yhden Hitas-asunnon, sekä heidän
+                        omistuksistaan.
+                    </span>
+                    <div>
+                        <DownloadButton
+                            buttonText="Lataa raportti"
+                            onClick={downloadMultipleOwnershipsReportPDF}
+                        />
+                    </div>
                 </div>
             </div>
-        </div>
+            <div className="report-container">
+                <div className="column">
+                    <Heading type="sub">Sääntelyn piirissä olevien Hitas-asuntojen omistajat</Heading>
+                    <span>
+                        Listaus henkilöistä, jotka omistavat yhden tai useamman sääntelyn piirissä olevan Hitas-asunnon,
+                        sekä heidän omistuksistaan.
+                    </span>
+                    <div>
+                        <DownloadButton
+                            buttonText="Lataa raportti"
+                            onClick={downloadRegulatedOwnershipsReportExcel}
+                        />
+                    </div>
+                </div>
+            </div>
+        </>
     );
 };
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

A new report listing all owners of apartments covered by the Hitas regulation. The report should be located in the Owners' Reports submenu. Includes only owners of regulated companies, excludes: half-hitas companies, released and so-called rental housing companies.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Documentation**
  - [x] OpenAPI definitions have been updated

## Tickets

HT-703
