### PR TITLE
Change regulation status options in company edit form to include released_by_hitas for edge cases

### DIFF
--- a/frontend/src/features/housingCompany/HousingCompanyCreatePage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyCreatePage.tsx
@@ -42,8 +42,8 @@ import {
 } from "./components/HousingCompanyViewContextProvider";
 
 const regulationStatusOptions = [
-    // Don't allow manually setting the regulation status to "released_by_hitas", as it should be set automatically.
     {label: getHousingCompanyRegulationStatusName("regulated"), value: "regulated"},
+    {label: getHousingCompanyRegulationStatusName("released_by_hitas"), value: "released_by_hitas"},
     {label: getHousingCompanyRegulationStatusName("released_by_plot_department"), value: "released_by_plot_department"},
 ];
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

There are uncommon edge cases where it is necessary to manually switch between regulated and released_by_hitas regulation status for housing companies.

This PR adds the third (missing) option to the dropdown for these use cases.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-744