### PR TITLE
Change ownership modal to open when add button clicked in sale form

### DIFF
--- a/frontend/src/common/components/OwnershipList.tsx
+++ b/frontend/src/common/components/OwnershipList.tsx
@@ -48,6 +48,7 @@ const OwnershipList = () => {
                                     name={`ownerships.${index}.owner`}
                                     transform={(obj) => formatOwner(obj)}
                                     RelatedModelMutateComponent={OwnerMutateForm}
+                                    isModalDefaultOpen={formObject.getValues(`ownerships.${index}.owner`) === undefined}
                                 />
                             </div>
                             <div className="percentage">

--- a/frontend/src/common/components/forms/RelatedModelInput.tsx
+++ b/frontend/src/common/components/forms/RelatedModelInput.tsx
@@ -213,6 +213,7 @@ interface RelatedModelInputProps {
     RelatedModelMutateComponent?: IRelatedModelMutateComponent;
     required?: boolean;
     disabled?: boolean;
+    isModalDefaultOpen?: boolean;
 }
 
 const RelatedModelInput = ({
@@ -229,11 +230,12 @@ const RelatedModelInput = ({
 
     required,
     disabled,
+    isModalDefaultOpen,
 }: RelatedModelInputProps) => {
     const formObject = useFormContext();
     formObject.register(name);
 
-    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [isModalOpen, setIsModalOpen] = useState(isModalDefaultOpen ?? false);
     const openModal = () => setIsModalOpen(true);
     const closeModal = () => setIsModalOpen(false);
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

In the apartment sale creation form when adding an owner the form first goes into an invalid state and then you need to edit the owner row to make it valid.

This change skips the invalid form step and opens the owner modal immediately.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-725
