### PR TITLE
Remove `LogEntry.delete` code as unused

### DIFF
--- a/backend/hitas/services/audit_log.py
+++ b/backend/hitas/services/audit_log.py
@@ -53,7 +53,7 @@ def bulk_create_log_entries(
         )
 
     # Delete log entries with the same pk as a newly created model.
-    if action is LogEntry.Action.CREATE:
+    if action is LogEntry.Action.CREATE and log_entries:
         condition = Q()
         for log_entry in log_entries:
             condition |= Q(content_type=log_entry.content_type) & (

--- a/backend/hitas/services/audit_log.py
+++ b/backend/hitas/services/audit_log.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Iterable, Literal, Optional, TypeAlias, overlo
 
 from auditlog.models import LogEntry
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import DateTimeField, OuterRef, Q, Subquery
+from django.db.models import DateTimeField, OuterRef, Subquery
 from django.utils.encoding import smart_str
 
 if TYPE_CHECKING:
@@ -51,16 +51,6 @@ def bulk_create_log_entries(
                 additional_data=additional_data,
             )
         )
-
-    # Delete log entries with the same pk as a newly created model.
-    if action is LogEntry.Action.CREATE and log_entries:
-        condition = Q()
-        for log_entry in log_entries:
-            condition |= Q(content_type=log_entry.content_type) & (
-                Q(object_pk=log_entry.object_pk) | Q(object_id=log_entry.object_id)
-            )
-
-        LogEntry.objects.filter(condition).delete()
 
     return LogEntry.objects.bulk_create(log_entries, ignore_conflicts=True)
 


### PR DESCRIPTION
# Hitas Pull Request

# Description

In the [related code](https://github.com/City-of-Helsinki/hitas/blob/0a47eac34df03bb655bd5cd912ffe6579e995a63/backend/hitas/services/audit_log.py#L23-L65), the variable `log_entries` starts as an empty list. If it remains empty then the later code will delete all `LogEntry` objects using `LogEntry.objects.filter(Q()).delete()` which is functionally the same as `LogEntry.objects.all().delete()`.

~~As a failsafe this PR adds a check that the `log_entries` list is non-empty.~~

As I was planning a test for that, I noticed that:

- Tests pass even if the `LogEntry.delete` block of code is removed.
- There is no test that asserts that the `LogEntry.delete` succeeded. In other words there are no tests that test the delete functionality.
- Reading out the count of deleted objects, there are _no tests_ where the count is more than `0`, _except_ for two tests that actually trigger the bug and delete the whole `LogEntry` table.

Because of the above, I could not figure out why the delete code exists and in which case does it actually delete something other than the whole table. Also this code existing prevents changing the `LogEntry` table to disallow deleting at the database level.

If there were ever `LogEntry` rows to be deleted, these should be duplicate `LogEntry.Action.CREATE` events for the same pk, and should be easy to remove later if needed.

Based on these I decided to remove the code block.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

## Tickets

HT-777
