### PR TITLE
Change CSRF error handling to open login URL in new tab when necessary

### DIFF
--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useEffect} from "react";
 import {Navigate, Route, Routes} from "react-router-dom";
 import App from "./app/App";
 import {selectIsAuthenticated} from "./app/authSlice";
@@ -35,6 +35,13 @@ export default function Router() {
     const protect = (element: React.JSX.Element) => {
         return isAuthenticated ? element : <Unauthorized />;
     };
+
+    function WindowClose() {
+        useEffect(() => {
+            window.close();
+        }, []);
+        return null;
+    }
 
     return (
         <Routes>
@@ -147,6 +154,10 @@ export default function Router() {
                 <Route
                     path="logout"
                     element={isAuthenticated ? <></> : <Logout />}
+                />
+                <Route
+                    path="window-close"
+                    element={<WindowClose />}
                 />
                 <Route
                     index

--- a/frontend/src/common/services/apis.ts
+++ b/frontend/src/common/services/apis.ts
@@ -69,7 +69,11 @@ const baseQueryWithReAuth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQue
         const errorMessage = (result.error?.data as {detail: string})?.detail;
         if (errorMessage?.startsWith("CSRF Failed:")) {
             hdsToast.error("CSRF Virhe. Uudelleenohjataan kirjautumissivulle.");
-            window.location.href = getSignInUrl(window.location.href);
+            setTimeout(() => {
+                // Open login in a new window/tab to avoid losing form data
+                const callBackUrl = new URL("/window-close", window.location.origin).toString();
+                window.open(getSignInUrl(callBackUrl), "_blank");
+            }, 1000);
         }
     }
     return result;


### PR DESCRIPTION
# Hitas Pull Request

# Description

Sometimes when a user hasn't used Hitas for a while, they get a CSRF error when submitting a form.

The frontend checks for this, and redirects the user to the login page, which will re-set the CSRF token cookie.

This will however clear the form.

This PR changes the check to open the login page in a new window or tab instead and then closes that new window or tab after login letting the user to re-submit the form without clearing it.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-762
