### PR TITLE
Fix crash caused by clearing ThirtyYearErrorTest select input

### DIFF
--- a/frontend/src/features/functions/ThirtyYearRegulationTabComponents/ThirtyYearErrorTest.tsx
+++ b/frontend/src/features/functions/ThirtyYearRegulationTabComponents/ThirtyYearErrorTest.tsx
@@ -84,6 +84,7 @@ const ThirtyYearErrorTest = () => {
                     options={testOptions}
                     defaultValue="result_noProblems"
                     setDirectValue
+                    required
                 />
             </FormProviderForm>
             <ThirtyYearErrorTestResult


### PR DESCRIPTION
# Hitas Pull Request

# Description

Clearing the ThirtyYearErrorTest select input crashes the frontend. This input shouldn't be clearable either way, so this PR changes it to be required, which also makes it non-clearable.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-773
