### PR TITLE
Change owner identifier to allow empty input

### DIFF
--- a/frontend/src/common/components/mutateComponents/OwnerMutateForm.tsx
+++ b/frontend/src/common/components/mutateComponents/OwnerMutateForm.tsx
@@ -124,7 +124,6 @@ export default function OwnerMutateForm({
                 <TextInput
                     name="identifier"
                     label="Henkilö- tai Y-tunnus"
-                    required
                 />
                 <TextInput
                     name="email"

--- a/frontend/src/common/schemas/owner.ts
+++ b/frontend/src/common/schemas/owner.ts
@@ -12,7 +12,9 @@ export const OwnerSchema = object({
         .max(256, errorMessages.stringMaxIs + "256"),
     identifier: string({required_error: errorMessages.required})
         .min(1, errorMessages.required)
-        .max(11, errorMessages.stringMaxIs + "11"),
+        .max(11, errorMessages.stringMaxIs + "11")
+        .nullish()
+        .or(z.literal("")),
     email: string().email(errorMessages.emailInvalid).nullish().or(z.literal("")),
     non_disclosure: boolean(),
 });

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -70,7 +70,8 @@ export function formatDate(value: string | null): string {
     return new Date(value).toLocaleDateString("fi-FI");
 }
 
-export function validateBusinessId(value: string): boolean {
+export function validateBusinessId(value: string | null | undefined): boolean {
+    if (value === null || value === undefined) return false;
     // This does not validate the check digit (last number), only the format
     // e.g. '1234567-8'
     // Returns true if the format is valid
@@ -83,8 +84,8 @@ export function validatePropertyId(value: string): boolean {
     return !!value.match(/^\d{1,4}-\d{1,4}-\d{1,4}-\d{1,4}$/);
 }
 
-export function validateSocialSecurityNumber(value: string): boolean {
-    if (value === null) return false;
+export function validateSocialSecurityNumber(value: string | null | undefined): boolean {
+    if (value === null || value === undefined) return false;
     if (!value.match(/^(\d{6})([A-FYXWVU+-])(\d{3})([\dA-Z])$/)) {
         return false;
     }


### PR DESCRIPTION
because some already are empty and they need to be editable

# Hitas Pull Request

# Description

Some Owners in the database are already missing the `identifier` field. This PR makes it possible to edit the name of such Owners without touching the `identifier` field.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-772
