### PR TITLE
Change previous CSRF error workaround to attempt CSRF refresh silently before falling back to re-login

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -6,7 +6,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.static import serve
 
 from hitas.views.health import HealthCheckView
-from users.views import UserInfoView
+from users.views import CsrfTokenView, UserInfoView
 
 
 class HitasLogoutView(helusers.views.LogoutView):
@@ -36,6 +36,7 @@ urlpatterns = [
     path("healthz", HealthCheckView.as_view(), name="health_check"),
     path("pysocial/", include("social_django.urls", namespace="social")),
     path("helauth/", include(helusers_pattern)),
+    path("helauth/csrf/", CsrfTokenView.as_view(), name="csrf"),
     path("helauth/userinfo/", UserInfoView.as_view(), name="userinfo"),
     # Static files can be served using django's built in static file server
     # since they are only used to serve admin panel assets.

--- a/backend/hitas/tests/apis/test_api_csrf.py
+++ b/backend/hitas/tests/apis/test_api_csrf.py
@@ -1,0 +1,13 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from hitas.tests.apis.helpers import HitasAPIClient
+
+
+@pytest.mark.django_db
+def test__api__csrf__refreshes_csrf_cookie(api_client: HitasAPIClient):
+    response = api_client.get(reverse("csrf"))
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert "csrftoken" in response.cookies

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -4525,6 +4525,16 @@ paths:
 
   # Helsinki profile authentication
 
+  /helauth/csrf/:
+    get:
+      description: Refresh CSRF cookie for the current browser session
+      operationId: refresh-csrf-cookie
+      tags:
+        - Helauth
+      responses:
+        "204":
+          description: Successfully refreshed CSRF cookie
+
   /helauth/userinfo/:
     get:
       description: Get user info for the currently logged in user

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,11 +1,23 @@
 import json
 from base64 import urlsafe_b64decode
 
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import ensure_csrf_cookie
 from rest_framework import status
+from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from social_django.models import UserSocialAuth
+
+
+@method_decorator(ensure_csrf_cookie, name="dispatch")
+class CsrfTokenView(APIView):
+    authentication_classes = []
+    permission_classes = [AllowAny]
+
+    def get(self, request: Request, *args, **kwargs) -> Response:
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class UserInfoView(APIView):

--- a/frontend/src/common/services/apis.test.ts
+++ b/frontend/src/common/services/apis.test.ts
@@ -1,0 +1,56 @@
+import {BaseQueryApi} from "@reduxjs/toolkit/query";
+
+import {baseQueryWithReAuth} from "./apis";
+
+jest.mock("typescript-cookie", () => ({
+    getCookie: jest.fn(() => "csrf-token"),
+}));
+
+jest.mock("../utils", () => ({
+    getSignInUrl: jest.fn(() => "https://example.com/login"),
+    hdsToast: {
+        error: jest.fn(),
+    },
+}));
+
+describe("baseQueryWithReAuth", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("refreshes csrf cookie and retries a failed mutation once", async () => {
+        const fetchMock = jest
+            .spyOn(global, "fetch")
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({detail: "CSRF Failed: CSRF token missing."}), {
+                    status: 403,
+                    headers: {"Content-Type": "application/json"},
+                })
+            )
+            .mockResolvedValueOnce(new Response(null, {status: 204}))
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ok: true}), {
+                    status: 200,
+                    headers: {"Content-Type": "application/json"},
+                })
+            );
+        const windowOpenMock = jest.spyOn(window, "open").mockImplementation(() => null);
+        const api = {
+            type: "mutation",
+            endpoint: "testMutation",
+            forced: false,
+            dispatch: jest.fn(),
+            getState: jest.fn(),
+            signal: new AbortController().signal,
+            abort: jest.fn(),
+            extra: undefined,
+        } as BaseQueryApi;
+
+        const result = await baseQueryWithReAuth({url: "/test", method: "POST", body: {hello: "world"}}, api, {});
+
+        expect(result).toEqual({data: {ok: true}, meta: expect.any(Object)});
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect((fetchMock.mock.calls[1][0] as Request).url).toContain("/helauth/csrf/");
+        expect(windowOpenMock).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/common/services/apis.ts
+++ b/frontend/src/common/services/apis.ts
@@ -49,7 +49,21 @@ const baseQuery = fetchBaseQuery({
     ...(!Config.token && {credentials: "include"}),
 });
 
-const baseQueryWithReAuth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = async (
+const authQuery = fetchBaseQuery({
+    baseUrl: Config.api_auth_url,
+    credentials: "include",
+});
+
+export const isCsrfFailure = (error?: FetchBaseQueryError): boolean => {
+    if (!error || error.status !== 403) {
+        return false;
+    }
+
+    const errorMessage = (error.data as {detail?: string})?.detail;
+    return errorMessage?.startsWith("CSRF Failed:") ?? false;
+};
+
+export const baseQueryWithReAuth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = async (
     args,
     api,
     extraOptions
@@ -62,18 +76,29 @@ const baseQueryWithReAuth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQue
     // Since we have access to both `api.extra` and `extraOptions` here, we can emulate that behavior by applying the `extraOptions`.
     api.extra = {...(api.extra ?? {}), ...extraOptions};
 
-    const result = await baseQuery(args, api, extraOptions);
+    let result = await baseQuery(args, api, extraOptions);
 
-    // Handle CSRF errors by redirecting to login page
-    if (result.error && result.error.status === 403) {
-        const errorMessage = (result.error?.data as {detail: string})?.detail;
-        if (errorMessage?.startsWith("CSRF Failed:")) {
-            hdsToast.error("CSRF Virhe. Uudelleenohjataan kirjautumissivulle.");
-            setTimeout(() => {
-                // Open login in a new window/tab to avoid losing form data
-                const callBackUrl = new URL("/window-close", window.location.origin).toString();
-                window.open(getSignInUrl(callBackUrl), "_blank");
-            }, 1000);
+    if (api.type === "mutation" && isCsrfFailure(result.error)) {
+        const csrfRefreshResult = await authQuery({url: "csrf/"}, api, extraOptions);
+
+        if (!csrfRefreshResult.error) {
+            result = await baseQuery(args, api, extraOptions);
+        }
+    }
+
+    // If refreshing the CSRF cookie was not enough, fall back to the login popup.
+    if (isCsrfFailure(result.error)) {
+        const loginWindow = window.open(
+            getSignInUrl(new URL("/window-close", window.location.origin).toString()),
+            "_blank"
+        );
+
+        if (loginWindow) {
+            hdsToast.error("CSRF Virhe. Kirjautumisikkuna avattiin.");
+        } else {
+            hdsToast.error(
+                "CSRF Virhe. Kirjautumisikkunan avaaminen estyi. Salli ponnahdusikkunat ja yritä uudelleen."
+            );
         }
     }
     return result;


### PR DESCRIPTION
# Hitas Pull Request

# Description

[PR 519](https://github.com/City-of-Helsinki/hitas/pull/519) implemented a workaround for a CSRF error issue reported by users. However the workaround isn't ideal and the UX issue still persists. This PR attempts to address the issue better by silently refreshing CSRF on error before falling back to the previous workaround of having the user log in in a new tab.

## Pull request checklist

Check the boxes for each DoD item that has been completed:

- **Testing**
  - [x] Changes have been tested
- **Documentation**
  - [x] OpenAPI definitions have been updated

## Tickets

HT-793
