### PR TITLE
Add default 0 for additional work in unconfirmed prices calculation

### DIFF
--- a/backend/hitas/services/indices.py
+++ b/backend/hitas/services/indices.py
@@ -361,9 +361,10 @@ def subquery_apartment_first_sale_acquisition_price_index_adjusted(
         first_sale_acquisition_price,
         output_field=HitasModelDecimalField(),
     )
+    additional_work = Coalesce(F("additional_work_during_construction"), 0, output_field=HitasModelDecimalField())
 
     return Round(
-        (acquisition_price + F("additional_work_during_construction") + interest)
+        (acquisition_price + additional_work + interest)
         * depreciation
         * current_value
         / NullIf(original_value, 0, output_field=HitasModelDecimalField()),  # prevent zero division errors


### PR DESCRIPTION
# Hitas Pull Request

# Description

If a user does not fill additional work in Apartment form, the unconfirmed prices on the Apartment details page are empty.

Filling in 0 on the form fixes the issue.

This could have been fixed by defaulting the form to 0, but then one of the fields would be inconsistent with the others.

Most of the code already does `additional_work_during_construction or 0` defaulting it to 0 if it is falsy (null).

There is one calculation that uses `additional_work_during_construction` without defaulting to 0.

This PR changes that calculation to also default to 0, solving the issue on the backend instead of changing one of the form fields.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-758
