### PR TITLE
Change regulation results table columns to be more consistent

### DIFF
--- a/frontend/src/features/functions/ThirtyYearRegulationTabComponents/ThirtyYearLoadedResults.tsx
+++ b/frontend/src/features/functions/ThirtyYearRegulationTabComponents/ThirtyYearLoadedResults.tsx
@@ -8,9 +8,9 @@ const ListHeaders = () => (
         <div className="list-header name">Nimi ja osoite</div>
         <div className="list-header date">Valmistumispäivä</div>
         <div className="list-header property-manager">
-            Isännöitsijätiedot
+            Isännöitsijän
             <br />
-            päivitetty viimeksi
+            sähköpostiosoite
         </div>
     </div>
 );

--- a/frontend/src/styles/components/_Functions.sass
+++ b/frontend/src/styles/components/_Functions.sass
@@ -112,6 +112,7 @@
         padding: $spacing-m
       .list-headers
         width: 63%
+        padding-right: 0
       .results-list__item
         cursor: inherit
         padding: 0
@@ -128,7 +129,16 @@
           @include flex-flow(row nowrap)
           @include justify-content(space-between)
           @include align-items(center)
+          gap: $spacing-s
           width: 63%
+          & > a
+            width: 100%
+          .date
+            min-width: 90px
+            text-align: right
+          .property-manager
+            width: 100%
+            text-align: right
         .buttons
           @include flexbox()
           @include justify-content(flex-end)


### PR DESCRIPTION
# Hitas Pull Request

# Description

Change regulation results table columns to be more consistent.

Before:

![image](https://github.com/user-attachments/assets/73c68952-232b-403b-b6b4-6edfc32332ec)

After:

![image](https://github.com/user-attachments/assets/0d6621d2-0d98-46fc-ae54-973e882f04af)

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-729
