### PR TITLE
Fix half-hitas last sale to trigger housing company release only if out-of-regulation

### DIFF
--- a/backend/hitas/views/apartment_sale.py
+++ b/backend/hitas/views/apartment_sale.py
@@ -138,8 +138,13 @@ class ApartmentSaleCreateSerializer(HitasModelSerializer):
                 ],
             )
 
-            # Half hitas housing companies are released from regulation when their last apartment is sold.
-            if apartment.housing_company.hitas_type == HitasType.HALF_HITAS:
+            # Half hitas housing companies are released from regulation when their last apartment is sold
+            # and they are past the 2-year regulation period.
+            if (
+                apartment.housing_company.hitas_type == HitasType.HALF_HITAS
+                and apartment.housing_company.completion_date is not None
+                and apartment.housing_company.completion_date <= timezone.now().date() - relativedelta(years=2)
+            ):
                 unsold_apartments = get_number_of_unsold_apartments(apartment.housing_company)
                 if unsold_apartments == 0:
                     apartment.housing_company.regulation_status = RegulationStatus.RELEASED_BY_HITAS


### PR DESCRIPTION
# Hitas Pull Request

# Description

Half-hitas housing companies should be released only after both conditions are true:

- All of the apartments in the housing company have been sold.
- The housing company has been completed at least 2 years ago.

Only the first condition was being checked.

This PR adds the other check and a test for it.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added

## Tickets

HT-778
