### PR TITLE
Change TextInput to not initially show errors on an empty form

### DIFF
--- a/frontend/src/common/components/forms/TextInput.tsx
+++ b/frontend/src/common/components/forms/TextInput.tsx
@@ -9,10 +9,13 @@ const TextInput = ({name, label = "", required, invalid, ...rest}: FormInputProp
 
     const {
         register,
-        formState: {errors},
+        formState: {errors, dirtyFields},
     } = formObject;
     const formText = register(name, {required: required});
-    const fieldError = dotted(errors, formText.name);
+    const isFieldDirty = dirtyFields[name] ?? false;
+    const hasValue = formObject.getValues(formText.name) !== "";
+    const shouldShowError = isFieldDirty || hasValue;
+    const fieldError = shouldShowError ? dotted(errors, formText.name) : undefined;
 
     return (
         <div className={`input-field input-field--text ${required ? "input-field--required" : ""}`}>


### PR DESCRIPTION
# Hitas Pull Request

# Description

When an empty form is loaded it can have validation errors already populated.

Do not show validation errors to the user on an empty pristine form. Require either a dirty field or a pre-populated value.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-724
