### PR TITLE
Add cross-field validation watch and trigger for purchase_price in ApartmentSale form

### DIFF
--- a/frontend/src/features/apartment/ApartmentSalePage/ApartmentSalePage.tsx
+++ b/frontend/src/features/apartment/ApartmentSalePage/ApartmentSalePage.tsx
@@ -90,6 +90,18 @@ const LoadedApartmentSalePage = () => {
     };
 
     useEffect(() => {
+        // purchase_price validation is dependant on, for example, share of loans and other maximum price calculations.
+        // Cross-field validation isn't automatically handled by react-hook-form so we need to notify the form when there are changes.
+        const subscription = formObject.watch((_value) => {
+            // Only trigger purchase_price validation if it has a value to avoid premature "field required" error.
+            if (_value.purchase_price || _value.purchase_price === 0) {
+                formObject.trigger(["purchase_price"]);
+            }
+        });
+        return () => subscription.unsubscribe();
+    }, [formObject.watch, formObject.trigger]);
+
+    useEffect(() => {
         // No need to trigger a validation when doing an apartments first sale
         // (Triggering can cause e.g. date fields to show errors prematurely if they are empty)
         if (!isApartmentFirstSale) {


### PR DESCRIPTION
# Hitas Pull Request

# Description

ApartmentSale form has a validation error on the `purchase_price` input which notifies the user if the calculation exceeds maximum prices. This is a cross-field validation. In other words the validity is dependent on multiple fields, not just `purchase_price`. For example the total price is calculated `purchase_price + apartment_share_of_housing_company_loans`.

react-hook-form does not automatically handle cross-field validation. If the user changes the value of `apartment_share_of_housing_company_loans`, which makes the calculation exceed the maximum prices and would make `purchase_price` invalid, the `purchase_price` form field isn't notified until the next `onChange` on `purchase_price`.

According to literature this is commonly solved by utilizing react-hook-form's `watch` and `trigger` methods.

This PR adds a `watch` over the whole ApartmentSale form and calls `trigger(["purchase_price"])` to re-validate `purchase_price` on any changes. The whole form is watched because multiple fields affect the calculation and there aren't many unrelated fields on the form.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-764