### PR TITLE
Change housing company status report table headings alignment to match content alignment

### DIFF
--- a/frontend/src/features/reports/components/HousingCompanyReports.tsx
+++ b/frontend/src/features/reports/components/HousingCompanyReports.tsx
@@ -38,13 +38,15 @@ export const HousingCompanyStatusTable = () => {
                 error={error}
                 isLoading={isLoading}
             >
-                <Table
-                    cols={statusTableColumns}
-                    rows={data as IHousingCompanyState[]}
-                    indexKey="status"
-                    theme={tableThemeBlack}
-                    zebra
-                />
+                <div className="housing-company-status-table">
+                    <Table
+                        cols={statusTableColumns}
+                        rows={data as IHousingCompanyState[]}
+                        indexKey="status"
+                        theme={tableThemeBlack}
+                        zebra
+                    />
+                </div>
                 <DownloadButton
                     buttonText="Lataa raportti"
                     onClick={downloadHousingCompanyStatesReportPDF}

--- a/frontend/src/styles/components/_Reports.sass
+++ b/frontend/src/styles/components/_Reports.sass
@@ -72,3 +72,8 @@
       @include flex-flow(row nowrap)
       @include justify-content(space-between)
       gap: $spacing-s
+
+.housing-company-status-table
+  width: 100%
+  thead th:nth-child(2), thead th:nth-child(3)
+    text-align: right


### PR DESCRIPTION
# Hitas Pull Request

# Description

Table cells in this table are aligned, but the headings' text is aligned left while the cell content is aligned right. This creates the illusion of the columns not being aligned. This PR changes the heading text alignment to right instead of left.

Before:

![image](https://github.com/user-attachments/assets/4e2158e6-817e-4ec2-aba2-c024af6aedc8)

After:

![image](https://github.com/user-attachments/assets/767be9b4-35fd-45c5-925a-87a7c19e7020)

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-729
