### PR TITLE
Change apartment floor input to allow dashes etc

### DIFF
--- a/frontend/src/common/schemas/apartment.ts
+++ b/frontend/src/common/schemas/apartment.ts
@@ -259,7 +259,7 @@ export type SurfaceAreaPriceCeilingCalculation = z.infer<typeof SurfaceAreaPrice
 
 export const ApartmentAddressSchema = AddressSchema.extend({
     apartment_number: writableRequiredNumber,
-    floor: nullishNumber,
+    floor: string().nullable(),
     stair: string().min(1, "Pakollinen kenttä!"),
 });
 export type IApartmentAddress = z.infer<typeof ApartmentAddressSchema>;

--- a/frontend/src/features/apartment/ApartmentCreatePage.tsx
+++ b/frontend/src/features/apartment/ApartmentCreatePage.tsx
@@ -328,7 +328,7 @@ const LoadedApartmentCreatePage = () => {
                             />
                         </div>
                         <div className="row">
-                            <NumberInput
+                            <TextInput
                                 name="address.floor"
                                 label="Kerros"
                             />


### PR DESCRIPTION
# Hitas Pull Request

# Description

Apartment floor is defined as a string in the database and the API, but the UI uses a number input for it.

Floors can have other characters than just digits, such as floor "1-2".

Change input to allow non-numeric characters.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-732