### PR TITLE
Add navigation elements to Apartment detail view to navigate directly to adjacent apertments

### DIFF
--- a/backend/hitas/tests/apis/test_api_apartment.py
+++ b/backend/hitas/tests/apis/test_api_apartment.py
@@ -736,6 +736,13 @@ def test__api__apartment__retrieve(api_client: HitasAPIClient):
             }
         ],
         "sell_by_date": str(sale_2.purchase_date),
+        "adjacent_apartments": [
+            {
+                "id": ap1.uuid.hex,
+                "apartment_number": ap1.apartment_number,
+                "stair": ap1.stair,
+            },
+        ],
     }
 
 
@@ -2005,6 +2012,13 @@ def test__api__apartment__update(api_client: HitasAPIClient, minimal_data: bool)
             "type": None,
             "conditions_of_sale": [],
             "sell_by_date": None,
+            "adjacent_apartments": [
+                {
+                    "id": ap.uuid.hex,
+                    "apartment_number": ap.apartment_number,
+                    "stair": ap.stair,
+                }
+            ],
         }
 
 
@@ -2224,6 +2238,7 @@ def test__api__apartment__update__overlapping_shares(
     del data["conditions_of_sale"]
     del data["sell_by_date"]
     del data["ownerships"]
+    del data["adjacent_apartments"]
     data["building"] = {"id": building_1.uuid.hex}
     data["shares"]["start"] = 20
     data["shares"]["end"] = 100

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -6374,6 +6374,26 @@ components:
               description: Building ID this apartment is associated with
               type: string
               example: dc1072975bab4ba69f64814f021c6785
+        adjacent_apartments:
+          description: List of adjacent apartments for pagination purposes
+          type: array
+          readOnly: true
+          items:
+            description: Adjacent apartment
+            type: object
+            properties:
+              id:
+                description: Adjacent apartment ID
+                type: string
+                example: dc1072975bab4ba69f64814f021c6785
+              apartment_number:
+                description: Apartment number of the adjacent apartment
+                type: integer
+                example: 2
+              stair:
+                description: Stair number of the adjacent apartment
+                type: string
+                example: A
         notes:
           description: Apartment notes
           type: string

--- a/frontend/src/common/schemas/apartment.ts
+++ b/frontend/src/common/schemas/apartment.ts
@@ -385,6 +385,13 @@ export const ApartmentSchema = object({
 });
 export type IApartment = z.infer<typeof ApartmentSchema>;
 
+export const AdjacentApartmentSchema = object({
+    id: string().nullable(),
+    apartment_number: number(),
+    stair: string(),
+});
+export type IAdjacentApartment = z.infer<typeof AdjacentApartmentSchema>;
+
 export const ApartmentDetailsSchema = object({
     id: APIIdString,
     is_sold: boolean(),
@@ -396,6 +403,7 @@ export const ApartmentDetailsSchema = object({
     prices: ApartmentPricesSchema,
     completion_date: string().nullable(),
     ownerships: OwnershipSchema.array(),
+    adjacent_apartments: AdjacentApartmentSchema.array(),
     notes: string(),
     improvements: object({
         market_price_index: MarketPriceIndexImprovementSchema.array(),

--- a/frontend/src/styles/components/_ApartmentDetails.sass
+++ b/frontend/src/styles/components/_ApartmentDetails.sass
@@ -32,7 +32,7 @@
         top: -3px
         left: -3px
 
-    span
+    .apartment-stats--metadata span
       &:not(:last-child):not(:empty):after
         @include inline-flex()
         @include justify-content(center)
@@ -49,6 +49,22 @@
 
       &:after
         display: none !important
+
+    &--apartment-select
+      margin: 0 $spacing-l
+
+      button
+        font-size: $fontsize-heading-l
+        font-weight: 700
+        line-height: 1
+        padding-right: 3px
+
+      [class^="Icon"]
+        top: calc($spacing-xs + 2px)
+        right: 3px
+
+  .apartment-heading-buttons
+    margin-left: auto
 
   .apartment-action-cards
     @include flexbox()


### PR DESCRIPTION
# Hitas Pull Request

# Description

To navigate to another apartment when in an apartment detail view you first have to navigate to the housing company detail view and select another apartment.

This PR adds navigation elements to the apartment detail view to allow for more direct navigation between apartments without leaving the apartment detail view.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added
- **Documentation**
  - [x] OpenAPI definitions have been updated

## Tickets

HT-749
