### PR TITLE
Add legacy_release_date as an editable field for housing company

### DIFF
--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -371,6 +371,7 @@ def test__api__housing_company__retrieve(api_client: HitasAPIClient, apt_with_nu
         "notes": hc1.notes,
         "archive_id": hc1.id,
         "release_date": hc1.legacy_release_date,
+        "legacy_release_date": hc1.legacy_release_date,
         "last_modified": {
             "datetime": log.timestamp.isoformat().replace("+00:00", "Z"),
             "user": {

--- a/backend/hitas/views/housing_company.py
+++ b/backend/hitas/views/housing_company.py
@@ -356,6 +356,7 @@ class HousingCompanyDetailSerializer(EnumSupportSerializerMixin, HitasModelSeria
             "notes",
             "archive_id",
             "release_date",
+            "legacy_release_date",
             "last_modified",
             "summary",
             "improvements",

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -5769,6 +5769,11 @@ components:
           format: date
           nullable: true
           readOnly: true
+        legacy_release_date:
+          description: Regulation release date for legacy housing companies. Overrides release_date.
+          type: string
+          format: date
+          nullable: true
         archive_id:
           description: Archive ID for this housing company
           type: integer

--- a/frontend/src/common/schemas/housingCompany.ts
+++ b/frontend/src/common/schemas/housingCompany.ts
@@ -112,6 +112,7 @@ export const HousingCompanyDetailsSchema = object({
     notes: string().nullable(),
     archive_id: number(),
     release_date: string().nullable(),
+    legacy_release_date: string().nullable(),
     last_modified: object({
         user: object({
             user: string().nullable(),
@@ -140,6 +141,7 @@ export const HousingCompanyWritableSchema = HousingCompanyDetailsSchema.pick({
     hitas_type: true,
     exclude_from_statistics: true,
     regulation_status: true,
+    legacy_release_date: true,
     address: true,
     acquisition_price: true,
     primary_loan: true,

--- a/frontend/src/features/housingCompany/HousingCompanyCreatePage.tsx
+++ b/frontend/src/features/housingCompany/HousingCompanyCreatePage.tsx
@@ -1,6 +1,6 @@
 import React, {useContext, useRef, useState} from "react";
 
-import {Fieldset, IconQuestionCircle} from "hds-react";
+import {Fieldset, IconQuestionCircle, TextInput as HDSTextInput} from "hds-react";
 import {useNavigate} from "react-router-dom";
 
 import {zodResolver} from "@hookform/resolvers/zod";
@@ -35,7 +35,7 @@ import {
     useGetPropertyManagersQuery,
     useSaveHousingCompanyMutation,
 } from "../../common/services";
-import {hdsToast, setAPIErrorsForFormFields, validateBusinessId} from "../../common/utils";
+import {formatDate, hdsToast, setAPIErrorsForFormFields, validateBusinessId} from "../../common/utils";
 import {
     HousingCompanyViewContext,
     HousingCompanyViewContextProvider,
@@ -63,6 +63,7 @@ const getInitialFormData = (housingCompany): IHousingCompanyWritable => {
         hitas_type: "new_hitas_1",
         exclude_from_statistics: false,
         regulation_status: "regulated",
+        legacy_release_date: null,
         building_type: {id: ""},
         business_id: "",
         developer: {id: ""},
@@ -137,6 +138,17 @@ const LoadedHousingCompanyCreatePage = (): React.JSX.Element => {
             });
     };
 
+    const getReleaseDateDisplay = (housingCompany?: IHousingCompanyDetails) => {
+        if (housingCompany) {
+            if (housingCompany.legacy_release_date) {
+                return "Vapautumispäivä korvattu";
+            } else if (housingCompany.release_date) {
+                return formatDate(housingCompany.release_date);
+            }
+        }
+        return "Ei vapautumispäivää";
+    };
+
     return (
         <>
             <FormProviderForm
@@ -205,6 +217,19 @@ const LoadedHousingCompanyCreatePage = (): React.JSX.Element => {
                                 defaultValue={initialFormData.hitas_type}
                                 setDirectValue
                                 required
+                            />
+                        </div>
+                        <div className="row">
+                            <HDSTextInput
+                                id="release_date"
+                                label="Laskennallinen vapautumispäivä"
+                                readOnly={true}
+                                defaultValue={getReleaseDateDisplay(housingCompany)}
+                            />
+                            <DateInput
+                                label="Korvaava vapautumispäivä"
+                                tooltipText="Tällä kentällä voi korvata automaattisesti lasketun vapautumispäivän. Oletuksena kentän voi jättää tyhjäksi."
+                                name="legacy_release_date"
                             />
                         </div>
                         <div className="row">

--- a/frontend/src/styles/components/_HousingCompanyPage.sass
+++ b/frontend/src/styles/components/_HousingCompanyPage.sass
@@ -152,3 +152,8 @@
 
   [class^="StatusLabel"]
     background-color: var(--color-engel-light)
+
+#release_date[readonly]
+  padding: 0 var(--spacing-s)
+  background-color: var(--input-background-default)
+  cursor: default


### PR DESCRIPTION
# Hitas Pull Request

# Description

This PR adds `legacy_release_date` as an editable field for housing companies so that corrections can be made to the release dates of housing companies by the plot department.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added

## Tickets

HT-771