### PR TITLE
Fix aggregate functions that included soft-deleted rows

### DIFF
--- a/backend/hitas/calculations/max_prices/max_price.py
+++ b/backend/hitas/calculations/max_prices/max_price.py
@@ -56,10 +56,11 @@ def create_max_price_calculation(
     apartment_share_of_housing_company_loans_date: datetime.date,
     additional_info: Optional[str],
 ) -> Dict[str, Any]:
+    non_deleted = Q(real_estates__buildings__apartments__deleted__isnull=True)
     housing_company = HousingCompany.objects.annotate(
         _completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"),
-        _last_apartment_completion_date=Max("real_estates__buildings__apartments__completion_date"),
-        sum_surface_area=Sum("real_estates__buildings__apartments__surface_area"),
+        _last_apartment_completion_date=Max("real_estates__buildings__apartments__completion_date", filter=non_deleted),
+        sum_surface_area=Sum("real_estates__buildings__apartments__surface_area", filter=non_deleted),
     ).get(uuid=housing_company_uuid)
 
     # For RR_NEW_HITAS housing companies (Ryhmärakentamiskohde kohde), the completion date is the date of the last

--- a/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
+++ b/backend/hitas/tests/apis/apartment_max_price/test_api_apartment_max_price_calc_examples.py
@@ -53,6 +53,12 @@ def test__api__apartment_max_price__construction_price_index__2011_onwards(api_c
         completion_date=datetime.date(2019, 11, 27),
         surface_area=4302,
     )
