### PR TITLE
Add two new sales reports, resales and first sales

### DIFF
--- a/backend/hitas/services/apartment_sale.py
+++ b/backend/hitas/services/apartment_sale.py
@@ -1,10 +1,15 @@
 from datetime import datetime
 
+from django.db.models import Window
+from django.db.models.functions import RowNumber
+
 from hitas.models import ApartmentSale
 
 
-def find_sales_on_interval_for_reporting(start_date: datetime.date, end_date: datetime.date) -> list[ApartmentSale]:
-    return list(
+def find_sales_on_interval_for_reporting(
+    start_date: datetime.date, end_date: datetime.date, sales_filter="all"
+) -> list[ApartmentSale]:
+    queryset = (
         ApartmentSale.objects.select_related("apartment__building__real_estate__housing_company__postal_code")
         .filter(
             purchase_date__gte=start_date,
@@ -18,3 +23,16 @@ def find_sales_on_interval_for_reporting(start_date: datetime.date, end_date: da
             "apartment__rooms",
         )
     )
+    if sales_filter in ["resale", "firstsale"]:
+        queryset = queryset.annotate(
+            sale_number_in_order=Window(
+                expression=RowNumber(),
+                partition_by="apartment",
+                order_by=["purchase_date", "id"],
+            ),
+        )
+    if sales_filter == "resale":
+        queryset = queryset.filter(sale_number_in_order__gt=1)
+    elif sales_filter == "firstsale":
+        queryset = queryset.filter(sale_number_in_order=1)
+    return list(queryset)

--- a/backend/hitas/tests/apis/test_api_reports.py
+++ b/backend/hitas/tests/apis/test_api_reports.py
@@ -1415,6 +1415,77 @@ def test__api__sales_by_area_report__multiple__different_postal_code(api_client:
     ]
 
 
+@pytest.mark.django_db
+def test__api__sales_by_area_report__filter_resales(api_client: HitasAPIClient):
+    # All apartments in the same area -> included in the same report row sale count
+    area_args = {
+        "apartment__building__real_estate__housing_company__postal_code__value": "00002",
+        "apartment__building__real_estate__housing_company__postal_code__cost_area": 1,
+    }
+    sale_args = dict(**area_args, purchase_date=datetime.date(2020, 1, 1))
+    ApartmentSaleFactory.create(**sale_args)  # Excluded: first sale
+    apartment = ApartmentFactory.create(
+        sales=[],
+        building__real_estate__housing_company__postal_code__value="00002",
+        building__real_estate__housing_company__postal_code__cost_area=1,
+    )
+    ApartmentSaleFactory.create(**sale_args, apartment=apartment)  # Excluded: first sale
+    ApartmentSaleFactory.create(**sale_args, apartment=apartment)  # Included: resale
+    sale_to_be_soft_deleted = ApartmentSaleFactory.create(**sale_args, apartment=apartment)  # Excluded: soft-deleted
+    sale_to_be_soft_deleted.delete()
+    ApartmentSaleFactory.create(**sale_args, apartment=apartment)  # Included: resale
+    ApartmentSaleFactory.create(
+        **area_args, purchase_date=datetime.date(2021, 1, 1), apartment=apartment
+    )  # Excluded: outside of date range
+    data = {
+        "start_date": "2020-01-01",
+        "end_date": "2020-01-31",
+        "filter": "resale",
+    }
+    url = reverse("hitas:sales-by-postal-code-and-area-report-list") + "?" + urlencode(data)
+    response: HttpResponse = api_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    workbook: Workbook = load_workbook(BytesIO(response.content), data_only=False)
+    worksheet: Worksheet = workbook.worksheets[0]
+    sales_count = list(worksheet.values)[1][3]
+    assert sales_count == 2, "There should be two resales"
+
+
+@pytest.mark.django_db
+def test__api__sales_by_area_report__filter_firstsales(api_client: HitasAPIClient):
+    # All apartments in the same area -> included in the same report row sale count
+    area_args = {
+        "apartment__building__real_estate__housing_company__postal_code__value": "00002",
+        "apartment__building__real_estate__housing_company__postal_code__cost_area": 1,
+    }
+    sale_args = dict(**area_args, purchase_date=datetime.date(2020, 1, 1))
+    ApartmentSaleFactory.create(**sale_args)  # Included: first sale
+    sale_to_be_soft_deleted = ApartmentSaleFactory.create(**sale_args)  # Excluded: soft-deleted
+    sale_to_be_soft_deleted.delete()
+    ApartmentSaleFactory.create(**area_args, purchase_date=datetime.date(2021, 1, 1))  # Excluded: outside of date range
+    apartment = ApartmentFactory.create(
+        sales=[],
+        building__real_estate__housing_company__postal_code__value="00002",
+        building__real_estate__housing_company__postal_code__cost_area=1,
+    )
+    sale_to_be_soft_deleted = ApartmentSaleFactory.create(**sale_args, apartment=apartment)  # Excluded: soft-deleted
+    sale_to_be_soft_deleted.delete()
+    ApartmentSaleFactory.create(**sale_args, apartment=apartment)  # Included: first sale
+    ApartmentSaleFactory.create(**sale_args, apartment=apartment)  # Excluded: resale
+    data = {
+        "start_date": "2020-01-01",
+        "end_date": "2020-01-31",
+        "filter": "firstsale",
+    }
+    url = reverse("hitas:sales-by-postal-code-and-area-report-list") + "?" + urlencode(data)
+    response: HttpResponse = api_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    workbook: Workbook = load_workbook(BytesIO(response.content), data_only=False)
+    worksheet: Worksheet = workbook.worksheets[0]
+    sales_count = list(worksheet.values)[1][3]
+    assert sales_count == 2, "There should be two first sales"
+
+
 # Multiple ownerships report
 
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -4129,6 +4129,13 @@ paths:
           schema:
             type: string
             example: 2023-02-01
+        - name: filter
+          required: false
+          in: query
+          description: Filter sales by `resale` or `firstsale` only.
+          schema:
+            type: string
+            example: "resale"
       responses:
         "200":
           description: Successfully downloaded a sales report by area and postal code

--- a/frontend/src/common/services/hitasApi/reports.ts
+++ b/frontend/src/common/services/hitasApi/reports.ts
@@ -50,13 +50,35 @@ export const downloadSalesReportPDF = ({startDate, endDate}: {startDate: string;
 export const downloadSalesByPostalCodeAndAreaReportPDF = ({
     startDate,
     endDate,
+    filter,
+}: {
+    startDate: string;
+    endDate: string;
+    filter?: string;
+}) => {
+    const params = `start_date=${startDate}&end_date=${endDate}` + (filter ? `&filter=${filter}` : "");
+    const url = `/reports/download-sales-by-postal-code-and-area-report?${params}`;
+    fetchAndDownloadPDF(url);
+};
+
+export const downloadReSalesByPostalCodeAndAreaReportPDF = ({
+    startDate,
+    endDate,
 }: {
     startDate: string;
     endDate: string;
 }) => {
-    const params = `start_date=${startDate}&end_date=${endDate}`;
-    const url = `/reports/download-sales-by-postal-code-and-area-report?${params}`;
-    fetchAndDownloadPDF(url);
+    downloadSalesByPostalCodeAndAreaReportPDF({startDate, endDate, filter: "resale"});
+};
+
+export const downloadFirstSalesByPostalCodeAndAreaReportPDF = ({
+    startDate,
+    endDate,
+}: {
+    startDate: string;
+    endDate: string;
+}) => {
+    downloadSalesByPostalCodeAndAreaReportPDF({startDate, endDate, filter: "firstsale"});
 };
 
 export const downloadRegulatedHousingCompaniesPDF = () =>

--- a/frontend/src/features/reports/ReportsPage.tsx
+++ b/frontend/src/features/reports/ReportsPage.tsx
@@ -7,7 +7,12 @@ import {
     HousingCompanyStatusTable,
 } from "./components/HousingCompanyReports";
 import OwnerReports from "./components/OwnerReports";
-import {SalesReportAll, SalesReportByAreas} from "./components/SalesReports";
+import {
+    FirstSalesReportByAreas,
+    ReSalesReportByAreas,
+    SalesReportAll,
+    SalesReportByAreas,
+} from "./components/SalesReports";
 import {SurfaceAreaPriceCeilingCalculationReport} from "./components/SurfaceAreaPriceCalculationReports";
 import {JobPerformanceReport} from "./components/JobPerformanceReport";
 
@@ -24,6 +29,10 @@ const ReportsPage = () => {
                     <SalesReportAll />
                     <Divider size="s" />
                     <SalesReportByAreas />
+                    <Divider size="s" />
+                    <ReSalesReportByAreas />
+                    <Divider size="s" />
+                    <FirstSalesReportByAreas />
                 </Accordion>
 
                 <Accordion

--- a/frontend/src/features/reports/components/SalesReports.tsx
+++ b/frontend/src/features/reports/components/SalesReports.tsx
@@ -2,7 +2,12 @@ import {useForm} from "react-hook-form";
 import {DownloadButton, Heading} from "../../../common/components";
 import {DateInput, FormProviderForm} from "../../../common/components/forms";
 import {SalesReportFormSchema} from "../../../common/schemas";
-import {downloadSalesByPostalCodeAndAreaReportPDF, downloadSalesReportPDF} from "../../../common/services";
+import {
+    downloadFirstSalesByPostalCodeAndAreaReportPDF,
+    downloadReSalesByPostalCodeAndAreaReportPDF,
+    downloadSalesByPostalCodeAndAreaReportPDF,
+    downloadSalesReportPDF,
+} from "../../../common/services";
 import {getLatestFullMonth} from "../../../common/utils";
 import {format} from "date-fns";
 
@@ -63,8 +68,26 @@ export const SalesReportAll = () => {
 export const SalesReportByAreas = () => {
     return (
         <BaseSalesReport
-            header="Raportti kaupoista postinumeroittain ja alueittain"
+            header="Kaikki kaupat postinumeroittain ja alueittain"
             downloadReportFunction={downloadSalesByPostalCodeAndAreaReportPDF}
+        />
+    );
+};
+
+export const ReSalesReportByAreas = () => {
+    return (
+        <BaseSalesReport
+            header="Jälleenmyynnit postinumeroittain ja alueittain"
+            downloadReportFunction={downloadReSalesByPostalCodeAndAreaReportPDF}
+        />
+    );
+};
+
+export const FirstSalesReportByAreas = () => {
+    return (
+        <BaseSalesReport
+            header="Uudiskohteet postinumeroittain ja alueittain"
+            downloadReportFunction={downloadFirstSalesByPostalCodeAndAreaReportPDF}
         />
     );
 };


### PR DESCRIPTION
# Hitas Pull Request

# Description

This PR adds two new reports, or rather two filters to an existing report: all sales report filtered by either resales only or first sales only.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Documentation**
  - [ ] OpenAPI definitions have been updated

## Tickets

HT-742

HT-743
