### PR TITLE
Add labels to MutateSearchList search inputs

### DIFF
--- a/frontend/src/common/components/mutateComponents/MutateSearchList.tsx
+++ b/frontend/src/common/components/mutateComponents/MutateSearchList.tsx
@@ -128,6 +128,7 @@ function ResultList<
 interface IMutateSearchListProps<
     TListFieldsWithTitles extends object,
     TFilterQueryParams extends object,
+    TFilterTitles extends object,
     TFormFieldsWithTitles extends object,
 > {
     listFieldsWithTitles: TListFieldsWithTitles;
@@ -135,6 +136,7 @@ interface IMutateSearchListProps<
     resultListMaxRows?: number;
     useGetQuery;
     emptyFilterParams: TFilterQueryParams;
+    filterTitles?: TFilterTitles;
     dialogTitles?: {modify?: string; new?: string};
     MutateFormComponent;
     mutateFormProps?: IMutateFormProps<TFormFieldsWithTitles>;
@@ -146,6 +148,7 @@ interface IMutateSearchListProps<
 export default function MutateSearchList<
     TListFieldsWithTitles extends object,
     TFilterQueryParams extends object,
+    TFilterTitles extends object,
     TFormFieldsWithTitles extends object,
 >({
     listFieldsWithTitles,
@@ -154,9 +157,10 @@ export default function MutateSearchList<
     useGetQuery,
     MutateFormComponent,
     emptyFilterParams,
+    filterTitles,
     dialogTitles,
     mutateFormProps,
-}: IMutateSearchListProps<TListFieldsWithTitles, TFilterQueryParams, TFormFieldsWithTitles>) {
+}: IMutateSearchListProps<TListFieldsWithTitles, TFilterQueryParams, TFilterTitles, TFormFieldsWithTitles>) {
     // search strings
     const [filterParams, setFilterParams] = useState<TFilterQueryParams>(emptyFilterParams);
 
@@ -176,12 +180,12 @@ export default function MutateSearchList<
     return (
         <div className="listing">
             <div className="filters">
-                {Object.entries(emptyFilterParams).map(([field, title], i) => (
+                {Object.entries(emptyFilterParams).map(([field, _defaultValue], i) => (
                     <TextInput
                         key={field}
                         id="filter__name"
                         ref={(element) => (ref.current[field] = element)}
-                        label={title as string}
+                        label={(filterTitles?.[field] ?? "") as string}
                         value={filterParams[field]}
                         onChange={(e) => setFilterParams((prev) => ({...prev, [field]: e.target.value}))}
                         onButtonClick={() => clearAndFocus(field)}

--- a/frontend/src/features/codes/CodesPage.tsx
+++ b/frontend/src/features/codes/CodesPage.tsx
@@ -40,6 +40,7 @@ const CodesPage = (): React.JSX.Element => {
                         listFieldsWithTitles={{name: "Nimi", identifier: "Henkilö- tai Y-tunnus"}}
                         useGetQuery={useGetOwnersQuery}
                         emptyFilterParams={{name: "", identifier: ""}}
+                        filterTitles={{name: "Nimi", identifier: "Henkilö- tai Y-tunnus"}}
                         dialogTitles={{modify: "Muokkaa henkilötietoja"}}
                         MutateFormComponent={OwnerMutateForm}
                     />
@@ -49,6 +50,7 @@ const CodesPage = (): React.JSX.Element => {
                         listFieldsWithTitles={{name: "Nimi", email: "Sähköpostiosoite"}}
                         useGetQuery={useGetPropertyManagersQuery}
                         emptyFilterParams={{name: "", email: ""}}
+                        filterTitles={{name: "Nimi", email: "Sähköpostiosoite"}}
                         dialogTitles={{modify: "Muokkaa isännöitsijän tietoja", new: "Lisää isännöitsijä"}}
                         MutateFormComponent={MutateForm}
                         mutateFormProps={propertyManagerMutateFormProps}
@@ -59,6 +61,7 @@ const CodesPage = (): React.JSX.Element => {
                         listFieldsWithTitles={{value: "Nimi"}}
                         useGetQuery={useGetDevelopersQuery}
                         emptyFilterParams={{value: ""}}
+                        filterTitles={{value: "Nimi"}}
                         dialogTitles={{modify: "Muokkaa rakennuttajan tietoja", new: "Lisää rakennuttaja"}}
                         MutateFormComponent={MutateForm}
                         mutateFormProps={developerMutateFormProps}


### PR DESCRIPTION
# Hitas Pull Request

# Description

"Omistajat", "Isännöitsijät" and "Rakennuttajat" tabs in "Koodisto" are missing labels for search input fields.

This PR adds the missing labels.

Before:

![image](https://github.com/user-attachments/assets/0df6f55f-3f10-4147-aaa8-31a6b6343737)

After:

![image](https://github.com/user-attachments/assets/4dafc1ef-74af-4b98-ac3b-f4306626130b)

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-727
