### PR TITLE
Add another exception for rr_new_hitas in Apartment sale

### DIFF
--- a/frontend/src/features/apartment/ApartmentDetailsPage/components/ApartmentConditionsOfSaleCard.tsx
+++ b/frontend/src/features/apartment/ApartmentDetailsPage/components/ApartmentConditionsOfSaleCard.tsx
@@ -39,7 +39,12 @@ const ApartmentSalesPageLinkButton = ({
         // If apartment has been sold for the first time, and it's company not fully completed, it can not be re-sold
         // Exception: rr_new_hitas, which allows re-selling before housing company is fully completed
         apartmentCantBeSoldErrorMessage = "Valmistumattoman taloyhtiön asuntoa ei voida jälleenmyydä";
-    } else if (apartment.prices.first_purchase_date && !apartment.completion_date) {
+    } else if (
+        apartment.prices.first_purchase_date &&
+        !apartment.completion_date &&
+        // Exception: rr_new_hitas also allows re-selling before apartment is fully completed
+        housingCompany.hitas_type !== "rr_new_hitas"
+    ) {
         apartmentCantBeSoldErrorMessage = "Valmistumatonta asuntoa ei voida jälleenmyydä";
     } else if (apartment.prices.first_purchase_date && housingCompany.hitas_type === "half_hitas") {
         apartmentCantBeSoldErrorMessage = "Puolihitas-taloyhtiön asuntoa ei voida jälleenmyydä";


### PR DESCRIPTION
# Hitas Pull Request

# Description

Apartments in housing companies of type `rr_new_hitas` (ryhmärakennuttamiskohde) should allow resale of apartments even during construction.

There is already an exception for this when the housing company is incomplete, but the apartment being incomplete still prevents the sale.

This PR adds another exception for `rr_new_hitas` for incomplete apartments as well.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-752
