### PR TITLE
Change codes list ordering to be by name and add pagination

### DIFF
--- a/backend/hitas/tests/apis/test_api_owner.py
+++ b/backend/hitas/tests/apis/test_api_owner.py
@@ -38,9 +38,9 @@ def test__api__owner__list__empty(api_client: HitasAPIClient):
 
 @pytest.mark.django_db
 def test__api__owner__list(api_client: HitasAPIClient):
-    owner1: Owner = OwnerFactory.create()
-    owner2: Owner = OwnerFactory.create()
-    non_disclosure_owner = OwnerFactory.create(non_disclosure=True)
+    owner1: Owner = OwnerFactory.create(name="Aa Testinen")
+    owner2: Owner = OwnerFactory.create(name="Bb Testinen")
+    non_disclosure_owner = OwnerFactory.create(name="Cc Testinen", non_disclosure=True)
     deobfuscate(non_disclosure_owner)
     url = reverse("hitas:owner-list")
     response = api_client.get(url)

--- a/backend/hitas/tests/apis/test_api_property_manager.py
+++ b/backend/hitas/tests/apis/test_api_property_manager.py
@@ -30,8 +30,8 @@ def test__api__property_manager__list__empty(api_client: HitasAPIClient):
 
 @pytest.mark.django_db
 def test__api__property_manager__list(api_client: HitasAPIClient):
-    pm1: PropertyManager = PropertyManagerFactory.create()
-    pm2: PropertyManager = PropertyManagerFactory.create()
+    pm1: PropertyManager = PropertyManagerFactory.create(name="Aa Testinen")
+    pm2: PropertyManager = PropertyManagerFactory.create(name="Bb Testinen")
 
     url = reverse("hitas:property-manager-list")
     response = api_client.get(url)

--- a/backend/hitas/views/owner.py
+++ b/backend/hitas/views/owner.py
@@ -78,6 +78,9 @@ class OwnerViewSet(HitasModelViewSet):
     serializer_class = OwnerSerializer
     model_class = NonObfuscatedOwner
 
+    def get_queryset(self):
+        return super().get_queryset().exclude(name="", identifier__isnull=True).order_by("name")
+
     def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         instance: Owner = self.get_object()
 

--- a/backend/hitas/views/property_manager.py
+++ b/backend/hitas/views/property_manager.py
@@ -49,7 +49,7 @@ class PropertyManagerViewSet(HitasModelViewSet):
     model_class = PropertyManager
 
     def get_queryset(self):
-        return PropertyManager.objects.all().order_by("id")
+        return PropertyManager.objects.all().order_by("name")
 
     def get_filterset_class(self):
         return PropertyManagerFilterSet

--- a/frontend/src/common/components/mutateComponents/MutateSearchList.tsx
+++ b/frontend/src/common/components/mutateComponents/MutateSearchList.tsx
@@ -1,6 +1,6 @@
 import {Button, IconCrossCircle, IconPlus, IconSearch, TextInput} from "hds-react";
 import {useCallback, useRef, useState} from "react";
-import {QueryStateHandler} from "../index";
+import {ListPageNumbers, QueryStateHandler} from "../index";
 import {IMutateFormProps, MutateModal} from "./index";
 
 interface IResultListProps<
@@ -35,12 +35,14 @@ function ResultList<
     setEmptyFilterParams,
     mutateFormProps,
 }: IResultListProps<TFilterQueryParams, TListFieldsWithTitles, TFormFieldsWithTitles>) {
+    const [currentPage, setCurrentPage] = useState(1);
+
     // ensure the params have minimum length
     Object.keys(params).forEach(
         (key) => params[key]?.length && params[key]?.length < searchStringMinLength && delete params[key]
     );
     // get the data
-    const {data, error, isLoading} = useGetQuery({...params, limit: resultListMaxRows});
+    const {data, error, isLoading} = useGetQuery({...params, limit: resultListMaxRows, page: currentPage});
 
     // state for the modals
     const [isMutateModalVisible, setIsMutateModalVisible] = useState(false);
@@ -94,6 +96,11 @@ function ResultList<
                 ))}
             </div>
             <div className="list-footer">
+                <ListPageNumbers
+                    currentPage={currentPage}
+                    setCurrentPage={setCurrentPage}
+                    pageInfo={data?.page}
+                />
                 <div className="list-footer-item">
                     Näytetään {data?.page.size}/{data?.page.total_items} hakutulosta
                 </div>


### PR DESCRIPTION
# Hitas Pull Request

# Description

This PR changes owner and property manager lists in the codes section to be ordered alphabetically by name and also adds a pagination to all codes section lists.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automated tests have been updated

## Tickets

HT-766

HT-767
