### PR TITLE
Change SalesAndMaximumPricesReport to filter resales only

### DIFF
--- a/backend/hitas/tests/apis/test_api_reports.py
+++ b/backend/hitas/tests/apis/test_api_reports.py
@@ -438,6 +438,13 @@ def test__api__sales_and_maximum_prices_report(api_client: HitasAPIClient):
         apartment__building__real_estate__housing_company__postal_code__value="00001",
         apartment__building__real_estate__housing_company__postal_code__cost_area=1,
     )
+    # Re-create sale as only resales are included in the report
+    sale_1: ApartmentSale = ApartmentSaleFactory.create(
+        purchase_date=datetime.date(2020, 1, 1),
+        purchase_price=50_000,
+        apartment_share_of_housing_company_loans=10_000,
+        apartment=sale_1.apartment,
+    )
     sale_2: ApartmentSale = ApartmentSaleFactory.create(
         purchase_date=datetime.date(2020, 2, 15),
         purchase_price=130_000,
@@ -445,6 +452,13 @@ def test__api__sales_and_maximum_prices_report(api_client: HitasAPIClient):
         apartment__surface_area=100,
         apartment__building__real_estate__housing_company__postal_code__value="00002",
         apartment__building__real_estate__housing_company__postal_code__cost_area=1,
+    )
+    # Re-create sale as only resales are included in the report
+    sale_2: ApartmentSale = ApartmentSaleFactory.create(
+        purchase_date=datetime.date(2020, 2, 15),
+        purchase_price=130_000,
+        apartment_share_of_housing_company_loans=100,
+        apartment=sale_2.apartment,
     )
     # Valid calculation
     ApartmentMaximumPriceCalculationFactory.create(

--- a/backend/hitas/views/reports.py
+++ b/backend/hitas/views/reports.py
@@ -78,7 +78,7 @@ class SalesAndMaximumPricesReportView(ViewSet):
         start: datetime.date = serializer.validated_data["start_date"]
         end: datetime.date = serializer.validated_data["end_date"]
 
-        sales = find_sales_on_interval_for_reporting(start_date=start, end_date=end)
+        sales = find_sales_on_interval_for_reporting(start_date=start, end_date=end, sales_filter="resale")
         workbook = build_sales_and_maximum_prices_report_excel(sales)
         filename = f"Hitas kauppa- ja enimmäishinnat aikavälillä {start.isoformat()} - {end.isoformat()}.xlsx"
         return get_excel_response(filename=filename, excel=workbook)


### PR DESCRIPTION
# Hitas Pull Request

# Description

To resolve reporting issues, it was requested that SalesAndMaximumPricesReport would only contain resales.

This PR adds `sales_filter="resale"` to the report to resolve the issues.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
  - [x] Automatic tests have been added

## Tickets

HT-782
