### PR TITLE
Revert django-auditlog from 3.x to 2.x

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -651,18 +651,18 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-auditlog"
-version = "3.2.0"
+version = "2.3.0"
 description = "Audit log app for Django"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "django_auditlog-3.2.0-py3-none-any.whl", hash = "sha256:63d02326c5b069cd5ae390c4729076f1d935c3a9cefc27893e79a01c42cd1a78"},
-    {file = "django_auditlog-3.2.0.tar.gz", hash = "sha256:66cf3945977ba60e0687fc264ac178f0c7b0eee013f25e1c63561d8ceb6a5c41"},
+    {file = "django-auditlog-2.3.0.tar.gz", hash = "sha256:b9d3acebb64f3f2785157efe3f2f802e0929aafc579d85bbfb9827db4adab532"},
+    {file = "django_auditlog-2.3.0-py3-none-any.whl", hash = "sha256:7bc2c87e4aff62dec9785d1b2359a2b27148f8c286f8a52b9114fc7876c5a9f7"},
 ]
 
 [package.dependencies]
-Django = ">=4.2"
+Django = ">=3.2"
 python-dateutil = ">=2.7.0"
 
 [[package]]
@@ -3609,4 +3609,4 @@ test = ["coverage (>=5.3)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "tox"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "dbcd897b038c7e1a8b690761414b0cc766f0a0f0ea02ffaf2dd5e7d6f4586035"
+content-hash = "f35edefc3e96620f65330e5d0424183a27b18195555cc099fd3b7bc07bfbd690"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ authors = []
 
 [tool.poetry.dependencies]
 Django = "^5.2.4"
-django-auditlog = "3.2.0"
+django-auditlog = "2.3.0"
 django-cors-headers = "^4.7.0"
 django-crum = "^0.7.9"
 django-enumfields2 = "^3.0.2" # Drop-in replacement for django-enumfields, which is not compatible with Python 3.11+


### PR DESCRIPTION
# Hitas Pull Request

# Description

Other changes need to be deployed to production. This PR reverts django-auditlog back to 2.x to delay production 3.x upgrade for now.
