### PR TITLE
Add venv to path for containers that run the image without the entrypoint script

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -88,6 +88,9 @@ FROM base AS production
 USER hitas
 WORKDIR /hitas/backend/
 
+ENV PATH=/hitas/venv/bin:$PATH
+ENV VIRTUAL_ENV=/hitas/venv
+
 # Copy project files, virtualenv, static files, and translations.
 COPY --chown=hitas:hitas . .
 COPY --chown=hitas:hitas --from=builder /hitas/venv /hitas/venv


### PR DESCRIPTION
# Hitas Pull Request

# Description

Currently the Dockerfile sets up a virtualenv for python but it is only activated in the entrypoint script. Containers such as the log transfer container do not activate virtualenv since they're built for images that do not set up virtualenv. As a workaround for now this PR adds venv to PATH.
