### PR TITLE
Change separate three month timestamp to calculation.valid_until

### DIFF
--- a/backend/hitas/services/email.py
+++ b/backend/hitas/services/email.py
@@ -84,7 +84,6 @@ def render_confirmed_max_price_calculation_pdf(
         "body_parts": pdf_body.texts,
         "title": filename,
         "date_today": datetime.date.strftime(timezone.now().date(), "%d.%m.%Y"),
-        "three_months_after_date_today": (timezone.now() + datetime.timedelta(days=90)).date(),
     }
     pdf = render_to_pdf(template="confirmed_maximum_price.jinja", context=context)
     return filename, pdf

--- a/backend/hitas/templates/confirmed_maximum_price.jinja
+++ b/backend/hitas/templates/confirmed_maximum_price.jinja
@@ -136,7 +136,7 @@
         {% if is_surface_area_maximum %}
             Enimmäismyyntihinta on vahvistettu rajahinnan perusteella ja laskelma on voimassa {{ maximum_price_calculation.valid_until|format_date }} asti.
         {% else %}
-            Enimmäismyyntihinta on voimassa {{ three_months_after_date_today|format_date }} asti.
+            Enimmäismyyntihinta on voimassa {{ maximum_price_calculation.valid_until|format_date }} asti.
         {% endif %}
     </p>
     <div class="plain-text">{{ body_parts.0|linebreaks }}</div>

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -1024,7 +1024,6 @@ class ApartmentViewSet(HitasModelViewSet):
             "maximum_price_calculation": mpc,
             "user": request.user,
             "body_parts": body_parts,
-            "three_months_after_date_today": (timezone.now() + datetime.timedelta(days=90)).date(),
         }
         pdf = get_pdf_response(filename=filename, template="confirmed_maximum_price.jinja", context=context)
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

This PR partially reverts the change from https://github.com/City-of-Helsinki/hitas/pull/517

The timestamp should be 90 days from calculation date, not 90 days from current date. `.valid_until` already matches that.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-763
