### PR TITLE
Add property managers report

### DIFF
--- a/backend/hitas/urls.py
+++ b/backend/hitas/urls.py
@@ -106,6 +106,13 @@ router.register(
     basename="unregulated-housing-companies-report",
 )
 
+# /api/v1/reports/download-property-managers-report
+router.register(
+    r"reports/download-property-managers-report",
+    views.PropertyManagersReportView,
+    basename="property-managers-report",
+)
+
 # /api/v1/reports/housing-company-states
 router.register(
     r"reports/housing-company-states",

--- a/backend/hitas/views/__init__.py
+++ b/backend/hitas/views/__init__.py
@@ -36,6 +36,7 @@ from hitas.views.reports import (
     MultipleOwnershipsReportView,
     OwnershipsByCompanyJSONReportView,
     OwnershipsByHousingCompanyReport,
+    PropertyManagersReportView,
     RegulatedHousingCompaniesReportView,
     RegulatedOwnershipsReportView,
     SalesAndMaximumPricesReportView,

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -4631,6 +4631,27 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /api/v1/reports/download-property-managers-report:
+    get:
+      description: Download an Excel report of property managers and their housing companies
+      operationId: fetch-property-managers-report-excel
+      tags:
+        - Reports
+      responses:
+        "200":
+          description: Successfully downloaded a report of property managers
+          content:
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                type: string
+                format: binary
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /api/v1/reports/housing-company-states:
     get:
       description: Get housing companies counted by their states


### PR DESCRIPTION
# Hitas Pull Request

# Description

This PR adds a new Excel report listing property managers and their housing companies. The report should also include property managers that have no housing companies. This information may be used to assess the need for cleaning up unused property managers.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added

## Tickets

HT-765
