### PR TITLE
Add "arvio" to unconfirmed max price PDF title

### DIFF
--- a/backend/hitas/templates/unconfirmed_maximum_price.jinja
+++ b/backend/hitas/templates/unconfirmed_maximum_price.jinja
@@ -15,7 +15,7 @@
         <br>{{ apartment.address.postal_code }} {{ apartment.address.city|upper }}
     </h3>
 
-    <h4>HITAS-HUONEISTON ENIMMÄISHINTA<br>
+    <h4>HITAS-HUONEISTON ENIMMÄISHINTA-ARVIO<br>
     • ilman yhtiökohtaisia parannuksia ja mahdollista yhtiölainaosuutta</h4>
 
     <table>

--- a/backend/hitas/tests/apis/apartment_max_price/test_api_unconfirmed_max_price_pdf.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_unconfirmed_max_price_pdf.py
@@ -101,7 +101,7 @@ def test__api__unconfirmed_max_price_pdf(api_client: HitasAPIClient, freezer, no
         00099 HELSINGIN KAUPUNKI
         {apartment.address}
         {apartment.postal_code.value} HELSINKI
-        HITAS-HUONEISTON ENIMMÄISHINTA
+        HITAS-HUONEISTON ENIMMÄISHINTA-ARVIO
         \x7f ilman yhtiökohtaisia parannuksia ja mahdollista yhtiölainaosuutta
         Omistaja ja omistusosuus (%)
         {expected_name}
@@ -210,7 +210,7 @@ def test__api__unconfirmed_max_price_pdf__old_hitas_ruleset(api_client: HitasAPI
         00099 HELSINGIN KAUPUNKI
         {apartment.address}
         {apartment.postal_code.value} HELSINKI
-        HITAS-HUONEISTON ENIMMÄISHINTA
+        HITAS-HUONEISTON ENIMMÄISHINTA-ARVIO
         \x7f ilman yhtiökohtaisia parannuksia ja mahdollista yhtiölainaosuutta
         Omistaja ja omistusosuus (%)
         {ownership.owner.name}
@@ -428,7 +428,7 @@ def test__api__unconfirmed_max_price_pdf__past_date(api_client: HitasAPIClient, 
         00099 HELSINGIN KAUPUNKI
         {apartment.address}
         {apartment.postal_code.value} HELSINKI
-        HITAS-HUONEISTON ENIMMÄISHINTA
+        HITAS-HUONEISTON ENIMMÄISHINTA-ARVIO
         \x7f ilman yhtiökohtaisia parannuksia ja mahdollista yhtiölainaosuutta
         Omistaja ja omistusosuus (%)
         {ownership.owner.name}


### PR DESCRIPTION
# Hitas Pull Request

# Description

This PR adds the word "arvio" to the unconfirmed max price PDF title to help reduce confusion and amount of support tickets resulting from it.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been updated

## Tickets

HT-759
