### PR TITLE
Change textarea font-family back to 'inherit' after HDS upgrade

### DIFF
--- a/frontend/src/styles/components/_Forms.sass
+++ b/frontend/src/styles/components/_Forms.sass
@@ -15,6 +15,9 @@
 input, input + label::before
   --focus-outline-color: var(--color-black-50)
 
+textarea
+  font-family: inherit
+
 [class*="input_hds-text-input__error-text"], [class*="text-input_hds-text-input__helper-text"]
   margin-top: 0 !important
   // top: -6px


### PR DESCRIPTION
# Hitas Pull Request

# Description

See https://github.com/City-of-Helsinki/hitas/pull/529
