### PR TITLE
Change logout method from GET to POST due to Django upgrade

### DIFF
--- a/frontend/src/app/useAuthentication.ts
+++ b/frontend/src/app/useAuthentication.ts
@@ -1,3 +1,4 @@
+import {getCookie} from "typescript-cookie";
 import {getLogOutUrl, getSignInUrl} from "../common/utils";
 import {setIsAuthenticating} from "./authSlice";
 import {useAppDispatch} from "./hooks";
@@ -15,7 +16,21 @@ export default function useAuthentication() {
     // Log the user out and redirect to route /logout
     const logOut = () => {
         dispatch(setIsAuthenticating(true));
-        window.location.href = getLogOutUrl();
+
+        // Django logout must be a POST request with CSRF token
+        const form = document.createElement("form");
+        form.method = "POST";
+        form.action = getLogOutUrl();
+
+        const input = document.createElement("input");
+        input.type = "hidden";
+        input.name = "csrfmiddlewaretoken";
+        input.value = getCookie("csrftoken") || "";
+        form.appendChild(input);
+
+        document.body.appendChild(form);
+        form.submit();
+        form.remove();
     };
 
     return {logOut, signIn};

--- a/frontend/src/common/utils.ts
+++ b/frontend/src/common/utils.ts
@@ -196,7 +196,7 @@ export const getSignInUrl = (callBackUrl: string): string => {
 export const getLogOutUrl = (): string => {
     const baseUrl = new URL(window.location.href).origin;
     const callBackUrl = baseUrl + `/logout`;
-    return Config.api_auth_url + "/logout?next=" + callBackUrl;
+    return Config.api_auth_url + "/logout/?next=" + callBackUrl;
 };
 
 // Returns apartment's maximum unconfirmed prices, whether they are pre-2011 or onwards-2011


### PR DESCRIPTION
# Hitas Pull Request

# Description

Django now requires logout to be POST. This PR changes the logout method from GET to POST.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested

