### PR TITLE
Change owner obfuscation of half-hitas owners to use completion date instead of purchase date

### DIFF
--- a/backend/hitas/tests/services/test_services_owner.py
+++ b/backend/hitas/tests/services/test_services_owner.py
@@ -167,6 +167,7 @@ def test_obfuscate_owners_without_regulated_apartments__half_hitas_sales_after_r
         sales=[],
         building__real_estate__housing_company__regulation_status=RegulationStatus.RELEASED_BY_HITAS,
         building__real_estate__housing_company__hitas_type=HitasType.HALF_HITAS,
+        completion_date="2020-01-01",
     )
 
     unsold_apartments_count = get_number_of_unsold_apartments(apartment.housing_company)


### PR DESCRIPTION
# Hitas Pull Request

# Description

2 years after latest purchase date is too long time for half-hitas owner obfuscation. Change to 2 years from housing company completion date.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added

## Tickets

HT-713
