### PR TITLE
Add persistence to housing company search filters

### DIFF
--- a/frontend/src/common/components/filters/FilterIntegerField.tsx
+++ b/frontend/src/common/components/filters/FilterIntegerField.tsx
@@ -19,7 +19,7 @@ export default function FilterIntegerField({
     filterParams,
     setFilterParams,
 }: FilterIntegerFieldProps): React.JSX.Element {
-    const [inputValue, setInputValue] = useState("");
+    const [inputValue, setInputValue] = useState(filterParams[filterFieldName] ?? "");
     const [isInvalid, setIsInvalid] = useState(false);
 
     const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/common/components/filters/FilterRelatedModelComboboxField.tsx
+++ b/frontend/src/common/components/filters/FilterRelatedModelComboboxField.tsx
@@ -96,12 +96,13 @@ export default function FilterRelatedModelComboboxField({
             key={`filter__${filterFieldName}`}
             label={label}
             options={options}
-            isOptionDisabled={(option) => option?.disabled}
+            isOptionDisabled={(option) => options.find((o) => o.label === option.label)?.disabled ?? false}
             toggleButtonAriaLabel="Toggle menu"
             onChange={onSelectionChange}
             onFocus={() => setIsQuerySkipped(false)} // Load options only after field is focused to reduce unnecessary api queries
             onBlur={() => setIsQuerySkipped(true)}
             filter={filterFunction}
+            defaultValue={filterParams && filterParams[filterFieldName] ? {label: filterParams[filterFieldName]} : null}
             clearable
         />
     );

--- a/frontend/src/common/components/filters/FilterSelectField.tsx
+++ b/frontend/src/common/components/filters/FilterSelectField.tsx
@@ -30,6 +30,13 @@ export default function FilterSelectField({
         setFilterParams(filters);
     };
 
+    if (defaultOption === undefined) {
+        defaultOption = {
+            label: options.find((o) => o.value === filterParams[filterFieldName])?.label ?? "",
+            value: filterParams[filterFieldName],
+        };
+    }
+
     return (
         <Select
             id={`filter__${filterFieldName}`}

--- a/frontend/src/common/components/filters/FilterTextInputField.tsx
+++ b/frontend/src/common/components/filters/FilterTextInputField.tsx
@@ -54,6 +54,7 @@ export default function FilterTextInputField({
             onFocus={() => setIsInvalid(false)}
             invalid={isInvalid}
             maxLength={maxLength}
+            defaultValue={filterParams[filterFieldName]}
             {...rest}
         />
     );

--- a/frontend/src/features/housingCompany/HousingCompanyListPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyListPage.tsx
@@ -44,8 +44,7 @@ const HousingCompanyListItem = ({housingCompany}: {housingCompany: IHousingCompa
     );
 };
 
-const HousingCompanyResultsList = ({filterParams}): React.JSX.Element => {
-    const [currentPage, setCurrentPage] = useState(1);
+const HousingCompanyResultsList = ({filterParams, currentPage, setCurrentPage}): React.JSX.Element => {
     const {data, error, isLoading, isFetching} = useGetHousingCompaniesQuery({...filterParams, page: currentPage});
 
     const LoadedHousingCompanyResultsList = ({
@@ -188,19 +187,44 @@ const getFilterDefaultsFromQueryParams = () => {
     return filterParams;
 };
 
+const getPageFromQueryParams = () => {
+    const params = new URLSearchParams(location.search);
+    return params.get("page") ?? undefined;
+};
+
+const removeUndefinedParams = (filterParams) => {
+    return JSON.parse(JSON.stringify(filterParams));
+};
+
 const HousingCompanyListPage = (): React.JSX.Element => {
     const navigate = useNavigate();
     const [filterParams, setFilterParams] = useState({
         is_regulated: "true",
         ...getFilterDefaultsFromQueryParams(),
     });
+    const [currentPage, setCurrentPage] = useState(getPageFromQueryParams() ?? 1);
 
     const updateFilters = (newFilters) => {
         setFilterParams(newFilters);
+        setCurrentPage(1);
         // Update URL with new filters
+        const queryParams = new URLSearchParams(removeUndefinedParams(newFilters)).toString();
+        navigate(
+            {
+                pathname: location.pathname,
+                search: queryParams,
+            },
+            {replace: true}
+        );
+    };
+    const updatePage = (newPage) => {
+        setCurrentPage(newPage);
+        // Update URL with new page
         const queryParams = new URLSearchParams(
-            // Remove undefined
-            JSON.parse(JSON.stringify(newFilters))
+            removeUndefinedParams({
+                ...filterParams,
+                page: newPage,
+            })
         ).toString();
         navigate(
             {
@@ -234,7 +258,11 @@ const HousingCompanyListPage = (): React.JSX.Element => {
                     />
                     <IconSearch />
                 </div>
-                <HousingCompanyResultsList filterParams={filterParams} />
+                <HousingCompanyResultsList
+                    filterParams={filterParams}
+                    currentPage={currentPage}
+                    setCurrentPage={updatePage}
+                />
                 <HousingCompanyFilters
                     filterParams={filterParams}
                     setFilterParams={updateFilters}

--- a/frontend/src/features/housingCompany/HousingCompanyListPage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyListPage.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from "react";
 
 import {Button, IconPlus, IconSearch, LoadingSpinner, StatusLabel} from "hds-react";
-import {Link} from "react-router-dom";
+import {Link, useNavigate} from "react-router-dom";
 
 import {Heading, ListPageNumbers, QueryStateHandler} from "../../common/components";
 import {
@@ -155,7 +155,6 @@ const HousingCompanyFilters = ({filterParams, setFilterParams}): React.JSX.Eleme
                     {value: "true", label: "Säännelty"},
                     {value: "false", label: "Ei säännelty"},
                 ]}
-                defaultOption={{value: "true", label: "Säännelty"}}
                 filterParams={filterParams}
                 setFilterParams={setFilterParams}
             />
@@ -163,8 +162,54 @@ const HousingCompanyFilters = ({filterParams, setFilterParams}): React.JSX.Eleme
     );
 };
 
+interface FilterParams {
+    display_name?: string | undefined;
+    street_address?: string | undefined;
+    postal_code?: string | undefined;
+    developer?: string | undefined;
+    property_manager?: string | undefined;
+    archive_id?: string | undefined;
+    is_regulated?: string | undefined;
+}
+
+const getFilterDefaultsFromQueryParams = () => {
+    const params = new URLSearchParams(location.search);
+    const filterParams: FilterParams = {
+        display_name: params.get("display_name") ?? undefined,
+        street_address: params.get("street_address") ?? undefined,
+        postal_code: params.get("postal_code") ?? undefined,
+        developer: params.get("developer") ?? undefined,
+        property_manager: params.get("property_manager") ?? undefined,
+        archive_id: params.get("archive_id") ?? undefined,
+    };
+    if (params.get("is_regulated")) {
+        filterParams.is_regulated = params.get("is_regulated") ?? undefined;
+    }
+    return filterParams;
+};
+
 const HousingCompanyListPage = (): React.JSX.Element => {
-    const [filterParams, setFilterParams] = useState({is_regulated: "true"});
+    const navigate = useNavigate();
+    const [filterParams, setFilterParams] = useState({
+        is_regulated: "true",
+        ...getFilterDefaultsFromQueryParams(),
+    });
+
+    const updateFilters = (newFilters) => {
+        setFilterParams(newFilters);
+        // Update URL with new filters
+        const queryParams = new URLSearchParams(
+            // Remove undefined
+            JSON.parse(JSON.stringify(newFilters))
+        ).toString();
+        navigate(
+            {
+                pathname: location.pathname,
+                search: queryParams,
+            },
+            {replace: true}
+        );
+    };
 
     return (
         <div className="view--housing-company-list">
@@ -185,14 +230,14 @@ const HousingCompanyListPage = (): React.JSX.Element => {
                         label=""
                         filterFieldName="display_name"
                         filterParams={filterParams}
-                        setFilterParams={setFilterParams}
+                        setFilterParams={updateFilters}
                     />
                     <IconSearch />
                 </div>
                 <HousingCompanyResultsList filterParams={filterParams} />
                 <HousingCompanyFilters
                     filterParams={filterParams}
-                    setFilterParams={setFilterParams}
+                    setFilterParams={updateFilters}
                 />
             </div>
         </div>


### PR DESCRIPTION
# Hitas Pull Request

# Description

Housing company search view does not persist search parameters or pagination.

This PR adds persistence for both, which helps for example when peeking at search results and then navigating back to the search.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-750