+    # Soft-deleted apartments should not be included in the calculation
+    ApartmentFactory.create(
+        building__real_estate__housing_company=a.housing_company,
+        completion_date=datetime.date(2020, 11, 27),
+        surface_area=4302,
+    ).delete()
 
     # Construction price improvement is not used, since this apartment's housing company is using new hitas rules!
     HousingCompanyConstructionPriceImprovementFactory.create(

--- a/backend/hitas/tests/apis/test_api_housing_company.py
+++ b/backend/hitas/tests/apis/test_api_housing_company.py
@@ -232,6 +232,16 @@ def test__api__housing_company__retrieve(api_client: HitasAPIClient, apt_with_nu
         sales__purchase_price=300.5,
         sales__apartment_share_of_housing_company_loans=400.0,
     )
+    # Soft-deleted apartments should not be included
+    ApartmentFactory.create(
+        building=hc1_re1_bu1,
+        completion_date=date(2020, 1, 1),
+        surface_area=20.5,
+        share_number_end=200,
+        share_number_start=101,
+        sales=[],
+    ).delete()
+
     hc1_re1_bu2: Building = BuildingFactory.create(real_estate=hc1_re1)
     ApartmentFactory.create(
         building=hc1_re1_bu2,

--- a/backend/hitas/tests/apis/test_api_reports.py
+++ b/backend/hitas/tests/apis/test_api_reports.py
@@ -612,6 +612,13 @@ def test__api__regulated_housing_companies_report__multiple_housing_companies(ap
         apartment__building__real_estate__housing_company=housing_company_2,
     )
 
+    # Soft-deleted apartments should not be included in the report
+    soft_delete_apartment = ApartmentFactory.create(
+        building=sale_2.apartment.building,
+        sales=[],
+    )
+    soft_delete_apartment.delete()
+
     url = reverse("hitas:regulated-housing-companies-report-list")
     response: HttpResponse = api_client.get(url)
 
@@ -679,6 +686,13 @@ def test__api__half_hitas_housing_companies_report__multiple_housing_companies(a
         apartment__completion_date=datetime.date(2021, 1, 1),
         apartment__building__real_estate__housing_company=housing_company_2,
     )
+
+    # Soft-deleted apartments should not be included in the report
+    soft_delete_apartment = ApartmentFactory.create(
+        building=sale_2.apartment.building,
+        sales=[],
+    )
+    soft_delete_apartment.delete()
 
     url = reverse("hitas:half-hitas-housing-companies-report-list")
     response: HttpResponse = api_client.get(url)
@@ -813,6 +827,12 @@ def test__api__unregulated_housing_companies_report__legacy_release_date(api_cli
         completion_date=datetime.date(2021, 1, 1),
         building__real_estate__housing_company=housing_company,
     )
+
+    # Soft-deleted apartments should not be included in the report
+    soft_delete_apartment = ApartmentFactory.create(
+        building=apartment_2.building,
+    )
+    soft_delete_apartment.delete()
 
     url = reverse("hitas:unregulated-housing-companies-report-list")
     response: HttpResponse = api_client.get(url)
@@ -1083,6 +1103,12 @@ def test__api__housing_company_states_report__not_completed(api_client: HitasAPI
         completion_date=None,
         building__real_estate__housing_company=housing_company,
     )
+
+    # Soft-deleted apartments should not be included in the report
+    soft_delete_apartment = ApartmentFactory.create(
+        building__real_estate__housing_company=housing_company,
+    )
+    soft_delete_apartment.delete()
 
     url = reverse("hitas:housing-company-states-report-list")
     response: HttpResponse = api_client.get(url)

--- a/backend/hitas/tests/apis/thirty_year_regulation/utils.py
+++ b/backend/hitas/tests/apis/thirty_year_regulation/utils.py
@@ -61,6 +61,15 @@ def create_thirty_year_old_housing_company(
         building__real_estate__housing_company__regulation_status=RegulationStatus.REGULATED,
         **apartment_kwargs,
     )
+
+    # Soft-deleted apartments should not be included
+    soft_delete_apartment = ApartmentFactory.create(
+        surface_area=10,
+        completion_date=regulation_month,
+        sales=[],
+        building=apartment.building,
+    )
+    soft_delete_apartment.delete()
     return apartment.housing_company
 
 

--- a/backend/hitas/tests/factories/apartment.py
+++ b/backend/hitas/tests/factories/apartment.py
@@ -92,6 +92,12 @@ def create_apartment_max_price_calculation(create_indices=True, **kwargs) -> Apa
             building__real_estate__housing_company__hitas_type=HitasType.NEW_HITAS_I,
         )
 
+    # Soft-deleted apartments should not be included in the calculation
+    ApartmentFactory.create(
+        completion_date=FuzzyDate(date(2011, 1, 1), date(2020, 1, 1)).fuzz(),
+        building=kwargs["apartment"].building,
+    ).delete()
+
     if "calculation_date" not in kwargs:
         kwargs["calculation_date"] = FuzzyDate(date(2015, 1, 1)).fuzz()
 

--- a/backend/hitas/views/apartment.py
+++ b/backend/hitas/views/apartment.py
@@ -907,11 +907,14 @@ class ApartmentViewSet(HitasModelViewSet):
         return self.get_base_queryset().filter(building__real_estate__housing_company__id=hc_id)
 
     def get_detail_queryset(self):
+        non_deleted = Q(real_estates__buildings__apartments__deleted__isnull=True)
         housing_company = (
             HousingCompany.objects.filter(uuid=self.kwargs["housing_company_uuid"])
             .annotate(
                 _completion_date=max_date_if_all_not_null("real_estates__buildings__apartments__completion_date"),
-                _last_apartment_completion_date=Max("real_estates__buildings__apartments__completion_date"),  # For RR
+                _last_apartment_completion_date=Max(
+                    "real_estates__buildings__apartments__completion_date", filter=non_deleted
+                ),  # For RR
             )
             .first()
         )

--- a/backend/hitas/views/building.py
+++ b/backend/hitas/views/building.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from uuid import UUID
 
-from django.db.models import Count
+from django.db.models import Count, Q
 from rest_framework import serializers
 
 from hitas.exceptions import HitasModelNotFound, ModelConflict
@@ -90,7 +90,7 @@ class BuildingViewSet(HitasModelViewSet):
             Building.objects.filter(real_estate__id=re_id)
             .select_related("real_estate__housing_company__postal_code")
             .annotate(
-                apartment_count=Count("apartments"),
+                apartment_count=Count("apartments", filter=Q(apartments__deleted__isnull=True)),
             )
             .only(
                 "uuid",


### PR DESCRIPTION
# Hitas Pull Request

# Description

Various models in Hitas use django-safedelete for soft-delete. Django-safedelete automatically and transparently handles most situations where soft-deleted rows should not be included. However if you bypass application code such as model managers, and instead use database aggregation such as Min, Max, Sum or Count, these will not automatically exclude soft-deleted rows.

This PR adds tests for various apartment related issues, where aggregates should not have included soft-deleted apartments, and fixes for those issues.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added

## Tickets

HT-699
