### PR TITLE
Add drag and drop support for document form

### DIFF
--- a/frontend/src/common/components/FileDropZone.tsx
+++ b/frontend/src/common/components/FileDropZone.tsx
@@ -1,0 +1,102 @@
+import React, {useEffect} from "react";
+
+interface FileDropZoneProps {
+    onDraggingChange?: (isDragging: boolean) => void;
+    onFileDrop: (files: FileList) => void;
+    helpText?: string;
+}
+
+export default function FileDropZone({
+    onDraggingChange = () => {},
+    onFileDrop,
+    helpText,
+}: FileDropZoneProps): React.JSX.Element {
+    useEffect(() => {
+        let isDragging = document.documentElement.classList.contains("is-dragging");
+        let dragEndTimeout;
+
+        const startDrag = () => {
+            if (!isDragging) {
+                isDragging = true;
+                document.documentElement.classList.add("is-dragging");
+                onDraggingChange(true);
+                // Failsafe in case the dragleave is somehow missed and the user is no longer dragging
+                window.addEventListener("mousemove", handleMouseMove);
+            }
+        };
+
+        const endDrag = () => {
+            if (isDragging) {
+                isDragging = false;
+                document.documentElement.classList.remove("is-dragging");
+                onDraggingChange(false);
+                document
+                    .querySelector(".file-drop-zone.is-dragging-over-drop-zone")
+                    ?.classList.remove("is-dragging-over-drop-zone");
+                window.removeEventListener("mousemove", handleMouseMove);
+            }
+        };
+
+        const handleDragEnter = (event) => {
+            event.preventDefault();
+            dragEndTimeout = clearTimeout(dragEndTimeout);
+            startDrag();
+            if (event.target.classList.contains("file-drop-zone")) {
+                event.target.classList.add("is-dragging-over-drop-zone");
+            }
+        };
+
+        const handleDragOver = (event) => {
+            event.preventDefault();
+            dragEndTimeout = clearTimeout(dragEndTimeout);
+        };
+
+        const handleDragLeave = (event) => {
+            event.preventDefault();
+            dragEndTimeout = setTimeout(endDrag, 200);
+            if (event.target.classList.contains("file-drop-zone")) {
+                event.target.classList.remove("is-dragging-over-drop-zone");
+            }
+        };
+
+        const handleDrop = (event) => {
+            event.preventDefault();
+            endDrag();
+            if (
+                event.target.classList.contains("file-drop-zone") &&
+                event.dataTransfer.files &&
+                event.dataTransfer.files.length > 0
+            ) {
+                onFileDrop(event.dataTransfer.files);
+            }
+        };
+
+        const handleMouseMove = (event) => {
+            // Failsafe in case the dragleave is somehow missed and the user is no longer dragging
+            if (event.buttons === 0) {
+                endDrag();
+            }
+        };
+
+        window.addEventListener("dragenter", handleDragEnter);
+        window.addEventListener("dragover", handleDragOver);
+        window.addEventListener("dragleave", handleDragLeave);
+        window.addEventListener("drop", handleDrop);
+
+        return () => {
+            window.removeEventListener("dragenter", handleDragEnter);
+            window.removeEventListener("dragover", handleDragOver);
+            window.removeEventListener("dragleave", handleDragLeave);
+            window.removeEventListener("drop", handleDrop);
+            window.removeEventListener("mousemove", handleMouseMove);
+        };
+    }, [onDraggingChange]);
+
+    return (
+        <>
+            <div className="file-drop-zone">
+                <div className="file-drop-zone-helptext">{helpText ?? "Pudota tiedostot tähän."}</div>
+            </div>
+        </>
+    );
+}

--- a/frontend/src/common/components/index.ts
+++ b/frontend/src/common/components/index.ts
@@ -5,6 +5,7 @@ export {default as DetailField} from "./DetailField";
 export {default as Divider} from "./Divider";
 export {default as DownloadButton} from "./DownloadButton";
 export {default as EditButton} from "./EditButton";
+export {default as FileDropZone} from "./FileDropZone";
 export {default as GenericActionModal} from "./GenericActionModal";
 export {default as GenericDocumentsPage} from "./GenericDocumentsPage";
 export {default as GenericImprovementsPage} from "./GenericImprovementsPage";

--- a/frontend/src/styles/components/_Documents.sass
+++ b/frontend/src/styles/components/_Documents.sass
@@ -56,6 +56,7 @@
 
 .view--create-documents
   .field-sets
+    position: relative
     background-color: $color-black-5
 
   .document-list-item-file-row

--- a/frontend/src/styles/components/_FileDropZone.sass
+++ b/frontend/src/styles/components/_FileDropZone.sass
@@ -1,0 +1,32 @@
+@use "../imports" as *
+
+.file-drop-zone
+  display: none
+  .is-dragging &
+    display: grid
+  place-items: center
+  position: absolute
+  top: 0
+  left: 0
+  right: 0
+  bottom: 0
+  width: auto
+  height: auto
+  background: rgba($color-white, 0.90)
+  border: 2px dotted rgba($color-coat-of-arms, 0.90)
+  &.is-dragging-over-drop-zone
+    background: rgba($color-bus-light, 0.95)
+    border-color: rgba($color-coat-of-arms, 1)
+  transition: all 200ms ease-in-out
+
+.file-drop-zone-helptext
+  display: grid
+  place-items: center
+  top: 0%
+  bottom: 30%
+  position: sticky
+  font-size: 28px
+  font-weight: 700
+  height: 250px
+  pointer-events: none
+  color: $color-coat-of-arms

--- a/frontend/src/styles/components/index.sass
+++ b/frontend/src/styles/components/index.sass
@@ -7,6 +7,7 @@
 @forward "CreatePage"
 @forward "DialogModule"
 @forward "Documents"
+@forward "FileDropZone"
 @forward "Forms"
 @forward "Functions"
 @forward "HousingCompanyList"

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
# Hitas Pull Request

# Description

This PR adds drag and drop support for document form.

One or more files can be dragged and dropped onto the form and they are added as new document rows at the end of the form.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-57
